### PR TITLE
Fix for Time.parse test in test_helper.rb

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -663,7 +663,7 @@ class HelpersTest < Test::Unit::TestCase
         end
 
         get '/boom' do
-          expires '1000'
+          expires '9999'
         end
       end
     end


### PR DESCRIPTION
Use a 'real' bogus number string for the Time parsing error test. mktime() on different OSs disagree about the invalidity of "1000" as a time. Change to "9999", that is definitely out of range for days
