### PR TITLE
Register, avoid duplication.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1228,8 +1228,7 @@ module Sinatra
         extensions << Module.new(&block) if block_given?
         @extensions += extensions
         extensions.each do |extension|
-          extend extension
-          extension.registered(self) if extension.respond_to?(:registered)
+          extension.respond_to?(:registered) ? extension.registered(self) : extend(extension)
         end
       end
 

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -78,11 +78,14 @@ class ExtensionsTest < Test::Unit::TestCase
   end
 
   module BizzleExtension
-    def bizzle
-      bizzle_option
+    module ClassMethods
+      def bizzle
+        bizzle_option
+      end
     end
 
     def self.registered(base)
+      base.extend(ClassMethods)
       fail "base should be BizzleApp" unless base == BizzleApp
       fail "base should have already extended BizzleExtension" unless base.respond_to?(:bizzle)
       base.set :bizzle_option, 'bizzle!'


### PR DESCRIPTION
Now if module respond to `registered` it will not be extended by
default, you should do that inside `registered`.

I think is better to avoid duplications in this scenario:

``` rb
module MyExtension
  def self.registered(app)
    app.send(:include, InstanceMethods)
    app.extend(ClassMethods)
  end

  module InstanceMethods
  end

  module ClassMethods
  end
end
```

`Sinatra#register` think that we need to perform extend when we register something. This way I think is more clean but strict. 

What do you think guys?
