### PR TITLE
Deprecate :after-handler value for show_exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2211,11 +2211,6 @@ set :protection, :session => true
     happens. Enabled by default when <tt>environment</tt>
     is set to <tt>"development"</tt>, disabled otherwise.
   </dd>
-  <dd>
-    Can also be set to <tt>:after_handler</tt> to trigger
-    app-specified error handling before showing a stack
-    trace in the browser.
-  </dd>
 
   <dt>static</dt>
   <dd>Whether Sinatra should handle serving static files.</dd>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1099,9 +1099,11 @@ module Sinatra
 
       status(500) unless status.between? 400, 599
 
+      res = error_block!(boom.class, boom) || error_block!(status, boom)
+
       if server_error?
         dump_errors! boom if settings.dump_errors?
-        raise boom if settings.show_exceptions? and settings.show_exceptions != :after_handler
+        raise boom if settings.show_exceptions?
       end
 
       if not_found?
@@ -1109,9 +1111,9 @@ module Sinatra
         body '<h1>Not Found</h1>'
       end
 
-      res = error_block!(boom.class, boom) || error_block!(status, boom)
       return res if res or not server_error?
       raise boom if settings.raise_errors? or settings.show_exceptions?
+
       error_block! Exception, boom
     end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -247,10 +247,9 @@ class SettingsTest < Test::Unit::TestCase
       assert body.include?("<code>show_exceptions</code> setting")
     end
 
-    it 'does not override app-specified error handling when set to :after_handler' do
+    it 'does not override app-specified error handling' do
       ran = false
       mock_app do
-        set :show_exceptions, :after_handler
         error(RuntimeError) { ran = true }
         get('/') { raise RuntimeError }
       end
@@ -260,17 +259,16 @@ class SettingsTest < Test::Unit::TestCase
       assert ran
     end
 
-    it 'does catch any other exceptions when set to :after_handler' do
+    it 'does not a different exceptions' do
       ran = false
       mock_app do
-        set :show_exceptions, :after_handler
         error(RuntimeError) { ran = true }
         get('/') { raise ArgumentError }
       end
 
-      get '/'
-      assert_equal 500, status
-      assert !ran
+      assert_raises ArgumentError do
+        get '/'
+      end
     end
   end
 


### PR DESCRIPTION
It's very confusing for new users as they will write custom handlers
with `error(*codes, &:block)` but those would never run in development
because `handle_exception!` was raising a general exception before
checking for custom errors.

I believe the only advantage for that would be to display stack traces
on the browser for users but I think most of the times users are catching
custom errors they don't care much about the stack trace or even if they
care they can always raise the exception again

It's been a couple months I've tried to use sinatra built in error handler but would always drop it because I thought it didn't work till today when I took a closer look. I see README mentions the `:after_handler` option but it was not clear to me at all that I had to set that in order to make my error handler run in development. Initially I thought of submitting a README change to mention that here https://github.com/sinatra/sinatra#error-handling but after reading the code decided to take a chance on dropping that config option value and hear what you guys think?

In case you have strong options against it I can submit another PR to mention about the `show_exceptions, :after_handler` value on the error-handling section.
