### PR TITLE
Test dependency fix

### DIFF
--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require File.dirname(__FILE__) + '/helper'
+require 'erb'
 
 class BaseTest < Test::Unit::TestCase
   setup do
@@ -9,11 +10,11 @@ class BaseTest < Test::Unit::TestCase
 
   it 'allows unicode strings in ascii templates per default (1.9)' do
     next unless defined? Encoding
-    @base.new.haml(File.read(@base.views + "/ascii.haml").encode("ASCII"), {}, :value => "åkej")
+    @base.new.erb(File.read(@base.views + "/ascii.erb").encode("ASCII"), {}, :value => "åkej")
   end
 
   it 'allows ascii strings in unicode templates per default (1.9)' do
     next unless defined? Encoding
-    @base.new.haml(:utf8, {}, :value => "Some Lyrics".encode("ASCII"))
+    @base.new.erb(:utf8, {}, :value => "Some Lyrics".encode("ASCII"))
   end
 end

--- a/test/views/ascii.erb
+++ b/test/views/ascii.erb
@@ -1,2 +1,2 @@
 This file has no unicode in it!
-= value
+<%= value %>

--- a/test/views/utf8.erb
+++ b/test/views/utf8.erb
@@ -1,2 +1,2 @@
-%h1= value
+<h1><%= value %></h1>
 Ingen vill veta var du köpt din tröja.


### PR DESCRIPTION
remove haml requirement for running the base tests

this should remove the last 'hard' template test requirement that sinatra itself does not require.
I converted the encoding test to use erb. I figured since erb is in base ruby, and sinatra itself uses erb for the pretty showexceptions code -- this would be a win as it introduces no new base dependency.
