### PR TITLE
Added EventMachine-Sinatra Example

### DIFF
--- a/examples/event-machine.rb
+++ b/examples/event-machine.rb
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+
+
+require 'eventmachine'
+require 'sinatra/base'
+require 'thin'
+
+
+# This example shows you how to embed Sinatra into your EventMachine
+# application. This is very useful if you're application needs some
+# sort of API interface and you don't want to use EM's provided
+# web-server.
+
+def run
+
+  # Start he reactor
+  EM.run do
+
+    # define some defaults for our app
+    server = 'thin'
+    host = '0.0.0.0'
+    port = '8181'
+    web_app = HelloApp.new
+
+    # create a base-mapping that our application will set at. If I
+    # have the following routes:
+    #
+    #   get '/hello' do
+    #     'hello!'
+    #   end
+    #
+    #   get '/goodbye' do
+    #     'see ya later!'
+    #   end
+    #   
+    # Then I will get the following:
+    #   
+    #   mapping: '/'
+    #   routes:
+    #     /hello
+    #     /goodbye
+    #   
+    #   mapping: '/api'
+    #   routes:
+    #     /api/hello
+    #     /api/goodbye
+    dispatch = Rack::Builder.app do
+      map '/api' do
+        run web_app
+      end
+    end
+
+    # NOTE that we have to use an EM-compatible web-server. There
+    # might be more, but these are some that are currently available.
+    unless ['thin', 'hatetepe', 'goliath'].include? server
+      raise "Need an EM webserver, but #{server} isn't"
+    end
+
+    # Start the web server. Note that you are free to run other tasks
+    # within your EM instance.
+    Rack::Server.start({
+      app:    dispatch,
+      server: server,
+      Host:   host,
+      Port:   port
+    })
+  end
+end
+
+
+# Our simple hello-world app
+class HelloApp < Sinatra::Base
+  # threaded - False: Will take requests on the reactor thread
+  #            True:  Will queue request for background thread
+  configure do
+    set :threaded, false
+  end
+
+  # Request runs on the reactor thread (with threaded set to false)
+  get '/hello' do
+    'Hello World'
+  end
+
+  # Request runs on the reactor thread (with threaded set to false)
+  # and returns immediately. The deferred task does not delay the
+  # response from the web-service.
+  get '/delayed-hello' do
+    EM.defer do
+      sleep 5
+    end
+    'I\'m doing work in the background, but I am still free to take requests'
+  end
+end
+
+
+
+
+# start the application
+run


### PR DESCRIPTION
I've added a new example for running Sinatra within EventMachine.

When I first implemented this, it took me a while to figure out
how to do it properly. Even though it rides the line between being
an EventMachine example and a Sinatra example, I believe it can
be very useful to other Sinatra users. And more examples can't hurt
right?
