### PR TITLE
Bug: Sinatra ignores 'provides' condition when accept header is appended with "*/*;q=0.01"

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -755,6 +755,15 @@ class RoutingTest < Test::Unit::TestCase
     assert_body 'image/png'
   end
 
+  it 'prioritizes route with higher accept-quality' do
+    mock_app do
+      get('/', :provides => :html) { content_type }
+      get('/', :provides => :js) { content_type }
+    end
+    get '/', {}, { 'HTTP_ACCEPT' => 'application/json, text/javascript, */*; q=0.01' }
+    assert_body 'application/json'
+  end
+
   it 'accepts generic types' do
     mock_app do
       get('/', :provides => :xml) { content_type }


### PR DESCRIPTION
Test for when accept header is appended with "_/_;q=0.01" (like jQuery.getJSON() does) which makes Sinatra ignore the 'provides' condition.
