### PR TITLE
template rendering options, :scope and :extension

### DIFF
--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -223,6 +223,38 @@ class TemplatesTest < Test::Unit::TestCase
     end
     assert_equal "Hello <%= 'World' %>!", body
   end
+  
+  it "allows setting a file extension" do
+    options = { :erb => { :extension => 'html' } }
+    render_app(options) { render :test, :'hello.test' }
+
+    assert ok?
+    assert_equal "Hello World with html extension!", body
+  end
+  
+  it "allows passing a file extension" do
+    render_app(options) { render(:test, :'hello.test', { :extension => 'html' }) }
+
+    assert ok?
+    assert_equal "Hello World with html extension!", body
+  end
+  
+  it "passes scope to the template" do
+    mock_app {
+      template :scoped do
+        'Hello <%= foo %>'
+      end
+
+      get '/' do
+        some_scope = Class.new; def foo; 'World!'; end; end
+        erb :scoped, { :scope => some_scope }
+      end
+    }
+
+    get '/'
+    assert ok?
+    assert_equal 'Hello World!', body
+  end
 end
 
 # __END__ : this is not the real end of the script.

--- a/test/views/hello.test.html
+++ b/test/views/hello.test.html
@@ -1,0 +1,1 @@
+Hello World with html extension!


### PR DESCRIPTION
rkh asked me to wrap this up in a pull request on another fork from a previous version.  i've forked the most recent and done that.

simple modifications that allow passing an evaluation scope to templates as well as an option to use a different file extension other than that of the name of the rendering engine.

i've also added some unit tests to templates_test.rb, but I must confess to not actually getting to the point of running them because of all the necessary test dependencies.
