### PR TITLE
Only overwrite pass_block if there's a value

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -942,10 +942,13 @@ module Sinatra
     def route!(base = settings, pass_block = nil)
       if routes = base.routes[@request.request_method]
         routes.each do |pattern, keys, conditions, block|
-          pass_block = process_route(pattern, keys, conditions) do |*args|
+          returned_pass_block = process_route(pattern, keys, conditions) do |*args|
             env['sinatra.route'] = block.instance_variable_get(:@route_name)
             route_eval { block[*args] }
           end
+
+          # don't wipe out pass_block in superclass
+          pass_block = returned_pass_block if returned_pass_block
         end
       end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -669,6 +669,24 @@ class RoutingTest < Test::Unit::TestCase
     assert "this", body
   end
 
+  it "uses optional block passed to pass as route block if no other route is found and superclass has non-matching routes" do
+    base = Class.new(Sinatra::Base)
+    base.get('/foo') { 'foo in baseclass' }
+
+    mock_app(base) {
+      get "/" do
+        pass do
+          "this"
+        end
+        "not this"
+      end
+    }
+
+    get "/"
+    assert_equal 200, status
+    assert "this", body
+  end
+
   it "passes when matching condition returns false" do
     mock_app {
       condition { params[:foo] == 'bar' }


### PR DESCRIPTION
This prevents pass_block from being overwritten with nil which happens when the superclass has (non-matching) routes.

This bites in development as Sinatra::Base registers "get '/**sinatra**/:image.png'" only in development mode, so everything works fine in production but not in development.
