### PR TITLE
This patch changes Sinatra::Base#run! to look for :server_settings and pass them to the server

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1282,7 +1282,8 @@ module Sinatra
         set options
         handler      = detect_rack_handler
         handler_name = handler.name.gsub(/.*::/, '')
-        handler.run self, :Host => bind, :Port => port do |server|
+        server_settings = self.respond_to?(:server_settings) ? settings.server_settings : {}
+        handler.run self, server_settings.merge(:Port => port, :Host => bind) do |server|
           unless handler_name =~ /cgi/i
             $stderr.puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
             "on #{port} for #{environment} with backup from #{handler_name}"


### PR DESCRIPTION
I had the problem that I wanted to test SSL without the need of a real webserver in front of sinatra.
The only solution seems to be WEBRick, but in order to use it, I need to pass options to the server.

I wondered why it isn't already possible and so I made this patch.
I think it's a very general problem so the solution should be as general as possible.
I did not write tests. because the server_settings hash is just passed around and it's a very simple patch.

I am working on an extension sinatra-ssl, that relies on the patch.
