### PR TITLE
Allow status to be specified with symbols

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -228,6 +228,7 @@ module Sinatra
   module Helpers
     # Set or retrieve the response status code.
     def status(value = nil)
+      value = Rack::Utils::SYMBOL_TO_STATUS_CODE[value] if value.is_a?(Symbol)
       response.status = value if value
       response.status
     end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -228,8 +228,7 @@ module Sinatra
   module Helpers
     # Set or retrieve the response status code.
     def status(value = nil)
-      value = Rack::Utils::SYMBOL_TO_STATUS_CODE[value] if value.is_a?(Symbol)
-      response.status = value if value
+      response.status = Rack::Utils.status_code(value) if value
       response.status
     end
 


### PR DESCRIPTION
Let the `status` helper accept symbols representing HTTP status codes, by looking up the numeric status code in `Rack::Utils`

This allows you to e.g. specify `status :accepted` instead of `status 202`, so readers of your code doesn't have to remember less used status codes.