### PR TITLE
Make the request accept */* when HTTP_ACCEPT is not present or blank

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -22,8 +22,12 @@ module Sinatra
     # Returns an array of acceptable media types for the response
     def accept
       @env['sinatra.accept'] ||= begin
-        @env['HTTP_ACCEPT'].to_s.scan(HEADER_VALUE_WITH_PARAMS).
-          map! { |e| AcceptEntry.new(e) }.sort
+        if @env.include? 'HTTP_ACCEPT' and @env['HTTP_ACCEPT'].to_s != ''
+          @env['HTTP_ACCEPT'].to_s.scan(HEADER_VALUE_WITH_PARAMS).
+            map! { |e| AcceptEntry.new(e) }.sort
+        else
+          [AcceptEntry.new('*/*')]
+        end
       end
     end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -75,4 +75,18 @@ class RequestTest < Test::Unit::TestCase
     expected = { 'unquoted' => '0.25', 'quoted' => '0.25', 'chartest' => '";,x' }
     assert_equal(expected, request.preferred_type.params)
   end
+
+  it 'accepts */* when HTTP_ACCEPT is not present in the request' do
+    request = Sinatra::Request.new Hash.new
+    assert_equal 1, request.accept.size
+    assert request.accept?('text/html')
+    assert_equal '*/*', request.preferred_type.to_s
+  end
+
+  it 'accepts */* when HTTP_ACCEPT is blank in the request' do
+    request = Sinatra::Request.new 'HTTP_ACCEPT' => ''
+    assert_equal 1, request.accept.size
+    assert request.accept?('text/html')
+    assert_equal '*/*', request.preferred_type.to_s
+  end
 end


### PR DESCRIPTION
See #731.

When the request has no `HTTP_ACCEPT` header (or when `HTTP_ACCEPT` is blank), `accept` returns `[]` and there's no preferred type. So, when you call `accept?`, a `NoMethodErrorException` is raised.

This can be easily reproduced in irb:

```
/tmp% irb
irb(main):001:0> require 'sinatra'
=> true
irb(main):002:0> r = Sinatra::Request.new({})
=> #<Sinatra::Request:0x007fab14d64680 @env={}>
irb(main):003:0> r.accept? 'text/html'
NoMethodError: undefined method `include?' for nil:NilClass
    from /Users/patricio/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/sinatra-1.4.3/lib/sinatra/base.rb:31:in `accept?'
    from (irb):3
    from /Users/patricio/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
irb(main):004:0>
```

I've added a two tests and fixed the issue initializing the `@env['sinatra.accept']` to '_/_' when `HTTP_ACCEPT` header is not present or blank.
