### PR TITLE
removes indentation warning under 1.9.2

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1381,7 +1381,7 @@ module Sinatra
       end
     else
       def self.force_encoding(data, *) data end
-      end
+    end
 
     reset!
 


### PR DESCRIPTION
/home/slmn/.bundler/ruby/1.9.1/sinatra-026648d788a9/lib/sinatra/base.rb:1384: warning:
mismatched indentations at 'end' with 'if' at 1370
