### PR TITLE
Fix content length calculation for non string body

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 = Upcoming Release
 
  * Correctly handle encoded colons in routes. (Jeremy Evans)
+ * Calculate content-length for non-string response body. (Dmitrii Kharlamov)
  * Your contribution here.
 
 = 1.4.6 / 2015-03-23

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -150,7 +150,7 @@ module Sinatra
       if calculate_content_length?
         # if some other code has already set Content-Length, don't muck with it
         # currently, this would be the static file-handler
-        headers["Content-Length"] = body.inject(0) { |l, p| l + Rack::Utils.bytesize(p) }.to_s
+        headers["Content-Length"] = body.inject(0) { |l, p| l + Rack::Utils.bytesize(p.to_s) }.to_s
       end
 
       [status.to_i, headers, result]


### PR DESCRIPTION
When returning an object in body that is not a string, `bytesize` method
will be called to calculte content length and will fail and return a
500 without this.