### PR TITLE
coffee test: strip body in equal assertions

### DIFF
--- a/test/coffee_test.rb
+++ b/test/coffee_test.rb
@@ -71,7 +71,7 @@ class CoffeeTest < Test::Unit::TestCase
   it "passes coffee options to the coffee engine" do
     coffee_app { coffee "alert 'Aye!'\n", :no_wrap => true }
     assert ok?
-    assert_equal "alert('Aye!');", body
+    assert_body "alert('Aye!');"
   end
 
   it "passes default coffee options to the coffee engine" do
@@ -83,7 +83,7 @@ class CoffeeTest < Test::Unit::TestCase
     end
     get '/'
     assert ok?
-    assert_equal "alert('Aye!');", body
+    assert_body "alert('Aye!');"
   end
 end
 


### PR DESCRIPTION
I got errors running tests

```
  1) Failure:
test_passes_coffee_options_to_the_coffee_engine(CoffeeTest) [/Users/lest/code/sinatra/test/coffee_test.rb:74]:
<"alert('Aye!');"> expected but was
<"\nalert('Aye!');\n">.

  2) Failure:
test_passes_default_coffee_options_to_the_coffee_engine(CoffeeTest)     [/Users/lest/code/sinatra/test/coffee_test.rb:86]:
<"alert('Aye!');"> expected but was
<"\nalert('Aye!');\n">.
```

So I think it's good to use stripped body in assertion
