### PR TITLE
Indifferent param hashes nested within arrays

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -868,13 +868,16 @@ module Sinatra
     end
 
     # Enable string or symbol key access to the nested params hash.
-    def indifferent_params(params)
-      params = indifferent_hash.merge(params)
-      params.each do |key, value|
-        case value
-          when Hash  then params[key] = indifferent_params(value)
-          when Array then params[key] = value.map { |item| indifferent_params(item) }
-        end
+    def indifferent_params(object)
+      case object
+      when Hash
+        new_hash = indifferent_hash
+        object.each { |key, value| new_hash[key] = indifferent_params(value) }
+        new_hash
+      when Array
+        object.map { |item| indifferent_params(item) }
+      else
+        object
       end
     end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -372,6 +372,18 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 'well, alright', body
   end
 
+  it "supports arrays within params" do
+    mock_app {
+      get '/foo' do
+        assert_equal ['A', 'B'], params['bar']
+        'looks good'
+      end
+    }
+    get '/foo?bar[]=A&bar[]=B'
+    assert ok?
+    assert_equal 'looks good', body
+  end
+
   it "supports deeply nested params" do
     expected_params = {
       "emacs" => {


### PR DESCRIPTION
I found that when the params hash contained hashes nested within arrays, those hashes weren't converted to have indifferent access. I think this is worth fixing, so here's a patch which extends support for recursing through arrays of hashes as well as hashes of hashes. My first version threw errors when arrays contained any objects other than hashes, but Sinatra's test suite didn't catch it, so I added another test and revamped the indifferent_params method.

Please let me know what you think. Thanks for Sinatra!
