### PR TITLE
Remove reductant code

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -797,7 +797,7 @@ module Sinatra
       options.merge!(engine_options) { |key, v1, v2| v1 }
 
       # extract generic options
-      locals          = options.delete(:locals) || locals         || {}
+      locals          = options.delete(:locals) || locals
       views           = options.delete(:views)  || settings.views || "./views"
       layout          = options[:layout]
       layout          = false if layout.nil? && options.include?(:layout)


### PR DESCRIPTION
local variable `locals` has `{}` as defalut value, So `||` operator would never enter
last condition.