### PR TITLE
Disable path_traversal protection for handling encoded slashes test.

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -90,7 +90,10 @@ class RoutingTest < Test::Unit::TestCase
   end
 
   it "it handles encoded slashes correctly" do
-    mock_app { get("/:a") { |a| a } }
+    mock_app {
+      set :protection, :except => :path_traversal
+      get("/:a") { |a| a }
+    }
     get '/foo%2Fbar'
     assert_equal 200, status
     assert_body "foo/bar"


### PR DESCRIPTION
Fixes the build but the decision to escape slashes in rack-protection is in direct
competition with this test so is this the right way to solve it? Is this even
desired behaviour anymore?
