### PR TITLE
attachment extname

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -189,7 +189,8 @@ module Sinatra
       if filename
         params = '; filename="%s"' % File.basename(filename)
         response['Content-Disposition'] << params
-        content_type(File.extname(filename))
+        ext = File.extname(filename)
+        content_type(ext) unless response['Content-Type'] or ext.empty?
       end
     end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -596,6 +596,20 @@ class HelpersTest < Test::Unit::TestCase
     it 'sets the Content-Type response header without extname' do
       attachment_app('test')
       get '/attachment'
+      assert_equal 'text/html;charset=utf-8', response['Content-Type']
+      assert_equal '<sinatra></sinatra>', body   
+    end
+    
+    it 'sets the Content-Type response header without extname' do
+      mock_app do
+        get '/attachment' do
+          content_type :atom
+          attachment 'test.xml'
+          response.write("<sinatra></sinatra>")
+        end
+      end
+      get '/attachment'
+      assert_equal 'application/atom+xml', response['Content-Type']
       assert_equal '<sinatra></sinatra>', body   
     end
     


### PR DESCRIPTION
Hi!
I have a simple app:

``` ruby
require './sinatra'

get "/" do
  attachment("test.xml")
  response.write("<sinatra></sinatra>")
end
```

and when I go to '/' I get the attachment 'test.html' instead of 'test.xml'
With my fix it works like you expect. But now it fails with `attachment("test")` for example. I don't know exactly what I should do in this case. @rkh, if you can point me in the right direction I'll try to fix it.
