### PR TITLE
Ruby warning fix in Templates#compile_template

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -835,7 +835,7 @@ module Sinatra
             @preferred_extension = engine.to_s
             find_template(views, data, template) do |file|
               path ||= file # keep the initial path rather than the last one
-              if found = File.exists?(file)
+              if found = File.exist?(file)
                 path = file
                 break
               end


### PR DESCRIPTION
Ruby warns: `File.exists?` is a deprecated name, use `File.exist?` instead; this patch makes Sinatra `ruby -w`-clean (from third parties’ perspective) again.
