### PR TITLE
added documentation for replacing #find_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1231,6 +1231,23 @@ end
 Renders `./views/index.myat`. See https://github.com/rtomayko/tilt to
 learn more about Tilt.
 
+### Using Custom Logic for Template Lookup
+
+To implement your own template lookup mechanism you can write your
+own `#find_template` method:
+
+``` ruby
+configure do
+  set :views [ './views/a', './views/b' ]
+end
+
+def find_template(views, name, engine, &block)
+  Array(views).each do |v|
+    super(v, name, engine, &block)
+  end
+end
+```
+
 ## Filters
 
 Before filters are evaluated before each request within the same


### PR DESCRIPTION
While I was looking for a way to use multiple directories for templates I found a test added in 441b17ead90d3e3a90a3a478edb216a00f624d0f which resolved all my problems.

I just added documentation for this feature.
