### PR TITLE
Add a note for tests with modular setup

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1590,7 +1590,7 @@ is recommended:
     end
   end
 
-  Note: If you are using Sinatra in the modular style, replace <tt>Sinatra::Application</tt> above with the class name of your app.
+Note: If you are using Sinatra in the modular style, replace <tt>Sinatra::Application</tt> above with the class name of your app.
 
 == Sinatra::Base - Middleware, Libraries, and Modular Apps
 


### PR DESCRIPTION
Found this because I switched between the two midway through development.

README suggests that for setup you need to have this in every test:

```
 def app
   Sinatra::Application
 end
```

But if you're using the modular setup, you must use the class name of your app instead. 
