### PR TITLE
Introduce APP_ENV and remove RACK_ENV

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -2039,7 +2039,7 @@ configure do
 end
 ```
 
-Läuft nur, wenn die Umgebung (RACK_ENV-Umgebungsvariable) auf `:production`
+Läuft nur, wenn die Umgebung (APP_ENV-Umgebungsvariable) auf `:production`
 gesetzt ist:
 
 ```ruby
@@ -2239,7 +2239,7 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 ## Umgebungen
 
 Es gibt drei voreingestellte Umgebungen in Sinatra: `"development"`,
-`"production"` und `"test"`. Umgebungen können über die `RACK_ENV`
+`"production"` und `"test"`. Umgebungen können über die `APP_ENV`
 Umgebungsvariable gesetzt werden. Die Standardeinstellung ist `"development"`.
 In diesem Modus werden alle Templates zwischen Requests neu geladen. Dazu gibt
 es besondere Fehlerseiten für 404 Stati und Fehlermeldungen. In `"production"`
@@ -2408,7 +2408,7 @@ class MyAppTest < Minitest::Test
     assert_equal 'Hallo Frank!', last_response.body
   end
 
-  def test_with_rack_env
+  def test_with_user_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "Du verwendest Songbird!", last_response.body
   end

--- a/README.es.md
+++ b/README.es.md
@@ -1808,7 +1808,7 @@ configure do
 end
 ```
 
-Ejecutar únicamente cuando el entorno (la variable de entorno RACK_ENV) es
+Ejecutar únicamente cuando el entorno (la variable de entorno APP_ENV) es
 `:production`:
 
 ```ruby
@@ -1918,7 +1918,7 @@ set :protection, :except => [:path_traversal, :session_hijacking]
   <dt>environment</dt>
   <dd>
     Entorno actual, por defecto toma el valor de
-    <tt>ENV['RACK_ENV']</tt>, o <tt>"development"</tt> si no
+    <tt>ENV['APP_ENV']</tt>, o <tt>"development"</tt> si no
     está disponible.
   </dd>
 
@@ -2080,7 +2080,7 @@ de `production` y `test`, donde se cachean.
 especiales que muestran un stack trace en el navegador cuando son disparados.
 
 Para utilizar alguno de los otros entornos puede asignarse el valor
-correspondiente a la variable de entorno `RACK_ENV`, o bien utilizar la opción
+correspondiente a la variable de entorno `APP_ENV`, o bien utilizar la opción
 `-e` al ejecutar la aplicación:
 
 ```shell

--- a/README.fr.md
+++ b/README.fr.md
@@ -2016,7 +2016,7 @@ configure do
 end
 ```
 
-Lancé si l'environnement (variable d'environnement RACK_ENV) est `:production` :
+Lancé si l'environnement (variable d'environnement APP_ENV) est `:production` :
 
 ```ruby
   configure :production do
@@ -2121,7 +2121,7 @@ set :protection, :session => true
   </dd>
 
   <dt>environment</dt>
-  <dd>environnement courant, par défaut <tt>ENV['RACK_ENV']</tt>, ou
+  <dd>environnement courant, par défaut <tt>ENV['APP_ENV']</tt>, ou
   <tt>"development"</tt> si absent.</dd>
 
   <dt>logging</dt>
@@ -2229,7 +2229,7 @@ set :protection, :session => true
 
 Il existe trois environnements prédéfinis : `"development"`,
 `"production"` et `"test"`. Les environements peuvent être
-sélectionné via la variable d'environnement `RACK_ENV`. Sa valeur par défaut
+sélectionné via la variable d'environnement `APP_ENV`. Sa valeur par défaut
 est `"development"`. Dans ce mode, tous les templates sont rechargés à
 chaque requête. Des handlers spécifiques pour `not_found` et
 `error` sont installés pour vous permettre d'avoir une pile de trace
@@ -2237,10 +2237,10 @@ dans votre navigateur. En mode `"production"` et `"test"` les
 templates sont mis en cache par défaut.
 
 Pour exécuter votre application dans un environnement différent, définissez la
-variable d'environnement `RACK_ENV` :
+variable d'environnement `APP_ENV` :
 
-```shell
-RACK_ENV=production ruby my_app.rb
+``` shell
+APP_ENV=production ruby my_app.rb
 ```
 
 Vous pouvez utiliser une des méthodes `development?`, `test?` et `production?`
@@ -2405,7 +2405,7 @@ class MonTest < Minitest::Test
     assert_equal 'Salut Frank !', last_response.body
   end
 
-  def test_avec_rack_env
+  def test_avec_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "Vous utilisez Songbird !", last_response.body
   end

--- a/README.hu.md
+++ b/README.hu.md
@@ -411,7 +411,7 @@ Csak indításkor, de minden környezetre érvényesen fusson le:
   end
 ```
 
-Csak akkor fusson le, ha a környezet (a RACK_ENV környezeti változóban)
+Csak akkor fusson le, ha a környezet (a APP_ENV környezeti változóban)
 `:production`-ra van állítva:
 
 ```ruby
@@ -562,7 +562,7 @@ könyvtárat ajánljuk:
       assert_equal 'Helló Frici!', last_response.body
     end
 
-    def test_with_rack_env
+    def test_with_user_agent
       get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
       assert_equal "Songbird-öt használsz!", last_response.body
     end

--- a/README.ja.md
+++ b/README.ja.md
@@ -1879,7 +1879,7 @@ configure do
 end
 ```
 
-環境設定(`RACK_ENV`環境変数)が`:production`に設定されている時だけ実行する方法:
+環境設定(`APP_ENV`環境変数)が`:production`に設定されている時だけ実行する方法:
 
 ```ruby
 configure :production do
@@ -1969,7 +1969,7 @@ set :protection, :session => true
 
   <dt>environment</dt>
   <dd>
-    現在の環境。デフォルトは<tt>ENV['RACK_ENV']</tt>、それが無い場合は<tt>"development"</tt>。
+    現在の環境。デフォルトは<tt>ENV['APP_ENV']</tt>、それが無い場合は<tt>"development"</tt>。
   </dd>
 
   <dt>logging</dt>
@@ -2081,12 +2081,12 @@ set :protection, :session => true
 
 ## 環境設定(Environments)
 
-３種類の既定環境、`"development"`、`"production"`および`"test"`があります。環境は、`RACK_ENV`環境変数を通して設定できます。デフォルト値は、`"development"`です。`"development"`環境において、すべてのテンプレートは、各リクエスト間で再ロードされ、そして、特別の`not_found`および`error`ハンドラがブラウザにスタックトレースを表示します。`"production"`および`"test"`環境においては、テンプレートはデフォルトでキャッシュされます。
+３種類の既定環境、`"development"`、`"production"`および`"test"`があります。環境は、`APP_ENV`環境変数を通して設定できます。デフォルト値は、`"development"`です。`"development"`環境において、すべてのテンプレートは、各リクエスト間で再ロードされ、そして、特別の`not_found`および`error`ハンドラがブラウザにスタックトレースを表示します。`"production"`および`"test"`環境においては、テンプレートはデフォルトでキャッシュされます。
 
-異なる環境を走らせるには、`RACK_ENV`環境変数を設定します。
+異なる環境を走らせるには、`APP_ENV`環境変数を設定します。
 
 ```shell
-RACK_ENV=production ruby my_app.rb
+APP_ENV=production ruby my_app.rb
 ```
 
 既定メソッド、`development?`、`test?`および`production?`を、現在の環境設定を確認するために使えます。
@@ -2230,7 +2230,7 @@ class MyAppTest < Minitest::Test
     assert_equal 'Hello Frank!', last_response.body
   end
 
-  def test_with_rack_env
+  def test_with_user_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "Songbirdを使ってます!", last_response.body
   end

--- a/README.ko.md
+++ b/README.ko.md
@@ -1991,7 +1991,7 @@ configure do
 end
 ```
 
-환경(RACK_ENV 환경 변수)이 `:production`일 때만 실행되게 하려면 이렇게 하면 됩니다.
+환경(APP_ENV 환경 변수)이 `:production`일 때만 실행되게 하려면 이렇게 하면 됩니다.
 
 ```ruby
 configure :production do
@@ -2094,7 +2094,7 @@ set :protection, :session => true
 
   <dt>environment</dt>
   <dd>
-    현재 환경, 기본값은 <tt>ENV['RACK_ENV']</tt> ENV에 없을 경우엔 "development".
+    현재 환경, 기본값은 <tt>ENV['APP_ENV']</tt> ENV에 없을 경우엔 "development".
   </dd>
 
   <dt>logging</dt>
@@ -2225,16 +2225,16 @@ set :protection, :session => true
 ## 환경(Environments)
 
 3가지의 미리 정의된 `environments` `"development"`, `"production"`, `"test"`
-가 있습니다. 환경은 `RACK_ENV` 환경 변수를 통해서도 설정됩니다. 기본값은
+가 있습니다. 환경은 `APP_ENV` 환경 변수를 통해서도 설정됩니다. 기본값은
 `"development"`입니다. `"development"` 모드에서는 모든 템플릿들은 요청 간에
 리로드됩니다. 또, `"development"` 모드에서는 특별한 `not_found` 와 `error`
 핸들러가 브라우저에서 스택 트레이스를 볼 수 있게합니다.
 `"production"`과 `"test"`에서는 기본적으로 템플릿은 캐시됩니다.
 
-다른 환경으로 실행시키려면 `RACK_ENV` 환경 변수를 사용하세요.
+다른 환경으로 실행시키려면 `APP_ENV` 환경 변수를 사용하세요.
 
 ```shell
-RACK_ENV=production ruby my_app.rb
+APP_ENV=production ruby my_app.rb
 ```
 
 현재 설정된 환경이 무엇인지 검사하기 위해서는 준비된 `development?`, `test?`,
@@ -2400,7 +2400,7 @@ class MyAppTest < Minitest::Test
     assert_equal 'Hello Frank!', last_response.body
   end
 
-  def test_with_rack_env
+  def test_with_user_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "You're using Songbird!", last_response.body
   end

--- a/README.md
+++ b/README.md
@@ -2043,7 +2043,7 @@ configure do
 end
 ```
 
-Run only when the environment (`RACK_ENV` environment variable) is set to
+Run only when the environment (`APP_ENV` environment variable) is set to
 `:production`:
 
 ```ruby
@@ -2148,7 +2148,7 @@ set :protection, :session => true
 
   <dt>environment</dt>
   <dd>
-    Current environment. Defaults to <tt>ENV['RACK_ENV']</tt>, or
+    Current environment. Defaults to <tt>ENV['APP_ENV']</tt>, or
     <tt>"development"</tt> if not available.
   </dd>
 
@@ -2291,16 +2291,16 @@ set :protection, :session => true
 ## Environments
 
 There are three predefined `environments`: `"development"`, `"production"` and
-`"test"`. Environments can be set through the `RACK_ENV` environment variable.
+`"test"`. Environments can be set through the `APP_ENV` environment variable.
 The default value is `"development"`. In the `"development"` environment all
 templates are reloaded between requests, and special `not_found` and `error`
 handlers display stack traces in your browser. In the `"production"` and
 `"test"` environments, templates are cached by default.
 
-To run different environments, set the `RACK_ENV` environment variable:
+To run different environments, set the `APP_ENV` environment variable:
 
 ```shell
-RACK_ENV=production ruby my_app.rb
+APP_ENV=production ruby my_app.rb
 ```
 
 You can use predefined methods: `development?`, `test?` and `production?` to
@@ -2469,7 +2469,7 @@ class MyAppTest < Minitest::Test
     assert_equal 'Hello Frank!', last_response.body
   end
 
-  def test_with_rack_env
+  def test_with_user_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "You're using Songbird!", last_response.body
   end

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1417,7 +1417,7 @@ configure do
 end
 ```
 
-Rodando somente quando o ambiente (`RACK_ENV` environment variável) é
+Rodando somente quando o ambiente (`APP_ENV` environment variável) é
 setado para `:production`:
 
 ```ruby

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -477,7 +477,7 @@ configure do
 end
 ```
 
-Correndo somente quando o ambiente (`RACK_ENV` environment variável) é
+Correndo somente quando o ambiente (`APP_ENV` environment variável) é
 definido para `:production`:
 
 ```ruby

--- a/README.ru.md
+++ b/README.ru.md
@@ -2022,7 +2022,7 @@ configure do
 end
 ```
 
-Будет запущено, когда окружение (RACK_ENV переменная) `:production`:
+Будет запущено, когда окружение (APP_ENV переменная) `:production`:
 
 ```ruby
 configure :production do
@@ -2121,8 +2121,8 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 
   <dt>environment</dt>
   <dd>
-    текущее окружение, по умолчанию, значение <tt>ENV['RACK_ENV']</tt> или
-    <tt>"development"</tt>, если <tt>ENV['RACK_ENV']</tt> недоступна.
+    текущее окружение, по умолчанию, значение <tt>ENV['APP_ENV']</tt> или
+    <tt>"development"</tt>, если <tt>ENV['APP_ENV']</tt> недоступна.
   </dd>
 
   <dt>logging</dt>
@@ -2249,7 +2249,7 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 ## Режим, окружение
 
 Есть 3 предопределенных режима, окружения: `"development"`, `"production"` и
-`"test"`. Режим может быть задан через переменную окружения `RACK_ENV`.
+`"test"`. Режим может быть задан через переменную окружения `APP_ENV`.
 Значение по умолчанию — `"development"`. В этом режиме работы все шаблоны
 перезагружаются между запросами. А также задаются специальные обработчики
 `not_found` и `error`, чтобы вы могли увидеть стек вызовов. В окружениях
@@ -2412,7 +2412,7 @@ class MyAppTest < Minitest::Test
     assert_equal 'Hello Frank!', last_response.body
   end
 
-  def test_with_rack_env
+  def test_with_user_agent
     get '/', {}, 'HTTP_USER_AGENT' => 'Songbird'
     assert_equal "You're using Songbird!", last_response.body
   end

--- a/README.zh.md
+++ b/README.zh.md
@@ -1933,7 +1933,7 @@ configure do
 end
 ```
 
-只有当环境 (`RACK_ENV` 环境变量) 被设定为 `:production` 时才运行：
+只有当环境 (`APP_ENV` 环境变量) 被设定为 `:production` 时才运行：
 
 ```ruby
 configure :production do
@@ -2033,8 +2033,8 @@ set :protection, :session => true
 
   <dt>environment</dt>
   <dd>
-    当前环境，默认是 <tt>ENV['RACK_ENV']</tt>，
-    或者 <tt>"development"</tt> (如果 ENV['RACK_ENV'] 不可用)。
+    当前环境，默认是 <tt>ENV['APP_ENV']</tt>，
+    或者 <tt>"development"</tt> (如果 ENV['APP_ENV'] 不可用)。
   </dd>
 
   <dt>logging</dt>
@@ -2145,15 +2145,15 @@ set :protection, :session => true
 ## 环境
 
 Sinatra 中有三种预先定义的环境："development"、"production" 和 "test"。
-环境可以通过 `RACK_ENV` 环境变量设置。默认值为 "development"。
+环境可以通过 `APP_ENV` 环境变量设置。默认值为 "development"。
 在开发环境下，每次请求都会重新加载所有模板，
 特殊的 `not_found` 和 `error` 错误处理器会在浏览器中显示 stack trace。
 在测试和生产环境下，模板默认会缓存。
 
-在不同的环境下运行，设置 `RACK_ENV` 环境变量：
+在不同的环境下运行，设置 `APP_ENV` 环境变量：
 
 ```shell
-RACK_ENV=production ruby my_app.rb
+APP_ENV=production ruby my_app.rb
 ```
 
 可以使用预定义的三种方法： `development?`、`test?` 和 `production?` 来检查当前环境：

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1776,7 +1776,7 @@ module Sinatra
 
     reset!
 
-    set :environment, (ENV['RACK_ENV'] || :development).to_sym
+    set :environment, (ENV['APP_ENV'] || ENV['RACK_ENV'] || :development).to_sym
     set :raise_errors, Proc.new { test? }
     set :dump_errors, Proc.new { !test? }
     set :show_exceptions, Proc.new { development? }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
-ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 Encoding.default_external = "UTF-8" if defined? Encoding
 
 RUBY_ENGINE = 'ruby' unless defined? RUBY_ENGINE

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -105,7 +105,7 @@ module IntegrationHelper
 
     def command
       @command ||= begin
-        cmd = ["RACK_ENV=#{environment}", "exec"]
+        cmd = ["APP_ENV=#{environment}", "exec"]
         if RbConfig.respond_to? :ruby
           cmd << RbConfig.ruby.inspect
         else
@@ -176,7 +176,7 @@ module IntegrationHelper
         # SINGLETHREAD means create a new runtime
         vm = org.jruby.embed.ScriptingContainer.new(org.jruby.embed.LocalContextScope::SINGLETHREAD)
         vm.load_paths = [File.expand_path('../../lib', __FILE__)]
-        vm.environment = ENV.merge('RACK_ENV' => environment.to_s)
+        vm.environment = ENV.merge('APP_ENV' => environment.to_s)
 
         # This ensures processing of RUBYOPT which activates Bundler
         vm.provider.ruby_instance_config.process_arguments []


### PR DESCRIPTION
`RACK_ENV` should not be used with values other than `development` and `deployment`. Therefore, it can't be used to check for `production environment.

See http://www.hezmatt.org/~mpalmer/blog/2013/10/13/rack_env-its-not-for-you.html

In fact, it can even cause some issues if your app is using unicorn, as they're including internal rack middlewares relying on `RACK_ENV` to have the `deployment` value.
See https://github.com/defunkt/unicorn/blob/master/lib/unicorn.rb#L56-L79

Rack itself does that too.
https://github.com/rack/rack/blob/4e4ab39b0508aa3e59f5d7e53696ef6ae7c220ed/lib/rack/server.rb#L228

This removes using `RACK_ENV`, and replaces it with `SINATRA_ENV`.
Since it's a major changes, it should be merged in the Sinatra 2.0 branch. I'm not seeing anything of the kind, so feel free to stall this until there's discussion about it.