### PR TITLE
Use `headers` method instead of `header` method in `Sinatra::Response`

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -125,7 +125,7 @@ module Sinatra
         headers["Content-Length"] = body.inject(0) { |l, p| l + Rack::Utils.bytesize(p) }.to_s
       end
 
-      [status.to_i, header, result]
+      [status.to_i, headers, result]
     end
 
     private
@@ -159,7 +159,7 @@ module Sinatra
 
     private
 
-    def setup_close(env, status, header, body)
+    def setup_close(env, status, headers, body)
       return unless body.respond_to? :close and env.include? 'async.close'
       env['async.close'].callback { body.close }
       env['async.close'].errback { body.close }


### PR DESCRIPTION
Since `headers` is an alias for `header` (see `Rack::Response`) and `headers` is widely used in Sinatra. It's confusing that in `Sinatra::Response#finish` both `headers` and `header` are used.

And in `Sinatra::ExtendedRack#setup_close` use `headers` as parameter just like in `Sinatra::ExtendedRack#async?`
