### PR TITLE
Option hash not used in self#new

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1956,7 +1956,7 @@ module Sinatra
 
   # Create a new Sinatra application. The block is evaluated in the new app's
   # class scope.
-  def self.new(base = Base, options = {}, &block)
+  def self.new(base = Base, &block)
     base = Class.new(base)
     base.class_eval(&block) if block_given?
     base


### PR DESCRIPTION
There is an unused `options = {}` argument in `Sinatra.new` method:

``` ruby
# Create a new Sinatra application. The block is evaluated in the new app's
# class scope.
def self.new(base = Base, options = {}, &block)
  base = Class.new(base)
  base.class_eval(&block) if block_given?
  base
end
```

So it can be dropped. But this change is not really backwards-compatible with current Sinatra (somebody could just write `Sinatra.new(Sinatra::Base, {})` and it won't work after this commit), so it can be merged in 2.0, for example.
