### PR TITLE
[FEAT] Make sure fetch also works as expected in with_indifferent behavior

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1051,7 +1051,13 @@ module Sinatra
 
     # Creates a Hash with indifferent access.
     def indifferent_hash
-      Hash.new {|hash,key| hash[key.to_s] if Symbol === key }
+      new_hash = Hash.new {|hash,key| hash[key.to_s] if Symbol === key }
+      class << new_hash
+        def fetch(key, *extras)
+          super((key.kind_of?(Symbol) ? key.to_s : key), *extras)
+        end
+      end
+      new_hash
     end
 
     # Run the block with 'throw :halt' support and apply result to the response.

--- a/test/hash_indifferent_params_test.rb
+++ b/test/hash_indifferent_params_test.rb
@@ -1,0 +1,29 @@
+require File.expand_path('../helper', __FILE__)
+
+class BaseTest < Test::Unit::TestCase
+
+  setup do
+    @hash = {"some_key" => "moshe"}
+  end
+
+  it 'allows accessing hash with string key' do
+    parsed_hash =  Sinatra::Base.new.helpers.send(:indifferent_params,  @hash)
+    assert_equal "moshe" , parsed_hash["some_key"]
+  end
+
+  it 'allows accessing hash with symbol as key' do
+    parsed_hash =  Sinatra::Base.new.helpers.send(:indifferent_params,  @hash)
+    assert_equal "moshe" , parsed_hash[:some_key]
+  end
+
+  it 'allows accessing hash with fetch symbol as key' do
+    parsed_hash =  Sinatra::Base.new.helpers.send(:indifferent_params,  @hash)
+    assert_equal "moshe" , parsed_hash.fetch(:some_key, "wrong_value")
+  end
+
+  it 'allows accessing hash with fetch symbol as key' do
+    parsed_hash =  Sinatra::Base.new.helpers.send(:indifferent_params,  @hash)
+    assert_equal "moshe" , parsed_hash.fetch("some_key", "wrong_value")
+  end
+
+end


### PR DESCRIPTION
I understand sinatra wouldn't want to pull in ActiveSupport, makes perfect sense.

However, I came across a real surprising issue trying to debug the behaviour around the poor men's implementation of with_indifferent_access.
Given the following param:

``` ruby
params = {"host"=>"subcategory"}
```

I see:

``` ruby
params.class # => 'Hash'
params['host'] = "subcategory"
params[:host] = "subcategory"
```

All good so far, however when I try to use `fetch`, I see the following unexpected behaviour:

``` ruby
params.fetch(:host, 'default') # => 'default'
```

Updating only the params eigen class should fix that with little risk to this world, and beyond.
