### PR TITLE
Use Rack::File's Content-Type in send_file

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -358,6 +358,7 @@ module Sinatra
       result    = file.serving env
       result[1].each { |k,v| headers[k] ||= v }
       headers['Content-Length'] = result[1]['Content-Length']
+      headers['Content-Type'] = result[1]['Content-Type']
       halt opts[:status] || result[0], result[2]
     rescue Errno::ENOENT
       not_found


### PR DESCRIPTION
When doing multipart, file.serving(env) will set the Content-Type with
the boundary, so we have to import it.

This is dependent of [multiple byte-request serving in sinatra](https://github.com/rack/rack/pull/559), not yet merged.
