### PR TITLE
Fix access to arbitrary .png files in ruby 1.8 development mode

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1906,7 +1906,7 @@ module Sinatra
 
     configure :development do
       get '/__sinatra__/:image.png' do
-        filename = File.dirname(__FILE__) + "/images/#{params[:image]}.png"
+        filename = File.dirname(__FILE__) + "/images/#{params[:image].to_i}.png"
         content_type :png
         send_file filename
       end


### PR DESCRIPTION
This was sent to @rkh in a private email over a month ago, but since the security issue is minor, I haven't received any feedback from @rkh other than acknowledgement of receipt of the email, and this doesn't appear to have been addressed, I thought it best to post the fix publicly here.  Below is my email to @rkh:

```
Subject: Minor Security Vulnerability in Sinatra Development Mode

Konstantin,

This is a really minor security issue with sinatra that I found.
In development mode, Sinatra adds support for displaying the "Sinatra
doesn't know this ditty" 404 page.  This links to a picture, which
Sinatra also handles via:

https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1908
  get '/__sinatra__/:image.png' do
    filename = File.dirname(__FILE__) + "/images/#{params[:image]}.png"
    content_type :png
    send_file filename
  end

It's possible to fool Sinatra into requiring a file other than 404.png
or 500.png using a request like:

  GET /__sinatra__/test.png?image[]=../../../../

Because of how Sinatra combines route params with existing params
(https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1009),
params[:image] ends up becoming this in that case:

  ["../../../../", "test"]

which on ruby 1.8 (which sinatra still supports) can lead to a filename
of:

  "./lib/sinatra/images/../../../../test.png"

Basically, this allows for reading arbitrary png files that the server
process has access to on the system.  However, if the attacker has any
access to the system and can create a symlink anywhere the server
process can access, this amounts to reading any arbitrary file that the
server process has access to, not just png files.

This is really only an issue on ruby 1.8, since ruby 1.9+ has Array#to_s
default to Array#inspect, in which case it's very unlikely that the
filename produced would be a valid filename.

Sinatra only listens on localhost by default in development mode, so
this isn't a serious issue unless an attacker already has some type of
access to the system.  However, this does work even with the default
rack-protection settings.

I recommend the following change:

  filename = File.dirname(__FILE__) + "/images/#{params[:image].to_i}.png"

I would have reported this to GitHub issues, but since it is potentially
security related I felt a private email would be more appropriate. I
looked on the sinatra site for how to report security issues and I
didn't find anything (apologies if I missed it).

If you have any questions, please let me know.

Thanks,
Jeremy
```