### PR TITLE
Fix regexp to use case-insensitivity correctly

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -262,7 +262,7 @@ module Sinatra
     # Generates the absolute URI for a given path in the app.
     # Takes Rack routers and reverse proxies into account.
     def uri(addr = nil, absolute = true, add_script_name = true)
-      return addr if addr =~ /\A[A-z][A-z0-9\+\.\-]*:/
+      return addr if addr =~ /\A[a-z][a-z0-9\+\.\-]*:/i
       uri = [host = ""]
       if absolute
         host << "http#{'s' if request.secure?}://"


### PR DESCRIPTION
I noticed a faulty regexp in Sinatra's uri():
The regexp /[A-z]/ matches all alphabets, but also six non-alphabetic characters, as demonstrated by ("A".."z").to_a.join
=> "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz"