### PR TITLE
Don't escape parameters by default in included rack-protection (issue #310)

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1361,7 +1361,7 @@ module Sinatra
 
       def setup_protection(builder)
         return unless protection?
-        options = Hash === protection ? protection.dup : {}
+        options = Hash === protection ? protection.dup : {:except => [:escaped_params]}
         options[:except] = Array options[:except]
         options[:except] += [:session_hijacking, :remote_token] unless sessions?
         builder.use Rack::Protection, options


### PR DESCRIPTION
Don't escape parameters by default in included rack-protection. 

As @rkh claims in issue #310.
