### PR TITLE
add closed? method on Stream object to inspect the object's open/close state

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -332,6 +332,10 @@ module Sinatra
       end
 
       alias errback callback
+
+      def closed?
+        @closed
+      end
     end
 
     # Allows to start sending data to the client even though later parts of

--- a/test/streaming_test.rb
+++ b/test/streaming_test.rb
@@ -139,4 +139,11 @@ class StreamingTest < Test::Unit::TestCase
     get '/'
     assert ran
   end
+
+  it 'has a public interface to inspect its open/closed state' do
+    stream = Stream.new(Stream) { |out| out << :foo }
+    assert !stream.closed?
+    stream.close
+    assert stream.closed?
+  end
 end


### PR DESCRIPTION
So I have a list of streaming connections accumulated in a `connections` variable.

``` ruby
get '/' do
  stream(:keep_open) { |out| connections << out }
end
```

Over time the list of connections can get huge, and I would like to trim the dead ones:

``` ruby
connections.select(&:closed?).each(&:close)
```

Inspecting `@closed` on a stream object doesn't seem like the best way to go about it.
