### PR TITLE
Remove some 1.9.x 1.8.x specific workarounds 

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1523,8 +1523,7 @@ module Sinatra
 
       # Dynamically defines a method on settings.
       def define_singleton(name, content = Proc.new)
-        # replace with call to singleton_class once we're 1.9 only
-        (class << self; self; end).class_eval do
+        singleton_class.class_eval do
           undef_method(name) if method_defined? name
           String === content ? class_eval("def #{name}() #{content}; end") : define_method(name, &content)
         end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1925,7 +1925,7 @@ module Sinatra
             </style>
           </head>
           <body>
-            <h2>Sinatra doesn&rsquo;t know this ditty.</h2>
+            <h2>Sinatra doesn’t know this ditty.</h2>
             <img src='#{uri "/__sinatra__/404.png"}'>
             <div id="c">
               Try this:

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -867,7 +867,7 @@ module Sinatra
     include Helpers
     include Templates
 
-    URI_INSTANCE = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+    URI_INSTANCE = URI::Parser.new
 
     attr_accessor :app, :env, :request, :response, :params
     attr_reader   :template_cache

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -592,22 +592,12 @@ module Sinatra
     # Generates a Time object from the given value.
     # Used by #expires and #last_modified.
     def time_for(value)
-      if value.respond_to? :to_time
-        value.to_time
-      elsif value.is_a? Time
-        value
-      elsif value.respond_to? :new_offset
-        # DateTime#to_time does the same on 1.9
-        d = value.new_offset 0
-        t = Time.utc d.year, d.mon, d.mday, d.hour, d.min, d.sec + d.sec_fraction
-        t.getlocal
-      elsif value.respond_to? :mday
-        # Date#to_time does the same on 1.9
-        Time.local(value.year, value.mon, value.mday)
-      elsif value.is_a? Numeric
+      if value.is_a? Numeric
         Time.at value
-      else
+      elsif value.respond_to? :to_s
         Time.parse value.to_s
+      else
+        value.to_time
       end
     rescue ArgumentError => boom
       raise boom


### PR DESCRIPTION
* Revert special char in heredoc fix specific to 1.9.2

  This reverts commit 3c99033fcc34d6a231466e01c6f60fb4be9e8bfb. It was made to
  avoid a syntax error on Ruby 1.9.2. A tick in a heredoc now doesn't raise an
  error under Ruby 2.2.0.

* Remove check for availability of URI::Parser

  Related Commit: 4a02a757fde29ba21d241c838c8114f64a393fae

  In the above commit, the URI parser instance was switched based on the
  availability of the `Parser` module because Ruby 1.9.2 and above deprecated
  the usage of URI::decode in favour of URI::Parser#unescape. This change
  removes this switch since this is not required anymore.

* Use `singleton_class` in lieu of class << self whereever applicable

* Remove 1.8 specific handling in `time_for`

  Ruby 1.8 didn't support `to_time` method on a Time object, and so there was
  custom conversion of Date, DateTime objects to a Time object. This is no more
  a problem.