### PR TITLE
Update README to flag issue with optional routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ end
 Route patterns may have optional parameters:
 
 ```ruby
-get '/posts.?:format?' do
-  # matches "GET /posts" and any extension "GET /posts.json", "GET /posts.xml" etc.
+get '/post/:format?' do
+  # matches "GET /post/" and any extension "GET /posts/json", "GET /posts/xml" etc
 end
 ```
 


### PR DESCRIPTION
The original example would also match `GET /posts_anything` as `GET /posts` with a format of `"_anything"` because of the optional format separator, forcing the separator is kind of an ugly example so switch to using a trailing slash which should be recognised either way (I think). It'd be nice to be able to create optional groups e.g. `(.:format)?`