### PR TITLE
Fix link to Rack::Test docs.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1297,7 +1297,7 @@ typically don't have to +use+ them explicitly.
 == Testing
 
 Sinatra tests can be written using any Rack-based testing library
-or framework. {Rack::Test}[http://gitrdoc.com/brynary/rack-test] is
+or framework. {Rack::Test}[http://rdoc.info/github/brynary/rack-test/master/frames] is
 recommended:
 
   require 'my_sinatra_app'


### PR DESCRIPTION
The current link [1] is broken. Update it to point at the same page on rdoc.info [2].

1: http://gitrdoc.com/brynary/rack-test
2: http://rdoc.info/github/brynary/rack-test/master/frames
