### PR TITLE
Skip coffee test instead of exiting if execjs runtime is not available

### DIFF
--- a/test/coffee_test.rb
+++ b/test/coffee_test.rb
@@ -87,4 +87,10 @@ end
 
 rescue LoadError
   warn "#{$!.to_s}: skipping coffee tests"
+rescue
+  if $!.class.name == 'ExecJS::RuntimeUnavailable'
+    warn "#{$!.to_s}: skipping coffee tests"
+  else
+    raise
+  end
 end


### PR DESCRIPTION
This fixes the following issue when running rake:

```
$ rake
/home/billg/sinatra/test/helper.rb:2: warning: setting Encoding.default_external
cannot load such file -- asciidoctor: skipping asciidoc tests
/usr/local/lib/ruby/gems/2.1/gems/execjs-2.1.0/lib/execjs/runtimes.rb:51:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/exec
js for a list of available runtimes. (ExecJS::RuntimeUnavailable)
        from /usr/local/lib/ruby/gems/2.1/gems/execjs-2.1.0/lib/execjs.rb:5:in `<module:ExecJS>'
        from /usr/local/lib/ruby/gems/2.1/gems/execjs-2.1.0/lib/execjs.rb:4:in `<top (required)>'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/gems/2.1/gems/coffee-script-2.2.0/lib/coffee_script.rb:1:in `<top (required)>'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/gems/2.1/gems/coffee-script-2.2.0/lib/coffee-script.rb:1:in `<top (required)>'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:135:in `require'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:144:in `require'
        from /home/billg/sinatra/test/coffee_test.rb:4:in `<top (required)>'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/2.1/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/2.1/rake/rake_test_loader.rb:15:in `block in <main>'
        from /usr/local/lib/ruby/2.1/rake/rake_test_loader.rb:4:in `select'
        from /usr/local/lib/ruby/2.1/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib" -rubygems -I. -I"/usr/local/lib/ruby/2.1" "/usr/local/lib/ruby/2.1/rake/rake_test_loader.rb" "test/asciidoctor_test.r
b" "test/base_test.rb" "test/builder_test.rb" "test/coffee_test.rb" "test/compile_test.rb" "test/creole_test.rb" "test/delegator_test.rb" "test/encoding_test.rb" "tes
t/erb_test.rb" "test/extensions_test.rb" "test/filter_test.rb" "test/haml_test.rb" "test/helpers_test.rb" "test/integration_test.rb" "test/less_test.rb" "test/liquid_
test.rb" "test/mapped_error_test.rb" "test/markaby_test.rb" "test/markdown_test.rb" "test/mediawiki_test.rb" "test/middleware_test.rb" "test/nokogiri_test.rb" "test/r
abl_test.rb" "test/rack_test.rb" "test/radius_test.rb" "test/rdoc_test.rb" "test/readme_test.rb" "test/request_test.rb" "test/response_test.rb" "test/result_test.rb"
"test/route_added_hook_test.rb" "test/routing_test.rb" "test/sass_test.rb" "test/scss_test.rb" "test/server_test.rb" "test/settings_test.rb" "test/sinatra_test.rb" "t
est/slim_test.rb" "test/static_test.rb" "test/streaming_test.rb" "test/stylus_test.rb" "test/templates_test.rb" "test/textile_test.rb" "test/wlang_test.rb" "test/yajl
_test.rb" ]

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

This is ugly, but I'm not sure if there is a better way to fix it.  As you can see by the backtrace, coffee-script require execjs, and that raises ExecJS::RuntimeUnavailable, and you can't reference the ExecJS::RuntimeUnavailable constant before requiring execjs.
