### PR TITLE
Update CHANGELOG for 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 = 1.4.7 / 2016-01-24
 
+ * Add support for rack 2 by fixing a `LoadError` #1055 (Ben A. Morgan)
+
  * Add Ashley Williams, Trevor Bramble, and Kashyap Kondamudi to team Sinatra.
 
  * Correctly handle encoded colons in routes. (Jeremy Evans)


### PR DESCRIPTION
Mention rack 2 support in 1.4.7

[ci skip]