### PR TITLE
Added an example on how to share a cookie through a subdomain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,13 @@ the `sessions` setting:
 set :sessions, :domain => 'foo.com'
 ```
 
+To share your session across other apps on subdomains of foo.com, prefix the
+domain with a *.* like this instead:
+
+``` ruby
+set :sessions, :domain => '.foo.com'
+```
+
 ### Halting
 
 To immediately stop a request within a filter or route use:


### PR DESCRIPTION
See padrino/padrino-framework#1322.
