### PR TITLE
Use Sinatra::Runner In Integration Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ platforms :mri_18 do
   next if RUBY_ENGINE != 'ruby' or RUBY_VERSION > "1.8"
   gem 'rcov'
 end
+
+gem "sinatra-contrib", :path => "../sinatra-contrib"#:git => "git@github.com:apotonick/sinatra-contrib.git", :branch => "runner"


### PR DESCRIPTION
As per PR https://github.com/sinatra/sinatra-contrib/pull/122 we now use `Sinatra::Runner` for integration tests.

Only problem is that we have a development dependency to `sinatra-contrib` but @rkh promised to look into that.