### PR TITLE
Make it easier to override the parms method/attr_accessor.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1005,7 +1005,8 @@ module Sinatra
       values += match.captures.map! { |v| force_encoding URI_INSTANCE.unescape(v) if v }
 
       if values.any?
-        original, @params = params, params.merge('splat' => [], 'captures' => values)
+        original = @params
+        @params = @params.merge('splat' => [], 'captures' => values)
         keys.zip(values) { |k,v| Array === @params[k] ? @params[k] << v : @params[k] = v if v }
       end
 


### PR DESCRIPTION
Do not call the params method/attr_accessor except while in process_route block, so that overriding the params accessor method is simpler.
