### PR TITLE
Add parens for 'Ambiguous first argument' warnings in jruby

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -845,7 +845,7 @@ module Sinatra
       return unless path.start_with?(public_dir) and File.file?(path)
 
       env['sinatra.static_file'] = path
-      cache_control *settings.static_cache_control if settings.static_cache_control?
+      cache_control(*settings.static_cache_control) if settings.static_cache_control?
       send_file path, :disposition => nil
     end
 
@@ -1213,7 +1213,7 @@ module Sinatra
         keys = []
         if path.respond_to? :to_str
           pattern = path.to_str.gsub(/[^\?\%\\\/\:\*\w]/) { |c| encoded(c) }
-          pattern.gsub! /((:\w+)|\*)/ do |match|
+          pattern.gsub!(/((:\w+)|\*)/) do |match|
             if match == "*"
               keys << 'splat'
               "(.*?)"


### PR DESCRIPTION
Fixes this and is otherwise harmless:

```
/home/david/.gem/jruby/1.8/gems/sinatra-1.3.0.g/lib/sinatra/base.rb:848 warning: `*' interpreted as argument prefix
/home/david/.gem/jruby/1.8/gems/sinatra-1.3.0.g/lib/sinatra/base.rb:1216 warning: Ambiguous first argument; make sure.
```
