### PR TITLE
Use the URI_INSTANCE.unescape method in static files paths resolution

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1034,7 +1034,7 @@ module Sinatra
     # a matching file is found, returns nil otherwise.
     def static!(options = {})
       return if (public_dir = settings.public_folder).nil?
-      path = File.expand_path("#{public_dir}#{unescape(request.path_info)}" )
+      path = File.expand_path("#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}" )
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path

--- a/test/public/hello+world.txt
+++ b/test/public/hello+world.txt
@@ -1,0 +1,1 @@
+This is a test intended for the + sign in urls for static serving

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -233,4 +233,34 @@ class StaticTest < Minitest::Test
     assert response.headers.include?('Last-Modified')
   end
 
+  it 'serves files with a + sign in the path' do
+    mock_app do
+      set :static, true
+      set :public_folder, File.join(File.dirname(__FILE__), 'public')
+    end
+    
+    get "/hello+world.txt"
+    
+    real_path = File.join(File.dirname(__FILE__), 'public', 'hello+world.txt')
+    assert ok?
+    assert_equal File.read(real_path), body
+    assert_equal File.size(real_path).to_s, response['Content-Length']
+    assert response.headers.include?('Last-Modified')
+  end
+
+  it 'serves files with a URL encoded + sign (%2B) in the path' do
+    mock_app do
+      set :static, true
+      set :public_folder, File.join(File.dirname(__FILE__), 'public')
+    end
+    
+    get "/hello%2bworld.txt"
+    
+    real_path = File.join(File.dirname(__FILE__), 'public', 'hello+world.txt')
+    assert ok?
+    assert_equal File.read(real_path), body
+    assert_equal File.size(real_path).to_s, response['Content-Length']
+    assert response.headers.include?('Last-Modified')
+  end
+
 end


### PR DESCRIPTION
Hello there,

I encountered issues with + signs in the URLS for static files. The issue has been discussed in #1004 and #463 but the patch applied after these has not been made available to static files URLs.

I just changed the unescape method to be used to be the new one and added 2 unit tests regarding + signs in the URLs.

Regards,