### PR TITLE
Fixed incorrect example of long-polling in README

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1566,13 +1566,11 @@ connections = []
 
 get '/subscribe' do
   # Client-Registrierung beim Server, damit Events mitgeteilt werden können
-  stream(:keep_open) { |out| connections << out }
-
-  # tote Verbindungen entfernen
-  connections.reject!(&:closed?)
-
-  # Rückmeldung
-  "Angemeldet"
+  stream(:keep_open) do |out|
+    connections << out
+    # tote Verbindungen entfernen
+    connections.reject!(&:closed?)
+  end
 end
 
 post '/:message' do

--- a/README.fr.md
+++ b/README.fr.md
@@ -1540,13 +1540,11 @@ connexions = []
 
 get '/souscrire' do
   # abonne un client aux évènements du serveur
-  stream(:keep_open) { |out| connexions << out }
-
-  # purge les connexions abandonnées
-  connexions.reject!(&:closed?)
-
-  # compte-rendu
-  "abonné"
+  stream(:keep_open) do |out|
+    connexions << out
+    # purge les connexions abandonnées
+    connexions.reject!(&:closed?)
+  end
 end
 
 post '/message' do

--- a/README.ja.md
+++ b/README.ja.md
@@ -1439,13 +1439,11 @@ connections = []
 
 get '/subscribe' do
   # サーバイベントにおけるクライアントの関心を登録
-  stream(:keep_open) { |out| connections << out }
-
-  # 死んでいるコネクションを排除
-  connections.reject!(&:closed?)
-
-  # 肯定応答
-  "subscribed"
+  stream(:keep_open) do |out|
+    connections << out
+    # 死んでいるコネクションを排除
+    connections.reject!(&:closed?)
+  end
 end
 
 post '/message' do

--- a/README.ko.md
+++ b/README.ko.md
@@ -1525,13 +1525,11 @@ connections = []
 
 get '/subscribe' do
   # register a client's interest in server events
-  stream(:keep_open) { |out| connections << out }
-
-  # purge dead connections
-  connections.reject!(&:closed?)
-
-  # acknowledge
-  "subscribed"
+  stream(:keep_open) do |out|
+    connections << out
+    # purge dead connections
+    connections.reject!(&:closed?)
+  end
 end
 
 post '/message' do

--- a/README.md
+++ b/README.md
@@ -1558,13 +1558,11 @@ connections = []
 
 get '/subscribe' do
   # register a client's interest in server events
-  stream(:keep_open) { |out| connections << out }
-
-  # purge dead connections
-  connections.reject!(&:closed?)
-
-  # acknowledge
-  "subscribed"
+  stream(:keep_open) do |out|
+    connections << out
+    # purge dead connections
+    connections.reject!(&:closed?)
+  end
 end
 
 post '/:message' do

--- a/README.ru.md
+++ b/README.ru.md
@@ -1426,13 +1426,11 @@ connections = []
 
 get '/subscribe' do
   # регистрация клиента
-  stream(:keep_open) { |out| connections << out }
-
-  # удаление "мертвых клиентов"
-  connections.reject!(&:closed?)
-
-  # допуск
-  "subscribed"
+  stream(:keep_open) do |out|
+    connections << out }
+    # удаление "мертвых клиентов"
+    connections.reject!(&:closed?)
+  end
 end
 
 post '/message' do


### PR DESCRIPTION
Example of long-polling in Streaming Responses section was not working as expected.

The example first called `Sinatra::Base#body` with `Sinatra::Helpers::Stream` then again with ["subscribed"]`.
This resulted in instant rendering of`"subscribed"` as body of the response and closing of the
connection.

I fixed the incorrect example, see pull request.

Regards,
detomastah
