### PR TITLE
Use block.source_location to get the correct method name for a condition...

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1201,7 +1201,9 @@ module Sinatra
 
       # Add a route condition. The route is considered non-matching when the
       # block returns false.
-      def condition(name = "#{caller.first[/`.*'/]} condition", &block)
+      def condition(name = nil, &block)
+        name ||= "#{caller.detect{|s| s[block.source_location]}[/`.*'/]} condition"
+
         @conditions << generate_method(name, &block)
       end
 


### PR DESCRIPTION
... even when in debugger

Whilst delving around in sinatra internals I noticed that the values stored in the `@routes` instance variable were a little impenetrable because of the way that caller.first was giving a method name of 

```
"`send' condition"
```

 whilst in the debugger.

It might not be the responsibility of sinatra to care about people using the debugger, so I can understand if this doesn't belong here, so more of a speculative pull request.

Also I've not looked into the tests or how this might be tested, so happy to address that if you're interested in merging this in.
