### PR TITLE
Add before and after route activation hooks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ end
 Rake::TestTask.new(:"test:core") do |t|
   core_tests = %w[base delegator encoding extensions filter
      helpers mapped_error middleware radius rdoc
-     readme request response result route_added_hook
+     readme request response result route_added_hook route_activation_hook
      routing server settings sinatra static templates]
   t.test_files = core_tests.map {|n| "test/#{n}_test.rb"}
   t.ruby_opts = ["-rubygems"] if defined? Gem

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1605,12 +1605,35 @@ module Sinatra
         pattern, keys           = compile path
         conditions, @conditions = @conditions, []
 
-        wrapper                 = block.arity != 0 ?
-          proc { |a,p| unbound_method.bind(a).call(*p) } :
-          proc { |a,p| unbound_method.bind(a).call }
+        if block.arity != 0
+          wrapper = proc do |a, p|
+            add_activation_hooks(a, p, verb, path) { unbound_method.bind(a).call(*p) }
+          end
+        else
+          wrapper = proc do |a, p|
+            add_activation_hooks(a, p, verb, path) { unbound_method.bind(a).call }
+          end
+        end
+
         wrapper.instance_variable_set(:@route_name, method_name)
 
         [ pattern, keys, conditions, wrapper ]
+      end
+
+      # Add activation routes hooks
+      #
+      # Note: filters are ignored
+      def add_activation_hooks(a, p, verb, path, &block)
+        return block.call unless http_verb?(verb)
+
+        invoke_hook(:before_route_activation, a, verb, path, p)
+        result = block.call
+        invoke_hook(:after_route_activation, a, verb, path, p)
+        result
+      end
+
+      def http_verb?(verb)
+        %w(DELETE GET HEAD PATCH POST PUT).include?(verb.to_s.upcase)
       end
 
       def compile(path)

--- a/test/route_activation_hook_test.rb
+++ b/test/route_activation_hook_test.rb
@@ -1,0 +1,102 @@
+require File.expand_path('../helper', __FILE__)
+
+module RouteActivationTest
+  @before_activations, @after_activations = [], []
+  def self.before_activations ; @before_activations ; end
+  def self.after_activations ; @after_activations ; end
+  def self.before_route_activation(app, verb, path, params)
+    @before_activations << [app, verb, path, params]
+  end
+  def self.after_route_activation(app, verb, path, params)
+    @after_activations << [app, verb, path, params]
+  end
+end
+
+class RouteActivationHookTest < Test::Unit::TestCase
+  def activation_app
+    mock_app(Class.new(Sinatra::Base)) do
+      register RouteActivationTest
+
+      get('/:foo') {}
+      get('/block/:foo', &proc { |arg1| "custom block #{arg1}" })
+
+      # Added only to verify that they are not decorated with the hooks
+      before { @baz = 'pre-baz' }
+      after { @baz = 'after-baz' }
+    end
+  end
+
+  setup do
+    RouteActivationTest.before_activations.clear
+    RouteActivationTest.after_activations.clear
+  end
+
+  it "should be notified when a route without a block is about to be activated" do
+    activation_app
+    get '/bar'
+
+    before_activations = RouteActivationTest.before_activations
+    assert_equal 1, before_activations.size
+
+    activation = before_activations.first
+    assert_kind_of Sinatra::Base, activation[0]
+    assert_equal 'GET', activation[1]
+    assert_equal '/:foo', activation[2]
+    assert_equal ['bar'], activation[3]
+  end
+
+  it "should be notified after a route without a block has been activated" do
+    activation_app
+    get '/bar'
+
+    after_activations = RouteActivationTest.after_activations
+    assert_equal 1, after_activations.size
+
+    activation = after_activations.first
+    assert_kind_of Sinatra::Base, activation[0]
+    assert_equal 'GET', activation[1]
+    assert_equal '/:foo', activation[2]
+    assert_equal ['bar'], activation[3]
+  end
+
+  it "should be notified when a route with a block is about to be activated" do
+    activation_app
+    get '/block/bar'
+
+    before_activations = RouteActivationTest.before_activations
+    assert_equal 1, before_activations.size
+
+    activation = before_activations.first
+    assert_kind_of Sinatra::Base, activation[0]
+    assert_equal 'GET', activation[1]
+    assert_equal '/block/:foo', activation[2]
+    assert_equal ['bar'], activation[3]
+  end
+
+  it "should be notified after a route with a block has been activated" do
+    activation_app
+    get '/block/bar'
+
+    after_activations = RouteActivationTest.after_activations
+    assert_equal 1, after_activations.size
+
+    activation = after_activations.first
+    assert_kind_of Sinatra::Base, activation[0]
+    assert_equal 'GET', activation[1]
+    assert_equal '/block/:foo', activation[2]
+    assert_equal ['bar'], activation[3]
+  end
+
+  it "should only run once per extension" do
+    mock_app(Class.new(Sinatra::Base)) do
+      register RouteActivationTest
+      register RouteActivationTest
+      get('/') {}
+    end
+
+    get '/'
+
+    assert_equal 1, RouteActivationTest.before_activations.size
+    assert_equal 1, RouteActivationTest.after_activations.size
+  end
+end


### PR DESCRIPTION
These hooks provide a way to get more information about which routes are
activated (i.e., metrics, filtering, etc...)