### PR TITLE
Easier instrumentation via env['sinatra.route']

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1378,4 +1378,14 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 4, signature.length
     assert list.include?(signature)
   end
+
+  it "sets env['sinatra.route'] to the matched route" do
+    mock_app do
+      after do
+        assert_equal 'GET /users/:id/status', env['sinatra.route']
+      end
+      get('/users/:id/status') { 'ok' }
+    end
+    get '/users/1/status'
+  end
 end


### PR DESCRIPTION
Adds a `sinatra.route` entry to `request.env` with the route that was matched for the current request.

This allows an after filter or rack middleware to gather per-route statistics about incoming requests.

For example, newrelic_rpm could use this feature instead of [scanning all the routes a second time](https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/sinatra.rb#L44-L53).
