### PR TITLE
Update .yardopts to markdown

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
---readme README.rdoc
+--readme README.md
 --title 'Sinatra API Documentation'
 --charset utf-8
-'lib/**/*.rb' - '*.rdoc'
+--markup markdown
+'lib/**/*.rb' - '*.md'


### PR DESCRIPTION
Update .yardopts file to reflect new use of markdown in docs.

This might be the cause of #764.

Related: should `AUTHORS`, `LICENSE` and/or `CHANGES` be added to the files to be included?
