### PR TITLE
Allow caller to specify path/line when rendering with Proc or String.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -838,7 +838,9 @@ module Sinatra
           end
         when Proc, String
           body = data.is_a?(String) ? Proc.new { data } : data
-          path, line = settings.caller_locations.first
+          caller = settings.caller_locations.first
+          path = options[:path] || caller[0]
+          line = options[:line] || caller[1]
           template.new(path, line.to_i, options, &body)
         else
           raise ArgumentError, "Sorry, don't know how to render #{data.inspect}."


### PR DESCRIPTION
When rendering a template from a supplied `Proc` or `String`, Sinatra generates the path/line information for Tilt via `settings.caller_locations`. This is a reasonable default, but the caller may wish to override the default (for example, if there happens to be a filesystem path associated with the String). This patch allows the caller to pass those values in the `options` parameter.
