### PR TITLE
Don't leave @default_layout set to false if rendering a template fails

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -619,11 +619,14 @@ module Sinatra
       scope           = options.delete(:scope)         || self
 
       # compile and render template
-      layout_was      = @default_layout
-      @default_layout = false
-      template        = compile_template(engine, data, options, views)
-      output          = template.render(scope, locals, &block)
-      @default_layout = layout_was
+      begin
+        layout_was      = @default_layout
+        @default_layout = false
+        template        = compile_template(engine, data, options, views)
+        output          = template.render(scope, locals, &block)
+      ensure
+        @default_layout = layout_was
+      end
 
       # render layout
       if layout


### PR DESCRIPTION
@default_layout is set to false during the part of Templates#render which actually invokes the template, but is only set back to its original value if the invocation was successful. This has has the result that if the template fails but the application later tries to render a different template in the same request, those templates won't have layouts.
