### PR TITLE
fix failing 1.8.7 tests

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -716,7 +716,7 @@ class HelpersTest < Test::Unit::TestCase
             get '/compare', {}, { 'HTTP_IF_MODIFIED_SINCE' => 'Sun, 26 Sep 2010 23:43:52 GMT' }
             assert_equal 200, status
             assert_equal 'foo', body
-            get '/compare', {}, { 'HTTP_IF_MODIFIED_SINCE' => 'Sun, 26 Sep 2100 23:43:52 GMT' }
+            get '/compare', {}, { 'HTTP_IF_MODIFIED_SINCE' => 'Sun, 26 Sep 2030 23:43:52 GMT' }
             assert_equal 304, status
             assert_equal '', body
           end


### PR DESCRIPTION
Ran tests under 1.8.7 and got 5 failures all related to #last_modified. Turns out it was being caused by 1.8.7.'s failure on `Time.httpdate 'Sun, 26 Sep 2100 23:43:52 GMT'`. Made a simple fix by changing to a date 1.8.7 could handle.
