### PR TITLE
Conslidate template rendering methods.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -672,7 +672,7 @@ module Sinatra
       end
     end
 
-    [:less, :sass, :scss, :stylus].each do |type|
+    [:less, :sass, :scss].each do |type|
       define_method(type) do |template, options = {}, locals = {}|
         options.merge! :layout => false, :default_content_type => :css
         render type, template, options, locals
@@ -688,6 +688,11 @@ module Sinatra
 
     def markaby(template = nil, options = {}, locals = {}, &block)
       render_ruby(:mab, template, options, locals, &block)
+    end
+
+    def stylus(template, options={}, locals={})
+      options.merge! :layout => false, :default_content_type => :css
+      render :styl, template, options, locals
     end
 
     def erubis(template, options = {}, locals = {})


### PR DESCRIPTION
Was using CodeClimate with my own Sinatra application, and stumbled upon Sinatra's CodeClimate analysis.
I saw the following there:

---

![sinatra_duplication_codeclimate](https://f.cloud.github.com/assets/3589911/1897955/977811b0-7c04-11e3-8f2f-f92a57e4103b.png)

---

This pull request will eliminate those two duplication issues from the code base by:
- Placing relevant methods together and defining them via `define_method`.
- Re-ordering methods within the module based on what they are rendering.

Ran the full, built-in test suite via `rake test` and had all tests pass.
