### PR TITLE
change CHANGES to CHANGELOG.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 = Upcoming Release
 
  * Correctly handle encoded colons in routes. (Jeremy Evans)
+ * Rename CHANGE to Changelog.md and update Rakefile. (Eliza Sorensen)
  * Your contribution here.
 
 = 1.4.6 / 2015-03-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 = Upcoming Release
 
  * Correctly handle encoded colons in routes. (Jeremy Evans)
- * Rename CHANGE to Changelog.md and update Rakefile. (Eliza Sorensen)
+ * Rename CHANGES to CHANGELOG.md and update Rakefile. (Eliza Sorensen)
  * Your contribution here.
 
 = 1.4.6 / 2015-03-23

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ can be applied as quickly as possible:
    modify the `README.md` file to reflect that. Again, if you don't
    update the `README`, we have to, and this holds up acceptance.
 
-4. **Update the change log (`CHANGES`):** The change log helps give an
+4. **Update the change log (`CHANGELOG.md`):** The change log helps give an
    overview of the changes that go into each release, and gives credit
    where credit is due. We make sure that the change log is up to date
    before each release, and we always appreciate it when people make

--- a/Rakefile
+++ b/Rakefile
@@ -182,8 +182,8 @@ if defined?(Gem)
   end
 
   task 'release' => ['test', package('.gem')] do
-    if File.binread("CHANGES") =~ /= \d\.\d\.\d . not yet released$/i
-      fail 'please update changes first' unless %x{git symbolic-ref HEAD} == "refs/heads/prerelease\n"
+    if File.binread("CHANGELOG.md") =~ /= \d\.\d\.\d . not yet released$/i
+      fail 'please update the changelog first' unless %x{git symbolic-ref HEAD} == "refs/heads/prerelease\n"
     end
 
     sh <<-SH


### PR DESCRIPTION
My first ruby project PR :tada: 

* moved `CHANGES` to `CHANGELOG.md`
* updated `CONTRIBUTING.md` doc 
* updated Rakefile to use `CHANGELOG.md`.

original issue: 
https://github.com/sinatra/sinatra/issues/1042