### PR TITLE
simplify compile method's code

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1631,7 +1631,7 @@ module Sinatra
               ignore << escaped(c).join if c.match(/[\.@]/)
               patt = encoded(c)
               patt.gsub(/%[\da-fA-F]{2}/) do |match|
-                match.split(//).map! {|char| char =~ /[A-Z]/ ? "[#{char}#{char.tr('A-Z', 'a-z')}]" : char}.join
+                match.split(//).map! {|char| char =~ /[A-F]/ ? "[#{char}#{char.downcase}]" : char}.join
               end
             end
 
@@ -1691,7 +1691,7 @@ module Sinatra
         unsafe_patterns = unsafe_ignore.map! do |unsafe|
           chars = unsafe.split(//).map! do |char|
             if char =~ /[A-Z]/
-              char <<= char.tr('A-Z', 'a-z')
+              char <<= char.downcase
             end
             char
           end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1631,7 +1631,7 @@ module Sinatra
               ignore << escaped(c).join if c.match(/[\.@]/)
               patt = encoded(c)
               patt.gsub(/%[\da-fA-F]{2}/) do |match|
-                match.split(//).map! {|char| char =~ /[A-F]/ ? "[#{char}#{char.downcase}]" : char}.join
+                match.split(//).map! { |char| char == char.downcase ? char : "[#{char}#{char.downcase}]" }.join
               end
             end
 
@@ -1690,10 +1690,7 @@ module Sinatra
         end
         unsafe_patterns = unsafe_ignore.map! do |unsafe|
           chars = unsafe.split(//).map! do |char|
-            if char =~ /[A-Z]/
-              char <<= char.downcase
-            end
-            char
+            char == char.downcase ? char : char + char.downcase
           end
 
           "|(?:%[^#{chars[0]}].|%[#{chars[0]}][^#{chars[1]}])"


### PR DESCRIPTION
Hi,  I noticed the original code ```char.tr('A-Z', 'a-z') ``` was to downcase the capital letter ， So why not just use ```String#downcase``` method?  