### PR TITLE
Fix Gemfile source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@
 # If you have issues with a gem: `bundle install --without-coffee-script`.
 
 RUBY_ENGINE = 'ruby' unless defined? RUBY_ENGINE
-source :rubygems unless ENV['QUICK']
+source 'https://rubygems.org' unless ENV['QUICK']
 gemspec
 
 gem 'rake'


### PR DESCRIPTION
When running `bundle install` this warning shows up:

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.

This PR eliminates this warning by using `https://rubygems.org` instead of `:rubygems` as Gemfile source.
