### PR TITLE
More narrow definition of Sinatra::Base#build

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1371,15 +1371,16 @@ module Sinatra
       # pipeline. The object is guaranteed to respond to #call but may not be
       # an instance of the class new was called on.
       def new(*args, &bk)
-        build(Rack::Builder.new, *args, &bk).to_app
+        build(new!(*args, &bk)).to_app
       end
 
       # Creates a Rack::Builder instance with all the middleware set up and
-      # an instance of this class as end point.
-      def build(builder, *args, &bk)
+      # the given +app+ as end point.
+      def build(app)
+        builder = Rack::Builder.new
         setup_default_middleware builder
         setup_middleware builder
-        builder.run new!(*args, &bk)
+        builder.run app
         builder
       end
 


### PR DESCRIPTION
Instead of taking a Rack::Builder as an argument, it would be a cleaner
separation of responsibilities to make Sinatra::Base#build take any app
as an argument and simply wrap it in the middleware pipeline.

My particular use case for this behavior is that I'd like to keep around
a reference to the original app in a test, but still be able to test the
app fronted by its middleware as well. Thus, I could call new! to get a
reference to the inner app, and then simply pass that reference through
build(app).to_app to get an instance of that app fronted by the
middleware.
