### PR TITLE
Don't assume a route's captures will always be Strings.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1002,7 +1002,13 @@ module Sinatra
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
       return unless match = pattern.match(route)
-      values += match.captures.map! { |v| force_encoding URI_INSTANCE.unescape(v) if v }
+      values += match.captures.map! do |v|
+        if v.kind_of?(String)
+          force_encoding URI_INSTANCE.unescape(v)
+        elsif v
+          v
+        end
+      end
 
       if values.any?
         original, @params = params, params.merge('splat' => [], 'captures' => values)


### PR DESCRIPTION
This is required to allow Addressable's URI templates to function with Sinatra's routing system.

```
require 'addressable/template'

def uri_template(pattern)
  @addressable_templates ||= {}
  @addressable_templates[pattern] ||= Addressable::Template.new(pattern)
end

get uri_template('/prefix{/segments*}') do
  params[:segments].inspect
end
```
