### PR TITLE
Fix no-initialization warning for @default_layout 

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -359,6 +359,10 @@ module Sinatra
       attr_accessor :content_type
     end
 
+    def initialize
+      @default_layout = :layout
+    end
+
     def erb(template, options={}, locals={})
       render :erb, template, options, locals
     end
@@ -462,7 +466,6 @@ module Sinatra
       # extract generic options
       locals          = options.delete(:locals) || locals         || {}
       views           = options.delete(:views)  || settings.views || "./views"
-      @default_layout = :layout if @default_layout.nil?
       layout          = options.delete(:layout)
       eat_errors      = layout.nil?
       layout          = @default_layout if layout.nil? or layout == true
@@ -533,6 +536,7 @@ module Sinatra
     attr_reader   :template_cache
 
     def initialize(app=nil)
+      super()
       @app = app
       @template_cache = Tilt::Cache.new
       yield self if block_given?


### PR DESCRIPTION
With stock sinatra-1.2.6 I get these warnings in tests (jruby 1.6.2 with -w flag):

/home/david/.gem/jruby/1.8/gems/sinatra-1.2.6/lib/sinatra/base.rb:551 warning: instance variable @default_layout not initialized
/home/david/.gem/jruby/1.8/gems/sinatra-1.2.6/lib/sinatra/base.rb:287 warning: instance variable @range not initialized

This pull request contains a fix for the first warning against master. See also my fix-init-warniings-1.2.x branch for both of the above warning fixed against 1.2.x
