### PR TITLE
Add license to gem spec. Fixes #816

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.authors           = ["Blake Mizerany", "Ryan Tomayko", "Simon Rozet", "Konstantin Haase"]
   s.email             = "sinatrarb@googlegroups.com"
   s.homepage          = "http://www.sinatrarb.com/"
+  s.license           = 'MIT'
   s.files             = `git ls-files`.split("\n") - %w[.gitignore .travis.yml]
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'


### PR DESCRIPTION
Although the repo carries a license, the spec does not list it.
Fixes #816
