### PR TITLE
Talk about inheriting from Sinatra::Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -2452,7 +2452,8 @@ available via the top-level DSL. Most top-level apps can be converted to
 `Sinatra::Base` is a blank slate. Most options are disabled by default,
 including the built-in server. See
 [Configuring Settings](http://sinatra.github.com/configuration.html)
-for details on available options and their behavior.
+for details on available options and their behavior. Inheriting from <code>Sinatra::Application</code>
+allows modular applications to have the same settings enabled as in a classic application.</p>
 
 ### Modular vs. Classic Style
 
@@ -2477,7 +2478,7 @@ different default settings:
   <tr>
     <td>app_file</td>
     <td>file loading sinatra</td>
-    <td>file subclassing Sinatra::Base</td>
+    <td>file subclassing Sinatra::Base or Sinatra::Application</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
I am currently teaching 26 people how to program in gSchool. We ran into an issue inheriting from Sinatra::Base where the HTTP method overriding using a hidden form field didn't work when inheriting from Sinatra::Base while it worked for a classic application

This commit adds in a note that you can inherit from Sinatra::Application to get the same settings as a classic application to make it a little more clear.
