### PR TITLE
rake test:core task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,16 @@ Rake::TestTask.new(:test) do |t|
   t.ruby_opts << '-I.'
 end
 
+Rake::TestTask.new(:"test:core") do |t|
+  core_tests = %w[base delegator encoding extensions filter
+     helpers mapped_error middleware radius rdoc
+     readme request response result route_added_hook
+     routing server settings sinatra static templates]
+  t.test_files = core_tests.map {|n| "test/#{n}_test.rb"}
+  t.ruby_opts = ["-rubygems"] if defined? Gem
+  t.ruby_opts << "-I."
+end
+
 # Rcov ================================================================
 
 namespace :test do


### PR DESCRIPTION
Add a test:core task to quickly run core tests (e.g non-template-engine tests), this helps with testing on MagLev, also I imagine it's nice to have someplace where the 'core' tests are explicitely stated
