### PR TITLE
Make all routing tests run, escape '$' in routes

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1067,7 +1067,7 @@ module Sinatra
       def compile(path)
         keys = []
         if path.respond_to? :to_str
-          special_chars = %w{. + ( )}
+          special_chars = %w{. + ( ) $}
           pattern =
             path.to_str.gsub(/((:\w+)|[\*#{special_chars.join}])/) do |match|
               case match

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -247,7 +247,7 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 'right on', body
   end
 
-  it "literally matches . in paths" do
+  it "literally matches dot in paths" do
     route_def '/test.bar'
 
     get '/test.bar'
@@ -256,14 +256,14 @@ class RoutingTest < Test::Unit::TestCase
     assert not_found?
   end
 
-  it "literally matches $ in paths" do
+  it "literally matches dollar sign in paths" do
     route_def '/test$/'
 
     get '/test$/'
     assert ok?
   end
 
-  it "literally matches + in paths" do
+  it "literally matches plus sign in paths" do
     route_def '/te+st/'
 
     get '/te%2Bst/'
@@ -272,7 +272,7 @@ class RoutingTest < Test::Unit::TestCase
     assert not_found?
   end
 
-  it "literally matches () in paths" do
+  it "literally matches parens in paths" do
     route_def '/test(bar)/'
 
     get '/test(bar)/'


### PR DESCRIPTION
Complete Ruby newbie here, so my apologies if this is nonsense.  I noticed this while trying to ensure that Scalatra's paths are compatible:

I think the test framework is shadowing several of the "literally matches" tests when it strips the punctuation from the names.  The '$' test should fail, but isn't running.  This patch renames the tests to disambiguate the munged names and adds '$' as a special character to make the existing test pass.
