### PR TITLE
Add bluecloth to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'radius'
 gem 'rabl' unless RUBY_ENGINE =~ /jruby|maglev/
 gem 'wlang', '>= 2.0.1' unless RUBY_ENGINE =~ /jruby|rbx/
 gem 'therubyracer' unless RUBY_ENGINE =~ /jruby|rbx/
+gem 'bluecloth' unless RUBY_ENGINE == 'jruby'
 
 if RUBY_ENGINE != 'rbx' or RUBY_VERSION < '1.9'
   gem 'liquid'


### PR DESCRIPTION
When running the tests:

> cannot load such file -- bluecloth: skipping markdown tests with Tilt::BlueClothTemplate

This PR fixes this warning by adding `bluecloth` to `Gemfile` except when running on JRuby.
