### PR TITLE
Recognize Path-like objects in Templates#compile_template

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -738,7 +738,14 @@ module Sinatra
           path, line = settings.caller_locations.first
           template.new(path, line.to_i, options, &body)
         else
-          raise ArgumentError, "Sorry, don't know how to render #{data.inspect}."
+          if data.respond_to?(:path) and path = data.path
+            path = File.absolute_path(path, views)
+            throw :layout_missing unless path.index(File.expand_path(views))==0
+            throw :layout_missing if eat_errors and not File.exists?(path)
+            template.new(path, 1, options)
+          else
+            raise ArgumentError, "Sorry, don't know how to render #{data.inspect}."
+          end
         end
       end
     end


### PR DESCRIPTION
The following commit aims at allowing the following behavior

```
get '/:some/:parameters' do

  #
  # Find an existing file that correspond to the request. Make some checks.
  # Returns a Pathname or a Path instance, responding to #path
  #
  filepath = ...

  #
  # Render found file, reusing sinatra template cache, options, etc.
  #
  erb filepath, ...

end
```

The pull request allows this provided that the located file is inside the views folder. This is to match the current behavior that does not allow rendering files outside it (without extending `find_template`).

I'm not sure this pull request makes sense. However, I'm not really confortable with the following workarounds:

```
# assuming a relative_from method that returns another Path(name)
erb filepath.relative_from(settings.views).to_s.to_sym

# manually use Tilt, no cache support
Tilt.new(filepath).render ...

# explicit use of the template cache
template_cache.fetch(filepath){ ... }.render ...
```

What do you think?
