### PR TITLE
Initialize Templates::ContentTyped @preferred_extension in  to nil.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -658,6 +658,7 @@ module Sinatra
     def initialize
       super
       @default_layout = :layout
+      @preferred_extension = nil
     end
 
     def erb(template, options = {}, locals = {}, &block)


### PR DESCRIPTION
Initialize @preferred_extension in Templates::ContentTyped to nil to avoid ruby warning about it not being initialized.
