### PR TITLE
Mention show_exception :after-handler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2308,8 +2308,14 @@ end
 ### Error
 
 The `error` handler is invoked any time an exception is raised from a route
-block or a filter. The exception object can be obtained from the
-`sinatra.error` Rack variable:
+block or a filter. But note in development it will only run if you set the
+show exceptions option to `:after_handler`.
+
+```ruby
+set :show_exceptions, :after_handler
+```
+
+The exception object can be obtained from the `sinatra.error` Rack variable.
 
 ``` ruby
 error do


### PR DESCRIPTION
error handler blocks won't run in development unless users set that
option

I suggested we deprecate that option in https://github.com/sinatra/sinatra/pull/884 but it's a breaking change for a minor release. So I thought it should be worth mentioning it on README. I want to continue working on that PR to fix another issue where a general `error` block will never run in development, not even if you set the :after_handler option.
