### PR TITLE
Try a fix for the spec failures, with an API change side-effect

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -12,6 +12,13 @@ require 'uri'
 require 'sinatra/show_exceptions'
 require 'sinatra/version'
 
+module Rack
+  class File
+    ALLOWED_VERBS = %w[GET HEAD OPTIONS POST]
+    ALLOW_HEADER = ALLOWED_VERBS.join(', ')
+  end
+end
+
 module Sinatra
   # The request object. See Rack::Request for more info:
   # http://rubydoc.info/github/rack/rack/master/Rack/Request

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -362,7 +362,7 @@ module Sinatra
 
       last_modified opts[:last_modified] if opts[:last_modified]
 
-      file   = Rack::File.new(settings.public_folder)
+      file   = Rack::File.new(File.dirname(settings.app_file))
       result = file.call(env)
       result[1].each { |k,v| headers[k] ||= v }
       headers['Content-Length'] = result[1]['Content-Length']

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -778,9 +778,10 @@ class HelpersTest < Minitest::Test
     end
 
     def send_file_app(opts={})
+      path = @file
       mock_app {
         get '/file.txt' do
-          send_file @file, opts
+          send_file path, opts
         end
       }
     end
@@ -882,10 +883,11 @@ class HelpersTest < Minitest::Test
     end
 
     it "does not override Content-Type if already set and no explicit type is given" do
+      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file @file
+          send_file path
         end
       end
       get '/'
@@ -893,10 +895,11 @@ class HelpersTest < Minitest::Test
     end
 
     it "does override Content-Type even if already set, if explicit type is given" do
+      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file @file, :type => :gif
+          send_file path, :type => :gif
         end
       end
       get '/'
@@ -904,9 +907,10 @@ class HelpersTest < Minitest::Test
     end
 
     it 'can have :status option as a string' do
+      path = @file
       mock_app do
         post '/' do
-          send_file @file, :status => '422'
+          send_file path, :status => '422'
         end
       end
       post '/'


### PR DESCRIPTION
TL;DR

Should we make static files that get served by `send_file` be restricted to `public` directory post 2.0?

Changes:

**Set the Rack::File's root to the app file's root**

`Rack::File`'s API doesn't accept a `nil` for root path. Earlier, we
were assigning the path of the file manually in Sinatra by the following
steps:

```ruby
file = Rack::File.new(nil)
file.path = path
file.serving(env)
```

But the API of `Rack::File#serving` has been changed to take two
arguments: `request` and `path` of the file. `Rack::File` would then
interpret the file path based on the root path supplied to it's `#new`
method, and the `path` value passed into the `#serving` method.

For these reasons, we decided to use `Rack::File.call` method, but this
causes issues with how the root path is set as `Rack::File` since it
appends the route fragment to the root path to fetch the file. This has
two side-effects:

1. The static file that's being served should be present in the public
directory
2. The static file path under `public` directory should match the route
fragment, including the extension.

For example:

```ruby
get '/file.txt' do
  send_file 'file.txt'
end
```

will fetch the file at `<app root>/public/file.txt`, whereas:

```ruby
get '/file' do
  send_file 'file.txt'
end
```

will try to fetch the file at `<app root>/public/file` and will fail
since there won't be a `file.txt` at that location.

This PR also fixes the failing specs that are caused by this appending
of `public` directory effect by simply setting the public directory to
app file root by using `settings.app_file` method.

**Revert 855208a2936b27da68588ba547b3fb70c3e48268**

This causes conflicts with the way the instance variable `@file` in the
test file works with the scope of `mock_app`. Without assigning the
`@file` instance variable to a temporary variable—in this case `path`—we
won't be able to access the instance var inside the `mock_app`'s `get`
context.
