### PR TITLE
Fix streaming Content-Length test

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -99,6 +99,6 @@ class IntegrationTest < Test::Unit::TestCase
 
   it "doesn't ignore Content-Length header when streaming" do
     response = server.get_response '/streaming'
-    assert_equal response['Content-Length'], '46'
+    assert_equal '46', response['Content-Length']
   end
 end


### PR DESCRIPTION
Mentioned by @splattael. Checks equality of `'46'` and `response['Content-Length']` in Content-Length streaming test from now on.
