### PR TITLE
Fix halt(invoke) breaks its argument

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -949,6 +949,7 @@ module Sinatra
       res = catch(:halt) { yield }
       res = [res] if Fixnum === res or String === res
       if Array === res and Fixnum === res.first
+        res = res.dup
         status(res.shift)
         body(res.pop)
         headers(*res)


### PR DESCRIPTION
When I passed an rack array variable to `halt` like

```
halt(@@forbidden)
```

the `halt` method breaks its argument, actually in `invoke` method. 

```
def invoke
  res = catch(:halt) { yield }
  res = [res] if Fixnum === res or String === res
  if Array === res and Fixnum === res.first
    status(res.shift)
    body(res.pop)
    headers(*res)
  elsif res.respond_to? :each
    body res
  end
  nil # avoid double setting the same response tuple twice
end
```

See there is `res.shift` and `res.pop`. It finally breaks my `@@forbidden` variable which is returned by `catch(:halt) { yield }`. 
My question is "is this a desired behavior?" If not, let's fix it. This is a pull request to fix it. 
