### PR TITLE
fixing changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
-= 1.3.1 / Not Yet Released
+= 1.3.2 / Not Yet Released
+
+= 1.3.1 / 2011-10-05
 
  * Support adding more than one callback to the stream object. (Konstantin
    Haase)


### PR DESCRIPTION
```
$ gem changelog sinatra

= 1.3.1 / Not Yet Released

 * Support adding more than one callback to the stream object. (Konstantin
   Haase)

[...]
```
