### PR TITLE
'bind' default value documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2017,7 +2017,7 @@ set :protection, :session => true
   </dd>
 
   <dt>bind</dt>
-  <dd>IP address to bind to (default: <tt>0.0.0.0</tt> <em>or</em> <tt>localhost</tt> if your <pre>environment</pre> is set to development.). Only used for built-in server.</dd>
+  <dd>IP address to bind to (default: <tt>0.0.0.0</tt> <em>or</em> <tt>localhost</tt> if your `environment` is set to development.). Only used for built-in server.</dd>
 
   <dt>default_encoding</dt>
   <dd>encoding to assume if unknown (defaults to <tt>"utf-8"</tt>).</dd>


### PR DESCRIPTION
I'm not sure if there is a way to directly contribute to the documentation, but hopefully this gets where it needs to go.

During my first use of `sinatra` today I had an issue of getting up and running just as easily as the documentation seems to imply. After a little digging it was because my environment was being default-ed to `development`. This may be common or expected knowledge in the ruby community, but being less experienced in the language caused a small pitfall.

Thanks for your time, and sorry if I'm way off base on my request!

Relevent code:
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1734
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1765
