### PR TITLE
Adding lib to loadpath and requiring sinatra/version 

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -1,4 +1,5 @@
-Kernel.load './lib/sinatra/version.rb'
+$LOAD_PATH.unshift 'lib'
+require 'sinatra/version'
 
 Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.description       = "Classy web-development dressed in a DSL"


### PR DESCRIPTION
Simple change adding lib to loadpath and requiring sinatra/version instead of loading lib/sinatra/version as hinted by @rkh on what sinatra should do on #318
