### PR TITLE
Expand regex example in Readme

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -203,7 +203,7 @@ end
 Routen mit regulären Ausdrücken sind auch möglich:
 
 ```ruby
-get %r{/hallo/([\w]+)} do
+get /^\/hallo\/([\w]+)$/ do
   "Hallo, #{params['captures'].first}!"
 end
 ```

--- a/README.es.md
+++ b/README.es.md
@@ -117,7 +117,7 @@ end
 Rutas con Expresiones Regulares:
 
 ``` ruby
-get %r{/hola/([\w]+)} do
+get /^\/hola\/([\w]+)$/ do
   "Hola, #{params['captures'].first}!"
 end
 ```

--- a/README.fr.md
+++ b/README.fr.md
@@ -207,7 +207,7 @@ end
 Une route peut aussi être définie par une expression régulière :
 
 ``` ruby
-get %r{/bonjour/([\w]+)} do
+get /^\/bonjour\/([\w]+)$/ do
   "Bonjour, #{params['captures'].first} !"
 end
 ```

--- a/README.hu.md
+++ b/README.hu.md
@@ -88,7 +88,7 @@ Az útvonalmintákban szerepelhetnek joker paraméterek is, melyeket a
 Reguláris kifejezéseket is felvehetünk az útvonalba:
 
 ```ruby
-  get %r{/hello/([\w]+)} do
+  get /^\/hello\/([\w]+)$/ do
     "Helló, #{params[:captures].first}!"
   end
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -207,7 +207,7 @@ end
 ルーティングを正規表現にマッチさせることもできます。
 
 ``` ruby
-get %r{/hello/([\w]+)} do
+get /^\/hello\/([\w]+)$/ do
   "Hello, #{params['captures'].first}!"
 end
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,7 +205,7 @@ end
 라우터는 정규표현식으로 매치할 수 있습니다.
 
 ``` ruby
-get %r{/hello/([\w]+)} do
+get /^\/hello\/([\w]+)$/ do
   "Hello, #{params[:captures].first}!"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ end
 Route matching with Regular Expressions:
 
 ``` ruby
-get %r{/hello/([\w]+)} do
+get /^\/hello\/([\w]+)$/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -216,6 +216,7 @@ Or with a block parameter:
 
 ``` ruby
 get %r{/hello/([\w]+)} do |c|
+  # Matches "GET /meta/hello/world", "GET /hello/world/1234" etc.
   "Hello, #{c}!"
 end
 ```

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -119,7 +119,7 @@ end
 Rotas podem casar com expressões regulares:
 
 ``` ruby
-get %r{/ola/([\w]+)} do
+get /^\/ola\/([\w]+)$/ do
   "Olá, #{params['captures'].first}!"
 end
 ```

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -88,7 +88,7 @@ end
 Rotas correspondem-se com expressões regulares:
 
 ``` ruby
-get %r{/ola/([\w]+)} do
+get /^\/ola\/([\w]+)$/ do
   "Olá, #{params['captures'].first}!"
 end
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -121,7 +121,7 @@ end
 Регулярные выражения в качестве шаблонов маршрутов:
 
 ```ruby
-get %r{/hello/([\w]+)} do
+get /^\/hello\/([\w]+)$/ do
   "Hello, #{params[:captures].first}!"
 end
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,7 +108,7 @@ end
 通过正则表达式匹配的路由：
 
 ~~~~ ruby
-get %r{/hello/([\w]+)} do
+get /^\/hello\/([\w]+)$/ do
   "Hello, #{params[:captures].first}!"
 end
 ~~~~


### PR DESCRIPTION
Relates to https://github.com/sinatra/sinatra/issues/917.

Changes one of the regular expression route examples to demonstrate the `/ ... /` syntax and that start-of-string (`^`) and end-of-string (`$`) characters can be used to constrain route matches. 

Adds a comment to the other regex example, using Ruby's `%r` syntax, to remind the user that it will match _around_ the expression, which may be unexpected (English only).
