### PR TITLE
Typo insetad => instead

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -667,7 +667,7 @@ module Sinatra
 
     def options
       warn "Sinatra::Base#options is deprecated and will be removed, " \
-        "use #settings insetad.\n\tfrom #{caller.first}"
+        "use #settings instead.\n\tfrom #{caller.first}"
       settings
     end
 


### PR DESCRIPTION
Just a very trivial typo.
