### PR TITLE
Add therubyracer gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'markaby'
 gem 'radius'
 gem 'rabl' unless RUBY_ENGINE =~ /jruby|maglev/
 gem 'wlang', '>= 2.0.1' unless RUBY_ENGINE =~ /jruby|rbx/
-gem 'therubyracer'
+gem 'therubyracer' unless RUBY_ENGINE =~ /jruby|rbx/
 
 if RUBY_ENGINE != 'rbx' or RUBY_VERSION < '1.9'
   gem 'liquid'


### PR DESCRIPTION
When running the tests:

> [WARNING] Please install gem 'therubyracer' to use Less.
> cannot load such file -- v8: skipping less tests

This PR fixes this warning by adding `therubyracer` gem to `Gemfile`.
