### PR TITLE
Showexceptions accept headers

### DIFF
--- a/lib/sinatra/showexceptions.rb
+++ b/lib/sinatra/showexceptions.rb
@@ -41,6 +41,7 @@ module Sinatra
     private
 
     def prefers_plain_text?(env)
+      !(Request.new(env).preferred_type("text/plain","text/html") == "text/html") &&
       [/curl/].index{|item| item =~ env["HTTP_USER_AGENT"]}
     end
 


### PR DESCRIPTION
Same as my last pull request, just now it should work with any type of HTTP ACCEPT header (I hope).

> The list of user agents is hard coded and currently only matches anything contaning the string "curl"
> There were some provisions in the code for this functionality, but apparently they were unused (at least a >grep -irn did not reveal any uses for the required function except for the one line in showexceptions.rb).
