### PR TITLE
Convert params hash symbols to strings - final

### DIFF
--- a/README.hu.md
+++ b/README.hu.md
@@ -56,8 +56,8 @@ hash-ből érhetünk el:
 ```ruby
   get '/hello/:name' do
     # illeszkedik a "GET /hello/foo" és a "GET /hello/bar" útvonalakra
-    # ekkor params[:name] értéke 'foo' vagy 'bar' lesz
-    "Helló #{params[:name]}!"
+    # ekkor params['name'] értéke 'foo' vagy 'bar' lesz
+    "Helló #{params['name']}!"
   end
 ```
 
@@ -71,17 +71,17 @@ is el tudod érni:
 ```
 
 Az útvonalmintákban szerepelhetnek joker paraméterek is, melyeket a
-`params[:splat]` tömbön keresztül tudunk elérni.
+`params['splat']` tömbön keresztül tudunk elérni.
 
 ```ruby
   get '/say/*/to/*' do
     # illeszkedik a /say/hello/to/world mintára
-    params[:splat] # => ["hello", "world"]
+    params['splat'] # => ["hello", "world"]
   end
 
   get '/download/*.*' do
     # illeszkedik a /download/path/to/file.xml mintára
-    params[:splat] # => ["path/to/file", "xml"]
+    params['splat'] # => ["path/to/file", "xml"]
   end
 ```
 
@@ -89,7 +89,7 @@ Reguláris kifejezéseket is felvehetünk az útvonalba:
 
 ```ruby
   get /^\/hello\/([\w]+)$/ do
-    "Helló, #{params[:captures].first}!"
+    "Helló, #{params['captures'].first}!"
   end
 ```
 
@@ -106,7 +106,7 @@ tervezhetők, így például az user agent karakterláncot alapul véve:
 
 ```ruby
   get '/foo', :agent => /Songbird (\d\.\d)[\d\/]*?/ do
-    "A Songbird #{params[:agent][0]} verzióját használod"
+    "A Songbird #{params['agent'][0]} verzióját használod"
   end
 
   get '/foo' do
@@ -244,7 +244,7 @@ változók közvetlenül elérhetőek lesznek a sablonokban:
 
 ```ruby
   get '/:id' do
-    @foo = Foo.find(params[:id])
+    @foo = Foo.find(params['id'])
     haml '%h1= @foo.name'
   end
 ```
@@ -253,7 +253,7 @@ De megadhatod egy lokális változókat tartalmazó explicit hash-ben is:
 
 ```ruby
   get '/:id' do
-    foo = Foo.find(params[:id])
+    foo = Foo.find(params['id'])
     haml '%h1= foo.name', :locals => { :foo => foo }
   end
 ```
@@ -332,7 +332,7 @@ használni:
   end
 
   get '/:name' do
-    bar(params[:name])
+    bar(params['name'])
   end
 ```
 
@@ -351,7 +351,7 @@ az útvonalakban és a sablonokban is:
 
   get '/foo/*' do
     @note #=> 'Szeva!'
-    params[:splat] #=> 'bar/baz'
+    params['splat'] #=> 'bar/baz'
   end
 ```
 
@@ -388,7 +388,7 @@ a `pass` függvényhívással:
 
 ```ruby
   get '/guess/:who' do
-    pass unless params[:who] == 'Frici'
+    pass unless params['who'] == 'Frici'
     "Elkaptál!"
   end
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1261,7 +1261,7 @@ before '/protected/*' do
 end
 
 after '/create/:slug' do |slug|
-  session[:last_slug] = slug
+  session['last_slug'] = slug
 end
 ```
 
@@ -1319,7 +1319,7 @@ helpers FooUtils, BarUtils
 enable :sessions
 
 get '/' do
-  "value = " << session[:value].inspect
+  "value = " << session['value'].inspect
 end
 
 get '/:value' do
@@ -1338,7 +1338,7 @@ end
 use Rack::Session::Pool, :expire_after => 2592000
 
 get '/' do
-  "value = " << session[:value].inspect
+  "value = " << session['value'].inspect
 end
 
 get '/:value' do
@@ -1659,12 +1659,12 @@ redirect to('/bar?sum=42')
 enable :sessions
 
 get '/foo' do
-  session[:secret] = 'foo'
+  session['secret'] = 'foo'
   redirect to('/bar')
 end
 
 get '/bar' do
-  session[:secret]
+  session['secret']
 end
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,8 +78,8 @@ end
 ~~~~ ruby
 get '/hello/:name' do
   # 匹配 "GET /hello/foo" 和 "GET /hello/bar"
-  # params[:name] 的值是 'foo' 或者 'bar'
-  "Hello #{params[:name]}!"
+  # params['name'] 的值是 'foo' 或者 'bar'
+  "Hello #{params['name']}!"
 end
 ~~~~
 
@@ -91,17 +91,17 @@ get '/hello/:name' do |n|
 end
 ~~~~
 
-路由范式也可以包含通配符参数， 可以通过`params[:splat]`数组获得。
+路由范式也可以包含通配符参数， 可以通过`params['splat']`数组获得。
 
 ~~~~ ruby
 get '/say/*/to/*' do
   # 匹配 /say/hello/to/world
-  params[:splat] # => ["hello", "world"]
+  params['splat'] # => ["hello", "world"]
 end
 
 get '/download/*.*' do
   # 匹配 /download/path/to/file.xml
-  params[:splat] # => ["path/to/file", "xml"]
+  params['splat'] # => ["path/to/file", "xml"]
 end
 ~~~~
 
@@ -109,7 +109,7 @@ end
 
 ~~~~ ruby
 get /^\/hello\/([\w]+)$/ do
-  "Hello, #{params[:captures].first}!"
+  "Hello, #{params['captures'].first}!"
 end
 ~~~~
 
@@ -127,7 +127,7 @@ end
 
 ~~~~ ruby
 get '/foo', :agent => /Songbird (\d\.\d)[\d\/]*?/ do
-  "你正在使用Songbird，版本是 #{params[:agent][0]}"
+  "你正在使用Songbird，版本是 #{params['agent'][0]}"
 end
 
 get '/foo' do
@@ -759,7 +759,7 @@ end
 
 ~~~~ ruby
 get '/:id' do
-  @foo = Foo.find(params[:id])
+  @foo = Foo.find(params['id'])
   haml '%h1= @foo.name'
 end
 ~~~~
@@ -768,7 +768,7 @@ end
 
 ~~~~ ruby
 get '/:id' do
-  foo = Foo.find(params[:id])
+  foo = Foo.find(params['id'])
   haml '%h1= foo.name', :locals => { :foo => foo }
 end
 ~~~~
@@ -871,7 +871,7 @@ end
 
 get '/foo/*' do
   @note #=> 'Hi!'
-  params[:splat] #=> 'bar/baz'
+  params['splat'] #=> 'bar/baz'
 end
 ~~~~
 
@@ -896,7 +896,7 @@ before '/protected/*' do
 end
 
 after '/create/:slug' do |slug|
-  session[:last_slug] = slug
+  session['last_slug'] = slug
 end
 ~~~~
 
@@ -924,7 +924,7 @@ helpers do
 end
 
 get '/:name' do
-  bar(params[:name])
+  bar(params['name'])
 end
 ~~~~
 
@@ -937,11 +937,11 @@ Session被用来在请求之间保持状态。如果被激活，每一个用户�
 enable :sessions
 
 get '/' do
-  "value = " << session[:value].inspect
+  "value = " << session['value'].inspect
 end
 
 get '/:value' do
-  session[:value] = params[:value]
+  session['value'] = params['value']
 end
 ~~~~
 
@@ -954,11 +954,11 @@ end
 use Rack::Session::Pool, :expire_after => 2592000
 
 get '/' do
-  "value = " << session[:value].inspect
+  "value = " << session['value'].inspect
 end
 
 get '/:value' do
-  session[:value] = params[:value]
+  session['value'] = params['value']
 end
 ~~~~
 
@@ -1000,7 +1000,7 @@ halt 402, {'Content-Type' => 'text/plain'}, 'revenge'
 
 ~~~~ ruby
 get '/guess/:who' do
-  pass unless params[:who] == 'Frank'
+  pass unless params['who'] == 'Frank'
   'You got me!'
 end
 
@@ -1146,12 +1146,12 @@ redirect to('/bar?sum=42')
 enable :sessions
 
 get '/foo' do
-  session[:secret] = 'foo'
+  session['secret'] = 'foo'
   redirect to('/bar')
 end
 
 get '/bar' do
-  session[:secret]
+  session['secret']
 end
 ~~~~
 
@@ -1192,7 +1192,7 @@ end
 
 ~~~~ ruby
 get '/article/:id' do
-  @article = Article.find params[:id]
+  @article = Article.find params['id']
   last_modified @article.updated_at
   etag @article.sha1
   erb :article
@@ -1874,8 +1874,8 @@ class LoginScreen < Sinatra::Base
   get('/login') { haml :login }
 
   post('/login') do
-    if params[:name] = 'admin' and params[:password] = 'admin'
-      session['user_name'] = params[:name]
+    if params['name'] = 'admin' and params['password'] = 'admin'
+      session['user_name'] = params['name']
     else
       redirect '/login'
     end
@@ -1954,8 +1954,8 @@ class MyApp < Sinatra::Base
     # 针对 '/define_route/:name' 的请求变量域
     @value = 42
 
-    settings.get("/#{params[:name]}") do
-      # 针对 "/#{params[:name]}" 的请求变量域
+    settings.get("/#{params['name']}") do
+      # 针对 "/#{params['name']}" 的请求变量域
       @value # => nil (并不是相同的请求)
     end
 


### PR DESCRIPTION
Reference: #903
Convert symbols params to string for all `params` and `session` variables in `.hu`, `.ko` and `zh` README files

/cc @kgrz and @kytrinyx