### PR TITLE
remove redundant/"protective" `to_sym`

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1399,7 +1399,7 @@ module Sinatra
       # Set configuration options for Sinatra and/or the app.
       # Allows scoping of settings for certain environments.
       def configure(*envs)
-        yield self if envs.empty? || envs.include?(environment.to_sym)
+        yield self if envs.empty? || envs.include?(environment)
       end
 
       # Use the specified Rack middleware


### PR DESCRIPTION
Because:
1. `to_sym` is not called elsewhere on `environment`'s value (see 5 lines above),
2. the value in `environment` must have been obtained with `to_sym` (search for `set :environment`).
