### PR TITLE
Use URI::Parser#unescape instead of URI::decode

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -850,6 +850,8 @@ module Sinatra
     include Helpers
     include Templates
 
+    URI = ::URI.const_defined?(:Parser) ? ::URI::Parser.new : ::URI
+
     attr_accessor :app
     attr_reader   :template_cache
 
@@ -971,7 +973,7 @@ module Sinatra
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
       return unless match = pattern.match(route)
-      values += match.captures.to_a.map { |v| force_encoding URI.decode(v) if v }
+      values += match.captures.to_a.map { |v| force_encoding URI.unescape(v) if v }
 
       if values.any?
         original, @params = params, params.merge('splat' => [], 'captures' => values)
@@ -1485,8 +1487,6 @@ module Sinatra
           raise TypeError, path
         end
       end
-
-      URI = ::URI.const_defined?(:Parser) ? ::URI::Parser.new : ::URI
 
       def encoded(char)
         enc = URI.escape(char)


### PR DESCRIPTION
URI::unescape is deprecated as of Ruby 1.9.2.

See:
- https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc
- https://github.com/rails/rails/commit/76b2d3e33730fce9680d0b6e97df12b1744fb23d

This patch will make it so `URI::Parser#unescape` is used when defined,
but fall back to `URI::unescape` when not.

It also gets rid of the following warning when running in verbose mode:

`lib/sinatra/base.rb:972:in 'block in process_route': warning: URI.unescape is obsolete`
