### PR TITLE
Fix for NameError: uninitialized constant HelpersTest::JSON

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 require 'date'
+require 'json'
 
 class HelpersTest < Test::Unit::TestCase
   def test_default


### PR DESCRIPTION
Fixes the following test error:

```
test_should_not_reset_the_content_type_to_html_for_error_handlers_0(HelpersTest::TestError):
NameError: uninitialized constant HelpersTest::JSON
```
