### PR TITLE
Drop 1.8.6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # Why use bundler?
-# Well, not all development dependencies install on all rubies. Moreover, `gem 
+# Well, not all development dependencies install on all rubies. Moreover, `gem
 # install sinatra --development` doesn't work, as it will also try to install
 # development dependencies of our dependencies, and those are not conflict free.
 # So, here we are, `bundle install`.
@@ -21,14 +21,8 @@ gem 'less', :group => 'less'
 gem 'liquid', :group => 'liquid'
 gem 'nokogiri', :group => 'nokogiri'
 gem 'slim', :group => 'slim'
-
-
-if RUBY_VERSION > '1.8.6'
-  gem 'coffee-script', '>= 2.0', :group => 'coffee-script'
-  gem 'rdoc', :group => 'rdoc'
-else
-  gem 'rack', '~> 1.1.0'
-end
+gem 'coffee-script', '>= 2.0', :group => 'coffee-script'
+gem 'rdoc', :group => 'rdoc'
 
 platforms :ruby do
   gem 'rdiscount', :group => 'rdiscount'

--- a/README.rdoc
+++ b/README.rdoc
@@ -1258,8 +1258,7 @@ You can access those options via <tt>settings</tt>:
 [public]              folder public files are served from
 
 [reload_templates]    whether or not to reload templates between requests.
-                      Enabled in development mode and on Ruby 1.8.6 (to
-                      compensate a bug in Ruby causing a memory leak).
+                      Enabled in development mode.
 
 [root]                project root folder.
 
@@ -1674,20 +1673,9 @@ Options are:
   -s # specify rack server/handler (default is thin)
   -x # turn on the mutex lock (default is off)
 
-== Requirements
-
-It is recommended to install Sinatra on Ruby 1.8.7, 1.9.2, JRuby or Rubinius.
+== Requirement
 
 The following Ruby versions are officially supported:
-
-[ Ruby 1.8.6 ]
-  It is not recommended to use 1.8.6 for Sinatra. However, it will be
-  officially supported until Sinatra 1.3.0 is released. RDoc and CoffeScript
-  templates are not supported by this Ruby version. 1.8.6 includes a major
-  memory leak in its Hash implementation, which is triggered by Sinatra
-  versions prior to 1.1.1. The current version explicitly prevents this leak
-  at the cost of performance. You will have to downgrade Rack to 1.1.x, as
-  Rack >= 1.2 no longer supports 1.8.6.
 
 [ Ruby 1.8.7 ]
   1.8.7 is fully supported, however, if nothing is keeping you from it, we
@@ -1707,6 +1695,8 @@ The following Ruby versions are officially supported:
   template libraries are known, however, if you choose to use JRuby, please
   look into JRuby rack handlers, as the Thin web server is not (yet) supported
   on JRuby.
+
+<b>Ruby 1.8.6 is no longer supported.</b>
 
 We also keep an eye on upcoming Ruby versions.
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -765,8 +765,7 @@ module Sinatra
       public_dir = File.expand_path(public_dir)
 
       path = File.expand_path(public_dir + unescape(request.path_info))
-      return if path[0, public_dir.length] != public_dir
-      return unless File.file?(path)
+      return unless path.start_with?(public_dir) and File.file?(path)
 
       env['sinatra.static_file'] = path
       send_file path, :disposition => nil
@@ -1351,7 +1350,7 @@ module Sinatra
     set :app_file, nil
     set :root, Proc.new { app_file && File.expand_path(File.dirname(app_file)) }
     set :views, Proc.new { root && File.join(root, 'views') }
-    set :reload_templates, Proc.new { development? or RUBY_VERSION < '1.8.7' }
+    set :reload_templates, Proc.new { development? }
     set :lock, false
 
     set :public, Proc.new { root && File.join(root, 'public') }

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -120,7 +120,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
 
   s.extra_rdoc_files = %w[README.rdoc README.de.rdoc README.jp.rdoc README.fr.rdoc README.es.rdoc README.hu.rdoc README.zh.rdoc LICENSE]
-  s.add_dependency 'rack', '~> 1.1'
+  s.add_dependency 'rack', '~> 1.2'
   s.add_dependency 'tilt', '>= 1.2.2', '< 2.0'
   s.add_development_dependency 'shotgun', '~> 0.6'
 


### PR DESCRIPTION
Pull in as soon as 1.8.6 support is officially dropped (so we can move on to Rack >= 1.2).
