### PR TITLE
Untitled

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1088,8 +1088,9 @@ module Sinatra
       end
 
       def metadef(message, &block)
-        (class << self; self; end).
-          send :define_method, message, &block
+        class << self
+          define_method(message, &block)
+        end
       end
 
     public


### PR DESCRIPTION
in Sinatra#new:
no need to use #send for #class_eval

in Sinatra::Base  ...#metadef:
use #define_method with an implicit self (removes the need of using #send to achieve the same effect on an explicit self)
