### PR TITLE
Revert back to Rack::File#serving; use new API

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -362,8 +362,9 @@ module Sinatra
 
       last_modified opts[:last_modified] if opts[:last_modified]
 
-      file   = Rack::File.new(settings.public_folder)
-      result = file.call(env)
+      file   = Rack::File.new(File.dirname(settings.app_file))
+      result = file.serving(request, path)
+
       result[1].each { |k,v| headers[k] ||= v }
       headers['Content-Length'] = result[1]['Content-Length']
       opts[:status] &&= Integer(opts[:status])

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -239,7 +239,11 @@ module Sinatra
         def block.each; yield(call) end
         response.body = block
       elsif value
-        headers.delete 'Content-Length' unless request.head? || value.is_a?(Rack::File) || value.is_a?(Stream)
+        # Rack 2.0 returns a Rack::File::Iterator here instead of
+        # Rack::File as it was in the previous API.
+        unless request.head? || value.is_a?(Rack::File::Iterator) || value.is_a?(Stream)
+          headers.delete 'Content-Length'
+        end
         response.body = value
       else
         response.body
@@ -368,7 +372,7 @@ module Sinatra
       result[1].each { |k,v| headers[k] ||= v }
       headers['Content-Length'] = result[1]['Content-Length']
       opts[:status] &&= Integer(opts[:status])
-      halt opts[:status] || result[0], result[2]
+      halt (opts[:status] || result[0]), result[2]
     rescue Errno::ENOENT
       not_found
     end
@@ -1054,6 +1058,7 @@ module Sinatra
     # Run the block with 'throw :halt' support and apply result to the response.
     def invoke
       res = catch(:halt) { yield }
+
       res = [res] if Fixnum === res or String === res
       if Array === res and Fixnum === res.first
         res = res.dup

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -778,9 +778,10 @@ class HelpersTest < Minitest::Test
     end
 
     def send_file_app(opts={})
+      path = @file
       mock_app {
         get '/file.txt' do
-          send_file @file, opts
+          send_file path, opts
         end
       }
     end
@@ -882,10 +883,11 @@ class HelpersTest < Minitest::Test
     end
 
     it "does not override Content-Type if already set and no explicit type is given" do
+      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file @file
+          send_file path
         end
       end
       get '/'
@@ -893,10 +895,11 @@ class HelpersTest < Minitest::Test
     end
 
     it "does override Content-Type even if already set, if explicit type is given" do
+      path = @file
       mock_app do
         get('/') do
           content_type :png
-          send_file @file, :type => :gif
+          send_file path, :type => :gif
         end
       end
       get '/'
@@ -904,9 +907,10 @@ class HelpersTest < Minitest::Test
     end
 
     it 'can have :status option as a string' do
+      path = @file
       mock_app do
         post '/' do
-          send_file @file, :status => '422'
+          send_file path, :status => '422'
         end
       end
       post '/'


### PR DESCRIPTION
* `Rack::File#serving` now returns `Rack::File::Iterator`. Use that to figure
out if the 'Content-Length' field should be deleted or not inside the `body()`
helper.

* The API of `Rack::File#serving` has been changed to take two arguments:
`request` and `path` of the file. `Rack::File` would then interpret the file
path based on the root path supplied to it's `#new` method, and the `path`
value passed into the `#serving` method.

* Set the root path for `Rack::File` to the app root path.

* Revert the earlier change to use `Rack::File#call` method because it appends
the route path fragment to the root path provided to `Rack::File#new` and
considers that as the file path for the static file.  Also, it doesn't work
with POST requests of static files, which Sinatra does. So we can't quite use
it without modification of the method.

* Revert 855208a2936b27da68588ba547b3fb70c3e48268. This causes conflicts with
the way the instance variable `@file` in the test file works with the scope of
`mock_app`. Without assigning the `@file` instance variable to a temporary
variable—in this case `path`—we won't be able to access the instance var
inside the mock_app > get context.