### PR TITLE
Send startup/shutdown messages to STDERR, not STDOUT.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1221,7 +1221,7 @@ module Sinatra
       def quit!(server, handler_name)
         # Use Thin's hard #stop! if available, otherwise just #stop.
         server.respond_to?(:stop!) ? server.stop! : server.stop
-        puts "\n== Sinatra has ended his set (crowd applauds)" unless handler_name =~/cgi/i
+        STDERR.puts "\n== Sinatra has ended his set (crowd applauds)" unless handler_name =~/cgi/i
       end
 
       # Run the Sinatra app as a self-hosted server using
@@ -1230,14 +1230,14 @@ module Sinatra
         set options
         handler      = detect_rack_handler
         handler_name = handler.name.gsub(/.*::/, '')
-        puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
+        STDERR.puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
           "on #{port} for #{environment} with backup from #{handler_name}" unless handler_name =~/cgi/i
         handler.run self, :Host => bind, :Port => port do |server|
           [:INT, :TERM].each { |sig| trap(sig) { quit!(server, handler_name) } }
           set :running, true
         end
       rescue Errno::EADDRINUSE => e
-        puts "== Someone is already performing on port #{port}!"
+        STDERR.puts "== Someone is already performing on port #{port}!"
       end
 
       # The prototype instance used to process requests.


### PR DESCRIPTION
The startup/shutdown messages for the standalone server really should go to STDERR, not STDOUT, since STDOUT might be used to pipe data out to another program. This commit addresses that.
