### PR TITLE
Modification of showexceptions.rb to output plain text stack traces to curl user agents

### DIFF
--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -1,3 +1,5 @@
-#!/usr/bin/env ruby -I ../lib -I lib
+#!/usr/bin/env ruby
 require 'sinatra'
 get('/') { 'this is a simple app' }
+
+get('/error') { FAIL! }

--- a/lib/sinatra/showexceptions.rb
+++ b/lib/sinatra/showexceptions.rb
@@ -41,6 +41,7 @@ module Sinatra
     private
 
     def prefers_plain_text?(env)
+      [/text\/plain/].index{|item| item =~ env["HTTP_ACCEPT"]} ||
       [/curl/].index{|item| item =~ env["HTTP_USER_AGENT"]}
     end
 


### PR DESCRIPTION
The list of user agents is hard coded and currently only matches anything contaning the string "curl"
There were some provisions in the code for this functionality, but apparently they were unused (at least a grep -irn did not reveal any uses for the required function except for the one line in showexceptions.rb).
