### PR TITLE
Infinite loop resulting in stack level too deep in Sinatra::Response#finish

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -84,9 +84,18 @@ module Sinatra
 
       # Rack::Response#finish sometimes returns self as response body. We don't want that.
       status, headers, result = super
-      result = body if result == self || Rack::BodyProxy === result
+      result = body if self == result
       [status, headers, result]
     end
+    
+    def ==(other)
+      [:status, :headers, :body, :length].each do |attribute|
+        return false unless other.respond_to?(attribute)
+        return false unless self.__send__(attribute) == other.__send__(attribute)
+      end
+      true
+    end
+    
   end
 
   # Some Rack handlers (Thin, Rainbows!) implement an extended body object protocol, however,

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -61,4 +61,20 @@ class ResponseTest < Test::Unit::TestCase
     @response.body = Rack::Response.new ["foo"]
     assert_same_body @response.body, ["foo"]
   end
+
+  it 'perform equality comparison based on the status, headers, body and length' do
+    assert_equal @response, Sinatra::Response.new
+    assert_equal @response, Rack::Response.new
+    assert_not_equal @response, Sinatra::Response.new("foo")
+    assert_not_equal @response, Rack::Response.new("foo")
+    assert_not_equal @response, Object
+    
+    test_response = Sinatra::Response.new
+    test_response.headers["Content-Type"] = "application/json"
+    assert_not_equal @response, test_response
+    
+    test_response = Sinatra::Response.new
+    test_response.length = 3
+    assert_not_equal @response, test_response
+  end
 end


### PR DESCRIPTION
If the call to _super_ on line 86 returns a Rack::BodyProxy instance inside _result_, the equality comparison on line 87 fails. The end result will be an infinite loop when calling _#each_ on _body_, which will cause a stack overflow.

Rather than add _|| Rack::BodyProxy === result_ on line 86, I suggest we overload the "==" operator in Sinatra::Response, to perform compare instances based solely on the _status_, _headers_, _body_ and _length_ attribute (of course, the comparison on line 86 needs to be flipped to _self == result_).
