### PR TITLE
Remove has_rdoc= method from gemspec

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -126,7 +126,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'tilt', '>= 1.2.2', '< 2.0'
   s.add_development_dependency 'shotgun', '~> 0.6'
 
-  s.has_rdoc = true
   s.homepage = "http://sinatra.rubyforge.org"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Sinatra", "--main", "README.rdoc"]
   s.require_paths = %w[lib]


### PR DESCRIPTION
This was throwing the following warning on rubygems 1.7:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.

Specification#has_rdoc= is deprecated as of rubygems version 1.7.0.
