### PR TITLE
Automatically replace routes with the same signature.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1158,7 +1158,7 @@ module Sinatra
           @signatures ||= {}
           if @signatures.key? verb_sig
             partial = signature[0,3]
-            verb_routes.delete_at verb_routes.index{ |a| a[0,3] == partial }
+            verb_routes.delete_if{ |a| a[0,3] == partial }
           end
           @signatures[verb_sig] = true
         end


### PR DESCRIPTION
The following code will return `first` when requesting `/`:

```
get('/'){ "first" }
get('/'){ "second" }
```

As a consequence of this, one cannot interactively develop or tweak a live application by reloading files defining certain routes. (For example, using [Pry](https://github.com/pry/pry) to debug an app and then issuing `edit -r routes.rb`, editing the routes and saving the file.) When reloading the same routes (with new code) the original routes are still matched.

This patch does not change the default behavior, but adds a new :replace_old_routes setting that automatically removes old routes with the same signature (disregarding the proc) when enabled. Testing on a dummy application with 5,000 explicit 'get' routes (thus 10,000 total routes) this adds only 60ms to the application's startup time.

Note that if the user adds a route and _then_ enables this setting they will have to add the replacement route **twice**: once to get its signature tracked and then once to actually wipe out the old settings. This behavior could be fixed if the calculating and storing of the signature was done regardless of the `replace_old_routes` setting. I have opted not to do this in order to have the absolute minimum impact when the setting is disabled.

Gavin Kistner (gavin@phrogz.net)
