### PR TITLE
Leave removing the body of a HEAD request to Rack::Head

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -646,16 +646,7 @@ module Sinatra
         end
       end
 
-      status, header, body = @response.finish
-
-      # On HEAD requests, if the Content-Length is "0", assume
-      # it was calculated erroneously for a manual HEAD response
-      # and remove it entirely.
-      if @env['REQUEST_METHOD'] == 'HEAD'
-        header.delete('Content-Length') if header['Content-Length'] == '0'
-      end
-
-      [status, header, body]
+      @response.finish
     end
 
     # Access settings defined with Base.set.


### PR DESCRIPTION
Commit 7b146e2: There is a Rack module to deal with the HTTP HEAD method, so Sinatra can leave this issue to Rack.

Commit 2509680: This one builds on the previous commit, but I committed separately b/c you might want to cherry-pick. My point here is that I'm not sure about the logics for removing the Content-Length of a HEAD request if it's "0". Actually, it's OK to have a GET response with Content-Length = "0" (think of a string resource which may be empty), so it should be OK to get a HEAD with Content-Length = "0" for the same resource. Actually, the HTTP specs seem to imply that a HEAD should always return the same Content-Length header of a GET. The special case in Sinatra looks unnecessary, and it may actually be unexpected by a client.
