### PR TITLE
Add redcarpet gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'radius'
 gem 'rabl' unless RUBY_ENGINE =~ /jruby|maglev/
 gem 'wlang', '>= 2.0.1' unless RUBY_ENGINE =~ /jruby|rbx/
 gem 'therubyracer' unless RUBY_ENGINE =~ /jruby|rbx/
+gem 'redcarpet' unless RUBY_ENGINE == 'jruby'
 
 if RUBY_ENGINE != 'rbx' or RUBY_VERSION < '1.9'
   gem 'liquid'


### PR DESCRIPTION
When running the tests:

> cannot load such file -- redcarpet: skipping markdown tests with Tilt::RedcarpetTemplate
> uninitialized constant Redcarpet: skipping markdown tests with Tilt::RedcarpetTemplate::Redcarpet2
> uninitialized constant Tilt::RedcarpetTemplate::Redcarpet1::RedcarpetCompat: skipping markdown tests with Tilt::RedcarpetTemplate::Redcarpet1

This PR adds `redcarpet` to `Gemfile`, except when running on JRuby.
