### PR TITLE
Fix CALLERS_TO_IGNORE to ignore Rubygems 2.0.0 require definition file

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1593,14 +1593,14 @@ module Sinatra
 
     public
       CALLERS_TO_IGNORE = [ # :nodoc:
-        /\/sinatra(\/(base|main|showexceptions))?\.rb$/, # all sinatra code
-        /lib\/tilt.*\.rb$/,                              # all tilt code
-        /^\(.*\)$/,                                      # generated code
-        /rubygems\/custom_require\.rb$/,                 # rubygems require hacks
-        /active_support/,                                # active_support require hacks
-        /bundler(\/runtime)?\.rb/,                       # bundler require hacks
-        /<internal:/,                                    # internal in ruby >= 1.9.2
-        /src\/kernel\/bootstrap\/[A-Z]/                  # maglev kernel files
+        /\/sinatra(\/(base|main|showexceptions))?\.rb$/,    # all sinatra code
+        /lib\/tilt.*\.rb$/,                                 # all tilt code
+        /^\(.*\)$/,                                         # generated code
+        /rubygems\/(custom|core_ext\/kernel)_require\.rb$/, # rubygems require hacks
+        /active_support/,                                   # active_support require hacks
+        /bundler(\/runtime)?\.rb/,                          # bundler require hacks
+        /<internal:/,                                       # internal in ruby >= 1.9.2
+        /src\/kernel\/bootstrap\/[A-Z]/                     # maglev kernel files
       ]
 
       # contrary to what the comment said previously, rubinius never supported this


### PR DESCRIPTION
This will fix #642...

> In rubygems 2.0.0, the file to override `Kernel#require` is `core_ext/kernel_require.rb` rather than `custom_require.rb`
