### PR TITLE
just a small refactoring

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -51,7 +51,7 @@ module Sinatra
     private
 
     def accept_entry(entry)
-      type, *options = entry.gsub(/\s/, '').split(';')
+      type, *options = entry.delete(' ').split(';')
       quality = 0 # we sort smalles first
       options.delete_if { |e| quality = 1 - e[2..-1].to_f if e.start_with? 'q=' }
       [type, [quality, type.count('*'), 1 - options.size]]
@@ -311,7 +311,7 @@ module Sinatra
         hash = {}
       end
 
-      values = values.map { |value| value.to_s.tr('_','-') }
+      values.map! { |value| value.to_s.tr('_','-') }
       hash.each do |key, value|
         key = key.to_s.tr('_', '-')
         value = value.to_i if key == "max-age"


### PR DESCRIPTION
`.gsub(/\s/, '')` vs `.delete(' ')`:

``` bash
~/projects/sinatra (git)-[master] % cat ~/test.rb
```

``` ruby
require 'benchmark'
n = 500000
test = 'asdasd asasdj sjdf sjd sd sjd sjdf sdjf'
Benchmark.bm do |x|
  x.report { n.times do; test.delete(' '); end }
  x.report { n.times do; test.gsub(/\s/, ''); end }
end
```

``` bash
~/projects/sinatra (git)-[master] % ruby ~/test.rb
      user     system      total        real
  0.540000   0.000000   0.540000 (  0.546389)
  1.880000   0.010000   1.890000 (  1.880384)
```
