### PR TITLE
extended Helper with Forwardable for delegation

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -299,15 +299,10 @@ module Sinatra
       response.headers
     end
 
-    # Access the underlying Rack session.
-    def session
-      request.session
-    end
-
-    # Access shared logger object.
-    def logger
-      request.logger
-    end
+    extend Forwardable
+    def_delegators :request,
+                   :session, # Access the underlying Rack session.
+                   :logger # Access shared logger object.
 
     # Look up a media type by file extension in Rack's mime registry.
     def mime_type(type)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -2,6 +2,7 @@
 require 'rack'
 require 'tilt'
 require 'rack/protection'
+require 'forwardable'
 
 # stdlib dependencies
 require 'thread'


### PR DESCRIPTION
The Helper module was using explicit methods to delegate `session` and `logger` to `request`. By extending it with Forwardable, this is now done the proper way i.e. using Ruby's delegation methods.