### PR TITLE
Rack 2 Support

### DIFF
--- a/lib/sinatra/show_exceptions.rb
+++ b/lib/sinatra/show_exceptions.rb
@@ -1,4 +1,8 @@
-require 'rack/showexceptions'
+begin
+  require 'rack/show_exceptions'
+rescue LoadError
+  require 'rack/showexceptions'
+end
 
 module Sinatra
   # Sinatra::ShowExceptions catches all exceptions raised from the app it


### PR DESCRIPTION
While using sinatra with a Rails 5 application, I was using rack 2.0.0.alpha. It appears that Rack changed the file name which lead to some debugging. I've made it the default for sinatra to require `'rack/show_exceptions'` and if it fails, falls back to `'rack/showexceptions'`.