### PR TITLE
Fix JRuby's incorrect behavior when using utf-8 method name.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1575,6 +1575,7 @@ module Sinatra
       end
 
       def generate_method(method_name, &block)
+        method_name = method_name.to_sym
         define_method(method_name, &block)
         method = instance_method method_name
         remove_method method_name


### PR DESCRIPTION
ref #820
The same problem occurred on padrino.
This is a jruby issue.
see: https://github.com/jruby/jruby/issues/1285 https://github.com/padrino/padrino-framework/pull/1508/files
