### PR TITLE
Remove test task warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,6 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
   t.ruby_opts = ['-rubygems'] if defined? Gem
   t.ruby_opts << '-I.'
-  t.warning = true
 end
 
 Rake::TestTask.new(:"test:core") do |t|
@@ -52,7 +51,6 @@ Rake::TestTask.new(:"test:core") do |t|
   t.test_files = core_tests.map {|n| "test/#{n}_test.rb"}
   t.ruby_opts = ["-rubygems"] if defined? Gem
   t.ruby_opts << "-I."
-  t.warning = true
 end
 
 # Rcov ================================================================


### PR DESCRIPTION
Somehow, the `Rakefile` has `warnings` set to true, which makes it impossible to follow. Also, the test suite shows warnings from other gems, which I think it's not helpful (we can't do anything right here).

Feel free to ignore and close this PR (if warnings don't bother you)
