### PR TITLE
Added a link to Slack in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3032,6 +3032,7 @@ SemVerTag.
 * [Twitter](http://twitter.com/sinatra)
 * [Mailing List](http://groups.google.com/group/sinatrarb/topics)
 * IRC: [#sinatra](irc://chat.freenode.net/#sinatra) on http://freenode.net
+* [Sinatra & Friends](https://sinatrarb.slack.com) on Slack
 * [Sinatra Book](https://github.com/sinatra/sinatra-book/) Cookbook Tutorial
 * [Sinatra Recipes](http://recipes.sinatrarb.com/) Community
   contributed recipes


### PR DESCRIPTION
It's hard to find Sinatra channel because https://sinatra-slack.herokuapp.com has only an invitation link.