### PR TITLE
Make route params available during error handler (Fixes #860)

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1006,6 +1006,9 @@ module Sinatra
         conditions.each { |c| throw :pass if c.bind(self).call == false }
         block ? block[self, values] : yield(self, values)
       end
+    rescue
+      @env['sinatra.error.params'] = @params
+      raise
     ensure
       @params = original if original
     end
@@ -1088,6 +1091,9 @@ module Sinatra
 
     # Error handling during requests.
     def handle_exception!(boom)
+      if error_params = @env['sinatra.error.params']
+        @params = @params.merge(error_params)
+      end
       @env['sinatra.error'] = boom
 
       if boom.respond_to? :http_status

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -628,6 +628,23 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 'Hello World', body
   end
 
+  it "makes original request params available in error handler" do
+    mock_app {
+      disable :raise_errors
+
+      get '/:foo' do
+        raise ArgumentError, "foo"
+      end
+
+      error do
+        "Hello #{params['foo']}2"
+      end
+    }
+
+    get '/bar'
+    assert_equal 'Hello bar2', body
+  end
+
   it "transitions to 404 when passed and no subsequent route matches" do
     mock_app {
       get '/:foo' do


### PR DESCRIPTION
This is kind of ugly, but I couldn't see a better way.  One
potential issue is that the splat and captures route params
will be overwritten by the error handler.  There's no way to
change that without breaking backwards compatibility.  We
could potentially offer the route splat/captures under
different param names, though.