### PR TITLE
Potential for reflected XSS in development mode 404 page

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1941,7 +1941,7 @@ module Sinatra
             <img src='#{uri "/__sinatra__/404.png"}'>
             <div id="c">
               Try this:
-              <pre>#{code}</pre>
+              <pre>#{Rack::Utils.escape_html(code)}</pre>
             </div>
           </body>
           </html>


### PR DESCRIPTION
I don't believe this affects any major browsers since you need a browser that isn't doing URL encoding, but for clients that will pass the URL unmodified there is an XSS in the development mode 404 page.

e.g. `curl http://example.com/1<script>prompt(document.domain)</ScRiPt>`

`request.path_info` is echoed directly onto the page:

https://github.com/sinatra/sinatra/blob/8b39bbdd2d260e7de31571d5591c0c6299ba955b/lib/sinatra/base.rb#L1944
