### PR TITLE
Improved self-hosted server.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1388,52 +1388,44 @@ module Sinatra
         @middleware << [middleware, args, block]
       end
 
+      # Stop the self-hosted server if running.
       def quit!
-        return unless running
+        return unless running?
         # Use Thin's hard #stop! if available, otherwise just #stop.
-        s = running_server
-        s.respond_to?(:stop!) ? s.stop! : s.stop
-        disable :running
+        running_server.respond_to?(:stop!) ? running_server.stop! : running_server.stop
+        $stderr.puts "== Sinatra has ended his set (crowd applauds)" unless handler_name =~/cgi/i
         set :running_server, nil
-        $stderr.puts "\n== Sinatra has ended his set (crowd applauds)" unless handler_name =~/cgi/i
         set :handler_name, nil
       end
+
+      alias_method :stop!, :quit!
 
       # Run the Sinatra app as a self-hosted server using
       # Thin, Puma, Mongrel, or WEBrick (in that order). If given a block, will call
       # with the constructed handler once we have taken the stage.
-      def run!(options = {})
-        return if running
+      def run!(options = {}, &block)
+        return if running?
         set options
         handler         = detect_rack_handler
         handler_name    = handler.name.gsub(/.*::/, '')
         server_settings = settings.respond_to?(:server_settings) ? settings.server_settings : {}
+        server_settings.merge!(:Port => port, :Host => bind)
 
         begin
-          handler.run self, server_settings.merge(:Port => port, :Host => bind) do |server|
-            unless handler_name =~ /cgi/i
-              $stderr.puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
-              "on #{port} for #{environment} with backup from #{handler_name}"
-            end
-
-            unless traps_setup
-              [:INT, :TERM].each { |sig| trap(sig) { quit!; exit } }
-              enable :traps_setup
-            end
-
-            enable :running
-            set :running_server, server
-            set :handler_name, handler_name
-            server.threaded = settings.threaded if server.respond_to? :threaded=
-
-            yield server if block_given?
-          end
+          start_server(handler, server_settings, handler_name, &block)
         rescue Errno::EADDRINUSE
-          disable :running
-          set :running_server, nil
-          set :handler_name, nil
           $stderr.puts "== Someone is already performing on port #{port}!"
+          raise
+        ensure
+          quit!
         end
+      end
+
+      alias_method :start!, :run!
+
+      # Check whether the self-hosted server is running or not.
+      def running?
+        running_server?
       end
 
       # The prototype instance used to process requests.
@@ -1479,6 +1471,38 @@ module Sinatra
       end
 
       private
+
+      # Starts the server by running the Rack Handler.
+      def start_server(handler, server_settings, handler_name, &block)
+        handler.run(self, server_settings) do |server|
+          unless handler_name =~ /cgi/i
+            $stderr.puts "== Sinatra/#{Sinatra::VERSION} has taken the stage " +
+            "on #{port} for #{environment} with backup from #{handler_name}"
+          end
+
+          setup_traps
+          set :running_server, server
+          set :handler_name,   handler_name
+          server.threaded = settings.threaded if server.respond_to? :threaded=
+
+          yield server if block_given?
+        end
+      end
+
+      def setup_traps
+        unless traps_setup?
+          at_exit { quit! }
+
+          [:INT, :TERM].each do |signal|
+            old_handler = trap(signal) do
+              quit!
+              old_handler.call if old_handler.respond_to?(:call)
+            end
+          end
+
+          set :traps_setup, true
+        end
+      end
 
       # Dynamically defines a method on settings.
       def define_singleton(name, content = Proc.new)
@@ -1811,7 +1835,6 @@ module Sinatra
     end
 
     set :run, false                       # start server via at-exit hook?
-    set :running, false                   # is the built-in server running now?
     set :running_server, nil
     set :handler_name, nil
     set :traps_setup, false


### PR DESCRIPTION
- Will now stop the self-hosted server _and exit_ the program on INT and TERM signals.
- No more multiple Sinatra messages on multiple signals.
- Stopping/quitting a server possible using .quit! and without the need of the actual server and handler_name.

Watcha thinking?
