### PR TITLE
Update .travis.yml so that you do not depend on a particular point release of JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  #- 1.9.4
-  #- rbx-1.2.4
   - rbx-18mode
   - rbx-19mode
-  - jruby-1.6.5
-  #- jruby-head
+  - jruby
   - ruby-head
 env:
   - "rack=1.3.4"


### PR DESCRIPTION
You guys, depending on a specific point release of JRuby is totally not cool.

More importantly, things will break once we upgrade JRuby. We even recommend this in the docs
now.
