### PR TITLE
Allow URI objects as redirect targets

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -173,7 +173,7 @@ module Sinatra
 
       # According to RFC 2616 section 14.30, "the field value consists of a
       # single absolute URI"
-      response['Location'] = uri(uri, settings.absolute_redirects?, settings.prefixed_redirects?)
+      response['Location'] = uri(uri.to_s, settings.absolute_redirects?, settings.prefixed_redirects?)
       halt(*args)
     end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -240,6 +240,17 @@ class HelpersTest < Test::Unit::TestCase
       assert_equal '', body
       assert_equal 'mailto:jsmith@example.com', response['Location']
     end
+
+    it 'accepts a URI object instead of a String' do
+      mock_app do
+        get('/') { redirect URI.parse('http://sinatrarb.com') }
+      end
+
+      get '/'
+      assert_equal 302, status
+      assert_equal '', body
+      assert_equal 'http://sinatrarb.com', response['Location']
+    end
   end
 
   describe 'error' do


### PR DESCRIPTION
If the object you pass to `#redirect` is a URI, redirect shouldn't do anything weird, it should just work.
