### PR TITLE
Add hostname condition tests

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -949,4 +949,15 @@ class RoutingTest < Test::Unit::TestCase
     assert ok?
     assert_equal 'bar in baseclass', body
   end
+
+  it "adds hostname condition when it is in options" do
+    mock_app {
+      get '/foo', :host => 'host' do
+        'foo'
+      end
+    }
+
+    get '/foo'
+    assert not_found?
+  end
 end


### PR DESCRIPTION
I've been reading the code and couldn't find a test that validates the need for the addition of the "host_name" condition in the route() method. I added it to validate it does what I thought it does.
Hope you find it useful!
