### PR TITLE
Reafactor creation hash with default value in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -111,7 +111,7 @@ end
 desc "list of authors"
 task :authors, [:commit_range, :format, :sep] do |t, a|
   a.with_defaults :format => "%s (%d)", :sep => ", ", :commit_range => '--all'
-  authors = Hash.new { |h,k| h[k] = 0 }
+  authors = Hash.new(0)
   blake   = "Blake Mizerany"
   overall = 0
   mapping = {


### PR DESCRIPTION
Pass default value as parameter for initializer rather than passing a `proc` to it. It's just cosmetic fix, but theoretically it either may approve a little bit performance.
