### PR TITLE
Update ShowExceptions to suit latest rack master

### DIFF
--- a/lib/sinatra/show_exceptions.rb
+++ b/lib/sinatra/show_exceptions.rb
@@ -24,18 +24,24 @@ module Sinatra
 
       if prefers_plain_text?(env)
         content_type = "text/plain"
-        body = [dump_exception(e)]
+        exception_string = dump_exception(e)
       else
         content_type = "text/html"
-        body = pretty(env, e)
+        exception_string = pretty(env, e)
       end
 
       env["rack.errors"] = errors
 
-      [500,
+      # Post 893a2c50 in rack/rack, the #pretty method above, implemented in
+      # Rack::ShowExceptions, returns a String instead of an array.
+      body = Array(exception_string)
+
+      [
+        500,
        {"Content-Type" => content_type,
         "Content-Length" => Rack::Utils.bytesize(body.join).to_s},
-       body]
+       body
+      ]
     end
 
     private


### PR DESCRIPTION
- Post 893a2c50 in rack/rack, the #pretty method used while generating
  the HTML error markup, implemented in Rack::ShowExceptions, returns a
  String instead of an Array. This change uses Array() to
  convert the exception string in both plain text and HTML modes
  to an array.
- Should fix #906
