### PR TITLE
Plus symbols in the URL should be converted to spaces when considered as param values

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -825,7 +825,7 @@ module Sinatra
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
       return unless match = pattern.match(route)
-      values += match.captures.to_a.map { |v| force_encoding URI.decode(v) if v }
+      values += match.captures.to_a.map { |v| force_encoding URI.decode_www_form_component(v) if v }
 
       if values.any?
         original, @params = params, params.merge('splat' => [], 'captures' => values)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -329,6 +329,17 @@ class RoutingTest < Test::Unit::TestCase
     assert not_found?
   end
 
+  it "converts plus sign into space as the value of a named param" do
+    mock_app {
+      get '/:test' do
+        params["test"]
+      end
+    }
+    get '/bob+ross'
+    assert ok?
+    assert_equal 'bob ross', body
+  end
+
   it "literally matches parens in paths" do
     route_def '/test(bar)/'
 


### PR DESCRIPTION
Closes #463.
