### PR TITLE
Loosen Rack restriction to allow Rack 2

### DIFF
--- a/lib/sinatra/show_exceptions.rb
+++ b/lib/sinatra/show_exceptions.rb
@@ -1,4 +1,8 @@
-require 'rack/showexceptions'
+if Rack.release < '2.0.0.alpha'
+  require 'rack/showexceptions'
+else
+  require 'rack/show_exceptions'
+end
 
 module Sinatra
   # Sinatra::ShowExceptions catches all exceptions raised from the app it

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
 
-  s.add_dependency 'rack', '~> 1.5', '>= 1.5.4', '< 1.6'
+  s.add_dependency 'rack', '>= 1.5', '<= 2.0'
   s.add_dependency 'tilt', '>= 1.3', '< 3'
   s.add_dependency 'rack-protection', '~> 1.4'
 end


### PR DESCRIPTION
I know this is probably a long shot to change something like this so Rails apps can use Rails master and Sinatra w/ Rack 2, but at Basecamp we're developing along with Rails master. Since Rails master is set to use Rack 2.0 (Rack master) and we're using Resque which requires Sinatra I can't get our app to Rails master without this change.

If you don't want to merge this I understand, but I figured at least you'd know what was coming in Rack 2/Rails 5. :smile: Thanks for your work on Sinatra!

---

Although unreleased, Rack master is now Rack 2.0. Rails 5 is in
development and requires Rack 2.0 so any project using Rails master and
Sinatra together (i.e a project using Resque) can't work together.

This change loosens the Rack restriction so Rack 2 can be used.

Additionally in
https://github.com/rack/rack/commit/857641dab255dbec490fead1d3a0f1ff999b2137
`showexceptions` file was renamed to `show_exceptions`. Since Rack does
their versioning differetly and returns an array of `[1,3]` we need to
use the `release` version to make the comparison.