### PR TITLE
Sinatra 2.0.0 alpha [redux]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@
 language: ruby
 
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1
   - 2.2
   - rbx-2
   - jruby
@@ -17,8 +12,6 @@ sudo: false
 
 matrix:
   include:
-    - { rvm: 1.8.7, env: tilt=master }
-    - { rvm: 1.9.3, env: tilt=master }
     - { rvm: 2.2, env: rack=master }
     - { rvm: 2.2, env: tilt=master }
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@
 language: ruby
 
 rvm:
-  - 2.2
-  - jruby-9.0.0.0
+  - 2.2.2
+  - 2.2.3
   - ruby-head
-  - jruby-head
   - rbx-2
+  - jruby-9.0.0.0
+  - jruby-head
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ sudo: false
 
 matrix:
   include:
-    - { rvm: 1.9.3, env: rack=1.4.0  }
     - { rvm: 1.8.7, env: tilt=master }
-    - { rvm: 1.9.3, env: rack=master }
     - { rvm: 1.9.3, env: tilt=master }
     - { rvm: 2.2, env: rack=master }
     - { rvm: 2.2, env: tilt=master }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: ruby
 
 rvm:
   - 2.2
-  - rbx-2
-  - jruby-9.0.0.0.pre1
-  - jruby-head
+  - jruby-9.0.0.0
   - ruby-head
+  - jruby-head
+  - rbx-2
 
 sudo: false
 
@@ -17,6 +17,6 @@ matrix:
   allow_failures:
     - env: rack=master
     - env: tilt=master
-    - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ rvm:
 sudo: false
 
 matrix:
-  include:
-    - { rvm: 2.2, env: rack=master }
-    - { rvm: 2.2, env: tilt=master }
   allow_failures:
-    - env: rack=master
-    - env: tilt=master
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 rvm:
   - 2.2
   - rbx-2
-  - jruby
+  - jruby-9.0.0.0.pre1
   - jruby-head
   - ruby-head
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,21 +11,9 @@ source 'https://rubygems.org' unless ENV['QUICK']
 gemspec
 
 gem 'rake'
+gem 'rack', github: 'rack/rack'
 gem 'rack-test', '>= 0.6.2'
 gem "minitest", "~> 5.0"
-
-# Allows stuff like `tilt=1.2.2 bundle install` or `tilt=master ...`.
-# Used by the CI.
-repos  = {'tilt' => "rtomayko/tilt", 'rack' => "rack/rack"}
-
-%w[tilt rack].each do |lib|
-  dep = case ENV[lib]
-        when 'stable', nil then nil
-        when /(\d+\.)+\d+/ then "~> " + ENV[lib].sub("#{lib}-", '')
-        else {:github => repos[lib], :branch => dep}
-        end
-  gem lib, dep
-end
 
 if RUBY_ENGINE == 'jruby'
   gem 'nokogiri', '!= 1.5.0'
@@ -42,6 +30,9 @@ if RUBY_ENGINE == "ruby"
   gem 'rdiscount'
   gem 'RedCloth'
   gem 'puma'
+  #TODO: remove explicit require once net-http-server does it
+  #(apparently it was shipped w/ stdlib in Rubies < 2.2.2)
+  gem 'gserver'
   gem 'net-http-server'
   gem 'yajl-ruby'
   gem 'nokogiri'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ if RUBY_ENGINE == 'jruby'
   gem 'trinidad'
 end
 
-if RUBY_ENGINE == "ruby" and RUBY_VERSION > '1.9.2'
+if RUBY_ENGINE == "ruby"
   gem 'less', '~> 2.0'
   gem 'therubyracer'
   gem 'redcarpet'
@@ -71,6 +71,6 @@ if RUBY_ENGINE == "rbx"
   gem 'rubysl-test-unit'
 end
 
-platforms :ruby_18, :jruby do
-  gem 'json' unless RUBY_VERSION > '1.9' # is there a jruby but 1.8 only selector?
+platforms :jruby do
+  gem 'json'
 end

--- a/README.md
+++ b/README.md
@@ -2871,31 +2871,10 @@ thin --threaded start
 
 The following Ruby versions are officially supported:
 <dl>
-  <dt>Ruby 1.8.7</dt>
+  <dt>Ruby 2.2.2+</dt>
   <dd>
-    1.8.7 is fully supported, however, if nothing is keeping you from it, we
-    recommend upgrading or switching to JRuby or Rubinius. Support for 1.8.7
-    will not be dropped before Sinatra 2.0. Ruby 1.8.6 is no longer supported.
-  </dd>
-
-  <dt>Ruby 1.9.2</dt>
-  <dd>
-    1.9.2 is fully supported. Do not use 1.9.2p0, as it is known to cause
-    segmentation faults when running Sinatra. Official support will continue
-    at least until the release of Sinatra 1.5.
-  </dd>
-
-  <dt>Ruby 1.9.3</dt>
-  <dd>
-    1.9.3 is fully supported and recommended. Please note that switching to 1.9.3
-    from an earlier version will invalidate all sessions. 1.9.3 will be supported
-    until the release of Sinatra 2.0.
-  </dd>
-
-  <dt>Ruby 2.x</dt>
-  <dd>
-    2.x is fully supported and recommended. There are currently no plans to drop
-    official support for it.
+    2.2.2 is fully supported and recommended. There are currently no plans to
+    drop official support for it.
   </dd>
 
   <dt>Rubinius</dt>
@@ -2911,6 +2890,8 @@ The following Ruby versions are officially supported:
     <tt>gem install trinidad</tt>.
   </dd>
 </dl>
+
+Versions of Ruby prior to 2.2.2 are no longer supported as of Sinatra 2.0.
 
 We also keep an eye on upcoming Ruby versions.
 

--- a/README.md
+++ b/README.md
@@ -2871,9 +2871,9 @@ thin --threaded start
 
 The following Ruby versions are officially supported:
 <dl>
-  <dt>Ruby 2.2.2+</dt>
+  <dt>Ruby 2.2</dt>
   <dd>
-    2.2.2 is fully supported and recommended. There are currently no plans to
+    2.2 is fully supported and recommended. There are currently no plans to
     drop official support for it.
   </dd>
 
@@ -2916,7 +2916,7 @@ implementation.
 If you run MacRuby, you should `gem install control_tower`.
 
 Sinatra currently doesn't run on Cardinal, SmallRuby, BlueRuby or any
-Ruby version prior to 1.8.7.
+Ruby version prior to 2.2.
 
 ## The Bleeding Edge
 
@@ -2946,7 +2946,7 @@ Then, in your project directory, create a `Gemfile`:
 
 ```ruby
 source 'https://rubygems.org'
-gem 'sinatra', :github => "sinatra/sinatra"
+gem 'sinatra', :github => 'sinatra/sinatra'
 
 # other dependencies
 gem 'haml'                    # for instance, if you use haml

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -150,7 +150,7 @@ module Sinatra
       if calculate_content_length?
         # if some other code has already set Content-Length, don't muck with it
         # currently, this would be the static file-handler
-        headers["Content-Length"] = body.inject(0) { |l, p| l + Rack::Utils.bytesize(p) }.to_s
+        headers["Content-Length"] = body.inject(0) { |l, p| l + p.bytesize }.to_s
       end
 
       [status.to_i, headers, result]

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -362,9 +362,8 @@ module Sinatra
 
       last_modified opts[:last_modified] if opts[:last_modified]
 
-      file      = Rack::File.new nil
-      file.path = path
-      result    = file.serving env
+      file   = Rack::File.new(settings.public_folder)
+      result = file.call(env)
       result[1].each { |k,v| headers[k] ||= v }
       headers['Content-Length'] = result[1]['Content-Length']
       opts[:status] &&= Integer(opts[:status])

--- a/lib/sinatra/show_exceptions.rb
+++ b/lib/sinatra/show_exceptions.rb
@@ -1,4 +1,4 @@
-require 'rack/showexceptions'
+require 'rack/show_exceptions'
 
 module Sinatra
   # Sinatra::ShowExceptions catches all exceptions raised from the app it
@@ -40,7 +40,7 @@ module Sinatra
         500,
         {
           "Content-Type" => content_type,
-          "Content-Length" => Rack::Utils.bytesize(body.join).to_s
+          "Content-Length" => body.join.bytesize.to_s
         },
         body
       ]

--- a/lib/sinatra/version.rb
+++ b/lib/sinatra/version.rb
@@ -1,3 +1,3 @@
 module Sinatra
-  VERSION = '1.4.6'
+  VERSION = '2.0.0'
 end

--- a/lib/sinatra/version.rb
+++ b/lib/sinatra/version.rb
@@ -1,3 +1,3 @@
 module Sinatra
-  VERSION = '2.0.0'
+  VERSION = '2.0.0-alpha'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
+  s.required_ruby_version = '>= 2.2.2'
+
   s.add_dependency 'rack', '>= 1.6'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '~> 1.5'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_dependency 'rack', '>= 1.6'
   s.add_dependency 'tilt', '~> 2.0'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
 
   s.required_ruby_version = '>= 2.2.0'
 
-  s.add_dependency 'rack', '>= 1.6'
+  s.add_dependency 'rack', '~> 2.0.0.alpha'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '~> 1.5'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
-  s.add_dependency 'rack', '~> 1.5', '>= 1.5.4', '< 1.6'
-  s.add_dependency 'tilt', '>= 1.3', '< 3'
-  s.add_dependency 'rack-protection', '~> 1.4'
+  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'tilt', '~> 2.0'
+  s.add_dependency 'rack-protection', '~> 1.5'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
-  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'rack', '>= 1.6'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '~> 1.5'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,12 +3,9 @@ Encoding.default_external = "UTF-8" if defined? Encoding
 
 RUBY_ENGINE = 'ruby' unless defined? RUBY_ENGINE
 
-begin
-  require 'rack'
-rescue LoadError
-  require 'rubygems'
-  require 'rack'
-end
+require 'bundler'
+require 'bundler/setup'
+require 'rack'
 
 testdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift testdir unless $LOAD_PATH.include?(testdir)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -778,10 +778,9 @@ class HelpersTest < Minitest::Test
     end
 
     def send_file_app(opts={})
-      path = @file
       mock_app {
         get '/file.txt' do
-          send_file path, opts
+          send_file @file, opts
         end
       }
     end
@@ -883,11 +882,10 @@ class HelpersTest < Minitest::Test
     end
 
     it "does not override Content-Type if already set and no explicit type is given" do
-      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file path
+          send_file @file
         end
       end
       get '/'
@@ -895,11 +893,10 @@ class HelpersTest < Minitest::Test
     end
 
     it "does override Content-Type even if already set, if explicit type is given" do
-      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file path, :type => :gif
+          send_file @file, :type => :gif
         end
       end
       get '/'
@@ -907,10 +904,9 @@ class HelpersTest < Minitest::Test
     end
 
     it 'can have :status option as a string' do
-      path = @file
       mock_app do
         post '/' do
-          send_file path, :status => '422'
+          send_file @file, :status => '422'
         end
       end
       post '/'

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -275,8 +275,7 @@ class RoutingTest < Minitest::Test
     assert_equal "foo=;bar=", body
   end
 
-  it "supports named captures like %r{/hello/(?<person>[^/?#]+)} on Ruby >= 1.9" do
-    next if RUBY_VERSION < '1.9'
+  it "supports named captures like %r{/hello/(?<person>[^/?#]+)}" do
     mock_app {
       get Regexp.new('/hello/(?<person>[^/?#]+)') do
         "Hello #{params['person']}"
@@ -286,8 +285,7 @@ class RoutingTest < Minitest::Test
     assert_equal 'Hello Frank', body
   end
 
-  it "supports optional named captures like %r{/page(?<format>.[^/?#]+)?} on Ruby >= 1.9" do
-    next if RUBY_VERSION < '1.9'
+  it "supports optional named captures like %r{/page(?<format>.[^/?#]+)?}" do
     mock_app {
       get Regexp.new('/page(?<format>.[^/?#]+)?') do
         "format=#{params[:format]}"
@@ -1299,59 +1297,24 @@ class RoutingTest < Minitest::Test
     assert_equal "hey", body
   end
 
-  # NOTE Block params behaves differently under 1.8 and 1.9. Under 1.8, block
-  # param arity is lax: declaring a mismatched number of block params results
-  # in a warning. Under 1.9, block param arity is strict: mismatched block
-  # arity raises an ArgumentError.
+  it 'raises an ArgumentError with block param arity 1 and no values' do
+    mock_app {
+      get '/foo' do |foo|
+        'quux'
+      end
+    }
 
-  if RUBY_VERSION >= '1.9'
+    assert_raises(ArgumentError) { get '/foo' }
+  end
 
-    it 'raises an ArgumentError with block param arity 1 and no values' do
-      mock_app {
-        get '/foo' do |foo|
-          'quux'
-        end
-      }
+  it 'raises an ArgumentError with block param arity 1 and too many values' do
+    mock_app {
+      get '/:foo/:bar/:baz' do |foo|
+        'quux'
+      end
+    }
 
-      assert_raises(ArgumentError) { get '/foo' }
-    end
-
-    it 'raises an ArgumentError with block param arity 1 and too many values' do
-      mock_app {
-        get '/:foo/:bar/:baz' do |foo|
-          'quux'
-        end
-      }
-
-      assert_raises(ArgumentError) { get '/a/b/c' }
-    end
-
-  else
-
-    it 'does not raise an ArgumentError with block param arity 1 and no values' do
-      mock_app {
-        get '/foo' do |foo|
-          'quux'
-        end
-      }
-
-      silence_warnings { get '/foo' }
-      assert ok?
-      assert_equal 'quux', body
-    end
-
-    it 'does not raise an ArgumentError with block param arity 1 and too many values' do
-      mock_app {
-        get '/:foo/:bar/:baz' do |foo|
-          'quux'
-        end
-      }
-
-      silence_warnings { get '/a/b/c' }
-      assert ok?
-      assert_equal 'quux', body
-    end
-
+    assert_raises(ArgumentError) { get '/a/b/c' }
   end
 
   it "matches routes defined in superclasses" do

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -244,7 +244,7 @@ class SettingsTest < Minitest::Test
       get '/'
       assert_equal 500, status
       assert body.include?("StandardError")
-      assert body.include?("<code>show_exceptions</code> setting")
+      assert body.include?("<code>Rack::ShowExceptions</code>")
     end
 
     it 'does not override app-specified error handling when set to :after_handler' do


### PR DESCRIPTION
(Reopening #1029 as a branch on core project to allow collaborator activity)
(Holy crap I named the branch with "2.2.0" but I'm not switching it around again. Sorry!)

Here we go!

The Plan:
 - Drop support for Rubies earlier than 2.2 (MRI and equivalent implementations)
 - Change nothing else
 - Move 1.4 development to the `1.4.x` branch, where releases will come from until 2.0 is fully released

Tasks:
 - [X] Revise Travis matrix
 - [X] Update gem version
 - [X] Add Ruby version dependency to gemspec
 - [x] Raise Rack version requirement to `~> 2.0`, fix new incompatibilities
 - [ ] Remove overt conditional statements for dropped Rubies
 - [ ] Update English README to communicate new set of supported versions related notes
 - [ ] Coordinate translations for non-English READMEs
 - [ ] Sweep outstanding issues for 1.4.x changes before shunting to maintenance branch
 - [ ] ...figure out what else should be done...
