### PR TITLE
Corrected grammar; replaced 'heavily recommended' with 'highly recommended

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1395,7 +1395,7 @@ module Sinatra
   #
   # The Application class should not be subclassed, unless you want to
   # inherit all settings, routes, handlers, and error pages from the
-  # top-level. Subclassing Sinatra::Base is heavily recommended for
+  # top-level. Subclassing Sinatra::Base is highly recommended for
   # modular applications.
   class Application < Base
     set :logging, Proc.new { ! test? }


### PR DESCRIPTION
Hi there,

I replaced '_heavily_ recommended' with '_highly_ recommended'  `</grammar_nazi>`

[1] http://www.lixiaolai.com/ocd/FILES/recommend_verb.htm
[2] http://www.macmillandictionary.com/dictionary/british/recommend

Cheers,
  Lee :beer:

<img src="https://img.skitch.com/20110525-1mfkxnkjxgpa27amdjh8cbt8i2.jpg">
