### PR TITLE
Additional .gitignore lines added to mitigate "git status" noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # please add general patterns to your global ignore list
 # see https://github.com/github/gitignore#readme
 
+/.bundle
+/.sass-cache
+/bin
 /pkg
 /doc/api
+/vendor
 /Gemfile.lock


### PR DESCRIPTION
Interested in running the test suite?:

```
bundle install --path vendor/bundle --binstubs
rake test # same as "bundle exec rake test" 
```

Got the following output:

``` shell
#   .bundle/
#   .sass-cache/
#   bin/
#   vendor/
```

To remove the noise (since those shouldn't ever be committed) I've added the related .gitignore lines.

FYI: This is extremely helpful for those that don't use gemsets.
