### PR TITLE
Default host to localhost when in development mode.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1690,7 +1690,7 @@ module Sinatra
     set :run, false                       # start server via at-exit hook?
     set :running, false                   # is the built-in server running now?
     set :server, %w[http webrick]
-    set :bind, '0.0.0.0'
+    set :bind, Proc.new { development? ? 'localhost' : '0.0.0.0' }
     set :port, Integer(ENV['PORT'] || 4567)
 
     ruby_engine = defined?(RUBY_ENGINE) && RUBY_ENGINE

--- a/lib/sinatra/main.rb
+++ b/lib/sinatra/main.rb
@@ -14,7 +14,7 @@ module Sinatra
       require 'optparse'
       OptionParser.new { |op|
         op.on('-p port',   'set the port (default is 4567)')                { |val| set :port, Integer(val) }
-        op.on('-o addr',   'set the host (default is 0.0.0.0)')             { |val| set :bind, val }
+        op.on('-o addr',   "set the host (default is #{bind})")             { |val| set :bind, val }
         op.on('-e env',    'set the environment (default is development)')  { |val| set :environment, val.to_sym }
         op.on('-s server', 'specify rack server/handler (default is thin)') { |val| set :server, val }
         op.on('-x',        'turn on the mutex lock (default is off)')       {       set :lock, true }


### PR DESCRIPTION
Running Rack apps on `0.0.0.0` in development mode will allow malicious
users on the local network (ex: Coffee Shop) to abuse or potentially
exploit the app. Safer to default host to `localhost` when in development
mode.
