### PR TITLE
show_exceptions :true overrides app-specified exception handling.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -725,7 +725,6 @@ module Sinatra
       @env['sinatra.error'] = boom
 
       dump_errors!(boom) if settings.dump_errors?
-      raise boom         if settings.show_exceptions?
 
       @response.status = 500
       if res = error_block!(boom.class)
@@ -750,6 +749,7 @@ module Sinatra
           end
         end
       end
+      raise boom if settings.show_exceptions? and keys == Exception
       nil
     end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -202,6 +202,29 @@ class SettingsTest < Test::Unit::TestCase
       assert body.include?("StandardError")
       assert body.include?("<code>show_exceptions</code> setting")
     end
+    
+    it 'does not override app-specified error handling' do
+      klass = Sinatra.new(Sinatra::Application)
+      mock_app(klass) {
+        enable :show_exceptions
+        
+        error RuntimeError do
+          'Big mistake !'
+        end
+        
+        get '/' do
+          raise RuntimeError
+        end  
+      }
+      
+      get '/'
+      assert_equal 500, status
+
+      assert ! body.include?("<code>")
+      assert body.include? "Big mistake !"
+      
+    end
+    
   end
 
   describe 'dump_errors' do


### PR DESCRIPTION
See issue #84
http://github.com/sinatra/sinatra/issues/issue/84
