### PR TITLE
Added a default encoding for RDoc parsing in gemspec file

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.files             = `git ls-files`.split("\n") - %w[.gitignore .travis.yml]
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
-  s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc]
+  s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
   s.add_dependency 'rack',            '~> 1.3', '>= 1.3.6'
   s.add_dependency 'rack-protection', '~> 1.2'


### PR DESCRIPTION
This essentially will run the `rdoc` command with the `--encoding=UTF-8` parameter
during the installation of the gem which will force utf-8 encoding irrespective of the 
locale settings of the user. 

This will solve [issue#504](https://github.com/sinatra/sinatra/issues/504)
