### PR TITLE
remove a redundant `require`

### DIFF
--- a/lib/sinatra.rb
+++ b/lib/sinatra.rb
@@ -1,4 +1,3 @@
-require 'sinatra/base'
 require 'sinatra/main'
 
 enable :inline_templates


### PR DESCRIPTION
As `require 'sinatra/base'` is the first line of sinatra/main.rb, this looks redundant to me.