### PR TITLE
Unify not_found and error 404 behavior (Fixes #814)

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1247,13 +1247,13 @@ module Sinatra
         args  = compile! "ERROR", //, block
         codes = codes.map { |c| Array(c) }.flatten
         codes << Exception if codes.empty?
+        codes << Sinatra::NotFound if codes.include?(404)
         codes.each { |c| (@errors[c] ||= []) << args }
       end
 
       # Sugar for `error(404) { ... }`
       def not_found(&block)
         error(404, &block)
-        error(Sinatra::NotFound, &block)
       end
 
       # Define a named template. The block must return the template source.

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -127,6 +127,21 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 404, status
   end
 
+  it "uses 404 error handler for not matching route" do
+    mock_app {
+      not_found do
+        "nf"
+      end
+      error 404 do
+        "e"
+      end
+    }
+
+    get "/"
+    assert_equal "e", body
+    assert_equal 404, status
+  end
+
   it 'matches empty PATH_INFO to "/" if no route is defined for ""' do
     mock_app do
       get '/' do


### PR DESCRIPTION
This makes not_found just call error 404, instead of also handling
the Sinatra::NotFound specially.