### PR TITLE
Change localhost links to linked representation

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -22,7 +22,7 @@ gem install sinatra
 ruby miapp.rb
 ```
 
-Ver en <http://localhost:4567>.
+Ver en [http://localhost:4567](http://localhost:4567).
 
 Se recomienda ejecutar `gem install thin`, porque Sinatra lo utilizará si está disponible.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -26,7 +26,8 @@ Puis lancez votre programme :
 ruby mon_application.rb
 ```
 
-Le résultat est visible sur : http://localhost:4567
+Le résultat est visible sur :
+[http://localhost:4567](http://localhost:4567)
 
 Il est recommandé d'exécuter également `gem install thin`, pour que
 Sinatra utilise le server Thin quand il est disponible.

--- a/README.hu.md
+++ b/README.hu.md
@@ -21,7 +21,7 @@ Telepítsd a gem-et és indítsd el az alkalmazást a következőképpen:
   ruby myapp.rb
 ```
 
-Az alkalmazás elérhető lesz itt: `http://localhost:4567`
+Az alkalmazás elérhető lesz itt: [http://localhost:4567](http://localhost:4567)
 
 ## Útvonalak (routes)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,7 +26,7 @@ gem install sinatra
 ruby myapp.rb
 ```
 
-[localhost:4567](http://localhost:4567) を開きます。
+[http://localhost:4567](http://localhost:4567) を開きます。
 
 ThinがあればSinatraはこれを利用するので、`gem install thin`することをお薦めします。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -26,7 +26,7 @@ gem install sinatra
 ruby myapp.rb
 ```
 
-`http://localhost:4567`를 확인해 보세요.
+[http://localhost:4567](http://localhost:4567) 를 확인해 보세요.
 
 `gem install thin`도 함께 실행하기를 권장합니다.
 thin이 설치되어 있을 경우 Sinatra는 thin을 통해 실행합니다.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And run with:
 ruby myapp.rb
 ```
 
-View at: http://localhost:4567
+View at: [http://localhost:4567](http://localhost:4567)
 
 It is recommended to also run `gem install thin`, which Sinatra will
 pick up if available.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -33,7 +33,7 @@ Em seguida execute:
 ruby minha_app.rb
 ```
 
-Acesse: [localhost:4567](http://localhost:4567)
+Acesse: [http://localhost:4567](http://localhost:4567)
 
 É recomendado também executar `gem install thin`. Caso esta gem esteja disponível, o
 Sinatra irá utilizá-la.

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -23,7 +23,7 @@ sudo gem install sinatra
 ruby minhaapp.rb
 ```
 
-Aceda em: [localhost:4567](http://localhost:4567)
+Aceda em: [http://localhost:4567](http://localhost:4567)
 
 ## Rotas
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -115,7 +115,7 @@ gem install sinatra
 ruby myapp.rb
 ```
 
-Оцените результат: http://localhost:4567
+Оцените результат: [http://localhost:4567](http://localhost:4567)
 
 Рекомендуется также установить Thin, сделать это можно командой: `gem install
 thin`. Thin — это более производительный и функциональный сервер для

--- a/README.zh.md
+++ b/README.zh.md
@@ -22,7 +22,7 @@ gem install sinatra
 ruby myapp.rb
 ~~~~
 
-在该地址查看： http://localhost:4567
+在该地址查看： [http://localhost:4567](http://localhost:4567)
 
 这个时候访问地址将绑定到 127.0.0.1 和 localhost ，如果使用 vagrant 进行开发，访问会失败，此时就需要进行 ip 绑定了：
 


### PR DESCRIPTION
This will generate a linked representation for all
`http://localhost:4567` URLs in the README.

I've noticed some PRs in the `sinatra/sinatra.github.com` repo (for
example: 3e5ac47e73d80da584e08a23b47b0867dab0c91b) were opened to add
anchor tags around the localhost URL. However, directly modifying data
in `_includes` in that repo won't be useful because those files are
auto-generated periodically. They should be changed here.