### PR TITLE
Server that was runned during integration test doesn't stops

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -13,7 +13,7 @@ class IntegrationTest < Test::Unit::TestCase
   end
 
   def command
-    cmd = []
+    cmd = ['exec']
     if RbConfig.respond_to? :ruby
       cmd << RbConfig.ruby.inspect
     else


### PR DESCRIPTION
There 2 processes started on my machine when running integration test:

```
lest     27893   0,2  1,0  2462696  21512 s002  S     8:12     0:00.97 /Users/lest/.rvm/rubies/ruby-1.9.2-p180/bin/ruby -I /Users/lest/code/sinatra/lib /Users/lest/code/sinatra/test/integration/app.rb -p 5881
lest     27892   0,0  0,0  2435544    692 s002  S     8:12     0:00.00 sh -c "/Users/lest/.rvm/rubies/ruby-1.9.2-p180/bin/ruby" -I "/Users/lest/code/sinatra/lib" "/Users/lest/code/sinatra/test/integration/app.rb" -p 5881 2>&1
```

In https://github.com/sinatra/sinatra/blob/master/test/integration_test.rb#L53 `TERM` signal is sended to process with pid 27892 (in my case) and it doesn't reflect on sinatra server with pid 27893 (it remains running). So after couple test runs I have a lot of running ruby processes.

I used exec in command and because of it ruby process replaces parent shell process and successfully stops after test.
