### PR TITLE
Fix duplicate caching of some templates

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -805,7 +805,8 @@ module Sinatra
       layout          = engine_options[:layout] if layout.nil? or (layout == true && engine_options[:layout] != false)
       layout          = @default_layout         if layout.nil? or layout == true
       layout_options  = options.delete(:layout_options) || {}
-      content_type    = options.delete(:content_type)   || options.delete(:default_content_type)
+      content_type    = options.delete(:default_content_type)
+      content_type    = options.delete(:content_type)   || content_type
       layout_engine   = options.delete(:layout_engine)  || engine
       scope           = options.delete(:scope)          || self
       options.delete(:layout)


### PR DESCRIPTION
The change above makes sure that the `default_content_type` option is always deleted from the options.

This in turn makes sure that identical template is cached only once, regardless of whether the explicit `content_type` option is specified or not.

Not to mention it also makes sure that the `default_content_type` option is not passed as an engine option to the engine which might complain about it.