### PR TITLE
Make the `status` helper accept status messages as symbols as in Rack::Utils.status_code

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -228,7 +228,7 @@ module Sinatra
   module Helpers
     # Set or retrieve the response status code.
     def status(value = nil)
-      response.status = value if value
+      response.status = status_code(value) if value
       response.status
     end
 


### PR DESCRIPTION
Rack provides the `Rack::Utils.status_code` method which allows to retrieve a
response status code by its "symbolified" message: e.g. you can call
`status_code(:ok)` and it returns `200`. It's great also because if you pass
`'200'` or `200` to it, it still returns `200`.

By adding a call to `status_code` to the `status` method, nothing has been
removed or modified for the API. Now, however, you can call:

``` ruby
status :ok
```

and it will work as well.

I'm holding back from updating the docs in order to see if this PR is getting any positive feedback. If it is, I'll be glad to update the docs as well. Thanks! :heart_decoration: 
