### PR TITLE
SSL support with WEBrick

### DIFF
--- a/README.de.rdoc
+++ b/README.de.rdoc
@@ -860,6 +860,25 @@ einer Bibliothek:
 
    MyApp.run! :host => 'localhost', :port => 9090
 
+Die run!-Methode unterstützt es auch, Optionen an den Rack-Handler
+weiterzureichen. Dazu muß ein Hash an den Parameter mit dem Namen des
+Handlers übergeben werden (in Kleinbuchstaben und als Symbol). Falls
+z.B. WEBrick mit SSL-Unterstützung auf Port 8443 genutzt werden soll,
+kann man den Server folgendermaßen starten:
+
+   require 'webrick/https'
+
+   [...]
+
+   MyApp.run! :port => 8443, :server => %w[webrick],
+              :webrick => {
+                :SSLEnable => true,
+                :SSLCertificate =>
+                  OpenSSL::X509::Certificate.new(File.read('cert.pem')),
+                :SSLPrivateKey  =>
+                  OpenSSL::PKey::RSA.new(File.read('key.pem')),
+                :SSLVerifyClient => nil }
+
 Die Methoden der Sinatra::Base-Subklasse sind genau die selben wie die
 der Top-Level DSL. Die meisten Top-Level Anwendungen können mit nur zwei Veränderungen zu Sinatra::Base-Komponenten konvertiert werden:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -854,6 +854,24 @@ component shipped as a library:
 
    MyApp.run! :host => 'localhost', :port => 9090
 
+The run! method also supports passing options to the Rack handler
+by passing a hash to the parameter with the (lowercase, symbol) name
+of the handler. So if you for example want to use WEBrick with SSL
+enabled on port 8443, you can start the server as follows:
+
+   require 'webrick/https'
+
+   [...]
+
+   MyApp.run! :port => 8443, :server => %w[webrick],
+              :webrick => {
+                :SSLEnable => true,
+                :SSLCertificate =>
+                  OpenSSL::X509::Certificate.new(File.read('cert.pem')),
+                :SSLPrivateKey  =>
+                  OpenSSL::PKey::RSA.new(File.read('key.pem')),
+                :SSLVerifyClient => nil }
+
 The methods available to Sinatra::Base subclasses are exactly as those
 available via the top-level DSL. Most top-level apps can be converted to
 Sinatra::Base components with two modifications:

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1127,9 +1127,11 @@ module Sinatra
         set options
         handler      = detect_rack_handler
         handler_name = handler.name.gsub(/.*::/, '')
+        # handler specific options use the lower case handler name as hash key, if present
+        handler_opts = options[handler_name.downcase.to_sym] || {}
         puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
           "on #{port} for #{environment} with backup from #{handler_name}" unless handler_name =~/cgi/i
-        handler.run self, :Host => bind, :Port => port do |server|
+        handler.run self, handler_opts.merge(:Host => bind, :Port => port) do |server|
           [:INT, :TERM].each { |sig| trap(sig) { quit!(server, handler_name) } }
           set :running, true
         end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -8,6 +8,7 @@ module Rack::Handler
       assert(app < Sinatra::Base)
       assert_equal 9001, options[:Port]
       assert_equal 'foo.local', options[:Host]
+      assert_equal 'foobar', options[:extra] if options[:extra]
       yield new
     end
 
@@ -43,5 +44,9 @@ class ServerTest < Test::Unit::TestCase
 
   it "falls back on the next server handler when not found" do
     @app.run! :server => %w[foo bar mock]
+  end
+
+  it "passes on extra options to the corresponding handler" do
+    @app.run! :mock => { :extra => 'foobar' }
   end
 end


### PR DESCRIPTION
I have implemented a small patch to enable the usage of SSL with WEBrick. This just enables the user to pass on extra options to the Rack handler in Sinatra::Application.run! A unit test and README additions (in english and german) are also included. I'd be happy if this could be included in Sinatra.
