### PR TITLE
Fixes accept? to match wildcards in HTTP_ACCEPT.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -28,7 +28,7 @@ module Sinatra
     end
 
     def accept?(type)
-      preferred_type.include?(type)
+      preferred_type(type).include?(type)
     end
 
     def preferred_type(*types)

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -63,6 +63,11 @@ class RequestTest < Test::Unit::TestCase
     end
   end
 
+  it "accepts types when wildcards are requested" do
+    request = Sinatra::Request.new('HTTP_ACCEPT' => 'image/*')
+    assert request.accept?('image/jpeg')
+  end
+
   it "properly decodes MIME type parameters" do
     request = Sinatra::Request.new(
       'HTTP_ACCEPT' => 'image/jpeg;unquoted=0.25;quoted="0.25";chartest="\";,\x"'


### PR DESCRIPTION
I wrote this in a comment on bce185f1966453aa7196118382c110894dc68aaf but since it is a behavior change, I'll just post a fix to get the old behavior back. If you think it should do what it did before, merge, if not, close. :)

The current code:

```
def accept? (type)
  preferred_type.include? type
end
```

**Problem**: if your `HTTP_ACCEPT` is `*/*` (as it would be treated if none were given at all as well), `preferred_type` without arguments just gives you `["*/*"]` because the arguments will be used to resolve patterns and without them, it just returns the patterns themselves. So `accept?` won't act how one would expect it to. That is, `accept?('foo/bar')` should be `true` when `HTTP_ACCEPT` is `*/*` or `foo/*` etc. **But it doesn't.**

I believe it should be ...

```
def accept? (type)
  preferred_type(type).include? type
end
```

... so that the pattern code in `preferred_type` is triggered and this bizarre function returns an array of types resolved from the patterns that will match `type`. It still works for non-wildcards, but also will work for wildcards as well, and it should still reject non-matching cases.

**Discovery**: The behavior I was testing in a project that deals with default accept cases started breaking with this commit. It was fixed when I used `preferred_type` instead of `accept?` so that the types are passed into `preferred_type` I could also add `"*/*"` as a case, but adding wildcard cases to match directly seems to defeat the purpose of them.

For instance, I could not just do:

```
if request.accept?('application/xml')
  # publish xml
else
  # handle error
end
```

and expect it will handle xml when `HTTP_ACCEPT` is `*/*`, which it seems like it should.

**Basically**: the behavior has changed. This code reverts the behavior back by allowing preferred_type to resolve patterns, but keeps the new return type of boolean (which makes sense) over what `accept?` was before (a simple alias of preferred_type, which returns an array)

**Test**: I added a single very simple test (tests sure are sparse!) to ensure the `accept?` will return `true` when the pattern matches the one given by `HTTP_ACCEPT`.
