### PR TITLE
Fix rdoc page-top link matching

### DIFF
--- a/test/rdoc_test.rb
+++ b/test/rdoc_test.rb
@@ -16,13 +16,13 @@ class RdocTest < Test::Unit::TestCase
   it 'renders inline rdoc strings' do
     rdoc_app { rdoc '= Hiya' }
     assert ok?
-    assert_body(/<h1[^>]*>Hiya(<span><a href=\"#label-Hiya\">&para;<\/a> <a href=\"#documentation\">&uarr;<\/a><\/span>)?<\/h1>/)
+    assert_body(/<h1[^>]*>Hiya(<span><a href=\"#label-Hiya\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/)
   end
 
   it 'renders .rdoc files in views path' do
     rdoc_app { rdoc :hello }
     assert ok?
-    assert_body(/<h1[^>]*>Hello From RDoc(<span><a href=\"#label-Hello\+From\+RDoc\">&para;<\/a> <a href=\"#documentation\">&uarr;<\/a><\/span>)?<\/h1>/)
+    assert_body(/<h1[^>]*>Hello From RDoc(<span><a href=\"#label-Hello\+From\+RDoc\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/)
   end
 
   it "raises error if template not found" do


### PR DESCRIPTION
https://github.com/rdoc/rdoc/pull/329 changed page-top link from `documentation` to `top`.

Since we rely on both the rdoc gem and bundled versions, add regex to allow both documentation or top in the result string.