### PR TITLE
Tilt 2 compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'haml', '>= 3.0'
 gem 'sass' if RUBY_VERSION < "2.0"
 gem 'builder'
 gem 'erubis'
-gem 'slim', '~> 1.0'
+gem 'slim', :git => 'git://github.com/slim-template/slim.git'
 gem 'temple', '!= 0.3.3'
 gem 'coffee-script', '>= 2.0'
 gem 'rdoc', RUBY_VERSION < '1.9' ? '~> 3.12' : '>= 4.0'

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -752,9 +752,15 @@ module Sinatra
     # named name.ext, where ext is registered on engine.
     def find_template(views, name, engine)
       yield ::File.join(views, "#{name}.#{@preferred_extension}")
-      Tilt.mappings.each do |ext, engines|
-        next unless ext != @preferred_extension and engines.include? engine
-        yield ::File.join(views, "#{name}.#{ext}")
+      if Tilt.respond_to?(:mappings)
+        Tilt.mappings.each do |ext, engines|
+          next unless ext != @preferred_extension and engines.include? engine
+          yield ::File.join(views, "#{name}.#{ext}")
+        end
+      else
+        Tilt.default_mapping.extensions_for(engine).each do |ext|
+          yield ::File.join(views, "#{name}.#{ext}") unless ext == @preferred_extension
+        end
       end
     end
 

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
   s.add_dependency 'rack', '~> 1.4'
-  s.add_dependency 'tilt', '~> 1.3', '>= 1.3.4'
+  s.add_dependency 'tilt', '>= 1.3.4', '< 3.0'
   s.add_dependency 'rack-protection', '~> 1.4'
 end

--- a/test/slim_test.rb
+++ b/test/slim_test.rb
@@ -48,7 +48,7 @@ class SlimTest < Test::Unit::TestCase
   HTML4_DOCTYPE = "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
 
   it "passes slim options to the slim engine" do
-    mock_app { get('/') { slim("x foo='bar'", :attr_wrapper => "'") }}
+    mock_app { get('/') { slim("x foo='bar'", :attr_quote => "'") }}
     get '/'
     assert ok?
     assert_body "<x foo='bar'></x>"
@@ -56,7 +56,7 @@ class SlimTest < Test::Unit::TestCase
 
   it "passes default slim options to the slim engine" do
     mock_app do
-      set :slim, :attr_wrapper => "'"
+      set :slim, :attr_quote => "'"
       get('/') { slim("x foo='bar'") }
     end
     get '/'
@@ -66,9 +66,9 @@ class SlimTest < Test::Unit::TestCase
 
   it "merges the default slim options with the overrides and passes them to the slim engine" do
     mock_app do
-      set :slim, :attr_wrapper => "'"
+      set :slim, :attr_quote => "'"
       get('/') { slim("x foo='bar'") }
-      get('/other') { slim("x foo='bar'", :attr_wrapper => '"') }
+      get('/other') { slim("x foo='bar'", :attr_quote => '"') }
     end
     get '/'
     assert ok?


### PR DESCRIPTION
WIP, do not merge yet.

This makes Sinatra comptabile with Tilt 2.0 (currently only from master. beta1 is old already) and 1.x.

I had to use Slim from master, but that should not be neccesary once a new version of Slim is released. 

/cc @rkh