### PR TITLE
Clarify default setting of :static to reflect the Proc

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -2541,7 +2541,7 @@ werden:
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
     <td>true</td>
   </tr>
 </table>

--- a/README.es.md
+++ b/README.es.md
@@ -2336,7 +2336,7 @@ de ambos estilos:
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
   </tr>
 </table>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -2523,7 +2523,7 @@ mineures en ce qui concerne les paramètres par défaut :
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
     <td>true</td>
   </tr>
 </table>

--- a/README.ja.md
+++ b/README.ja.md
@@ -2319,7 +2319,7 @@ end
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
     <td>true</td>
   </tr>
 </table>

--- a/README.ko.md
+++ b/README.ko.md
@@ -2492,7 +2492,7 @@ end
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -2562,7 +2562,7 @@ different default settings:
   <tr>
     <td>static</td>
     <td>true</td>
-    <td>false</td>
+    <td>File.exist?(public_folder)</td>
     <td>true</td>
   </tr>
 </table>

--- a/README.ru.md
+++ b/README.ru.md
@@ -2479,7 +2479,7 @@ end
     logging             true                    false
     method_override     true                    false
     inline_templates    true                    false
-    static              true                    false
+    static              true                    File.exist?(public_folder)
 
 ### Запуск модульных приложений
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1792,6 +1792,7 @@ Sinatra::Base子类可用的方法实际上就是通过顶层 DSL 可用的方�
     logging             true                    false
     method_override     true                    false
     inline_templates    true                    false
+    static              true                    File.exist?(public_folder)
 
 ### 运行一个模块化应用
 


### PR DESCRIPTION
The README states that `:static` is disabled by default in modular mode, but it is actually enabled if `:public_folder` is set and exists on the filesystem. This commit clarifies the README. 