### PR TITLE
README: show how to define helper functions in a separate `module`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -679,6 +679,22 @@ route handlers and templates:
     bar(params[:name])
   end
 
+Helper methods can be separately defined in a module:
+
+  module FooUtils
+    def bar(name)
+      "#{name}bar"
+    end
+  end
+
+  module MooUtils
+    # ...
+  end
+
+  helpers FooUtils, MooUtils
+
+The effect is same as including a module.
+
 === Using Sessions
 
 A session is used to keep state during requests. If activated, you have one


### PR DESCRIPTION
Developers might prefer to define helpers in a separate `module`, particularly
for modular apps, so let's provide an example in the docs.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com

---

I couldn't find instructions on translation here: http://www.sinatrarb.com/contributing. If the patch is good enough to be accepted, I will be happy to ammend it with translations (and rebase if needed), provided someone can help out there.
