### PR TITLE
Safer regexp in route matching examples

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -203,7 +203,7 @@ end
 Routen mit regulären Ausdrücken sind auch möglich:
 
 ```ruby
-get /^\/hallo\/([\w]+)$/ do
+get /\A\/hallo\/([\w]+)\z/ do
   "Hallo, #{params['captures'].first}!"
 end
 ```

--- a/README.es.md
+++ b/README.es.md
@@ -117,7 +117,7 @@ end
 Rutas con Expresiones Regulares:
 
 ``` ruby
-get /^\/hola\/([\w]+)$/ do
+get /\A\/hola\/([\w]+)\z/ do
   "Hola, #{params['captures'].first}!"
 end
 ```

--- a/README.fr.md
+++ b/README.fr.md
@@ -207,7 +207,7 @@ end
 Une route peut aussi être définie par une expression régulière :
 
 ``` ruby
-get /^\/bonjour\/([\w]+)$/ do
+get /\A\/bonjour\/([\w]+)\z/ do
   "Bonjour, #{params['captures'].first} !"
 end
 ```

--- a/README.hu.md
+++ b/README.hu.md
@@ -88,7 +88,7 @@ Az útvonalmintákban szerepelhetnek joker paraméterek is, melyeket a
 Reguláris kifejezéseket is felvehetünk az útvonalba:
 
 ```ruby
-  get /^\/hello\/([\w]+)$/ do
+  get /\A\/hello\/([\w]+)\z/ do
     "Helló, #{params['captures'].first}!"
   end
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -207,7 +207,7 @@ end
 ルーティングを正規表現にマッチさせることもできます。
 
 ``` ruby
-get /^\/hello\/([\w]+)$/ do
+get /\A\/hello\/([\w]+)\z/ do
   "Hello, #{params['captures'].first}!"
 end
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -206,7 +206,7 @@ end
 라우터는 정규표현식으로 매치할 수 있습니다.
 
 ``` ruby
-get /^\/hello\/([\w]+)$/ do
+get /\A\/hello\/([\w]+)\z/ do
   "Hello, #{params['captures'].first}!"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ end
 Route matching with Regular Expressions:
 
 ``` ruby
-get /^\/hello\/([\w]+)$/ do
+get /\A\/hello\/([\w]+)\z/ do
   "Hello, #{params['captures'].first}!"
 end
 ```

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -119,7 +119,7 @@ end
 Rotas podem casar com expressões regulares:
 
 ``` ruby
-get /^\/ola\/([\w]+)$/ do
+get /\A\/ola\/([\w]+)\z/ do
   "Olá, #{params['captures'].first}!"
 end
 ```

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -88,7 +88,7 @@ end
 Rotas correspondem-se com expressões regulares:
 
 ``` ruby
-get /^\/ola\/([\w]+)$/ do
+get /\A\/ola\/([\w]+)\z/ do
   "Olá, #{params['captures'].first}!"
 end
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -129,6 +129,7 @@ end
 Или с параметром блока:
 
 ```ruby
+# Находит "GET /meta/hello/world", "GET /hello/world/1234" и так далее
 get %r{/hello/([\w]+)} do |c|
   "Hello, #{c}!"
 end

--- a/README.ru.md
+++ b/README.ru.md
@@ -121,7 +121,7 @@ end
 Регулярные выражения в качестве шаблонов маршрутов:
 
 ```ruby
-get /^\/hello\/([\w]+)$/ do
+get /\A\/hello\/([\w]+)\z/ do
   "Hello, #{params['captures'].first}!"
 end
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,7 +108,7 @@ end
 通过正则表达式匹配的路由：
 
 ~~~~ ruby
-get /^\/hello\/([\w]+)$/ do
+get /\A\/hello\/([\w]+)\z/ do
   "Hello, #{params['captures'].first}!"
 end
 ~~~~


### PR DESCRIPTION
Complete #917
Change `^` and `$` regexp pattern matches to `\A` and `\z` respectively in all readme files.
Also added a comment to the other regex example (in russian readme) like as in #947 PR.
/cc @kytrinyx