### PR TITLE
Include delegators only in Sinatra classes, not in Object

### DIFF
--- a/lib/sinatra.rb
+++ b/lib/sinatra.rb
@@ -4,4 +4,4 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'sinatra/base'
 require 'sinatra/main'
 
-enable :inline_templates
+Sinatra::Application.enable :inline_templates

--- a/lib/sinatra/main.rb
+++ b/lib/sinatra/main.rb
@@ -25,4 +25,4 @@ module Sinatra
   at_exit { Application.run! if $!.nil? && Application.run? }
 end
 
-include Sinatra::Delegator
+[Sinatra::Request, Sinatra::Response, Sinatra::Base, Sinatra::Application].each {|klass| klass.send(:include, Sinatra::Delegator); klass.send(:extend, Sinatra::Delegator)}


### PR DESCRIPTION
Sinatra::Delegators is getting mixed in to Object, which forces in Object#get, Object#before, etc. This messes up method_missing stuff and is just generally a bad idea. This patch seems to keep all tests passing and makes sure that the delegators are only included in the actual Sinatra classes.
