### PR TITLE
Make proper Markdown headers in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-= 2.0.0 / 2016-0x-xx
+## 2.0.0 / 2016-0x-xx
 
  * Make route params available during error handler. #895 (Jeremy Evans)
 
@@ -6,7 +6,7 @@
 
  * Add Reel support. #793 (Patricio Mac Adden)
 
-= 1.4.7 / 2016-01-24
+## 1.4.7 / 2016-01-24
 
  * Add Ashley Williams, Trevor Bramble, and Kashyap Kondamudi to team Sinatra.
 
@@ -22,7 +22,7 @@
  * Add CONTRIBUTING guide. #987 (Katrina Owen)
 
 
-= 1.4.6 / 2015-03-23
+## 1.4.6 / 2015-03-23
 
  * Improve tests and documentation. (Darío Hereñú, Seiichi Yonezawa, kyoendo,
    John Voloski, Ferenc-, Renaud Martinet, Christian Haase, marocchino,
@@ -52,7 +52,7 @@
  * Upgrade test suite to Minitest version 5 and fix Ruby 2.2 compatibility.
    (Vipul A M)
 
-= 1.4.5 / 2014-04-08
+## 1.4.5 / 2014-04-08
 
  * Improve tests and documentation. (Seiichi Yonezawa, Mike Gehard, Andrew
    Deitrick, Matthew Nicholas Bradley, GoGo tanaka, Carlos Lazo, Shim Tw,
@@ -69,7 +69,7 @@
 
  * Fix bug in request.accept? that might trigger a NoMethodError. (sbonami)
 
-= 1.4.4 / 2013-10-21
+## 1.4.4 / 2013-10-21
 
  * Allow setting layout to false specifically for a single rendering engine.
    (Matt Wildig)
@@ -104,7 +104,7 @@
 
  * Reduce file size of dev mode images for 404 and 500 pages. (Francis Go)
 
-= 1.4.3 / 2013-06-07
+## 1.4.3 / 2013-06-07
 
  * Running a Sinatra file directly or via `run!` it will now ignore an
    empty $PORT env variable. (noxqsgit)
@@ -125,7 +125,7 @@
 
  * Request#accept? now returns true instead of a truthy value. (Alan Harris)
 
-= 1.4.2 / 2013-03-21
+## 1.4.2 / 2013-03-21
 
  * Fix parsing error for case where both the pattern and the captured part
    contain a dot. (Florian Hanke, Konstantin Haase)
@@ -134,11 +134,11 @@
 
  * Improve documentation. (Patricio Mac Adden, Joe Bottigliero)
 
-= 1.4.1 / 2013-03-15
+## 1.4.1 / 2013-03-15
 
  * Make delegated methods available in config.ru (Konstantin Haase)
 
-= 1.4.0 / 2013-03-15
+## 1.4.0 / 2013-03-15
 
  * Add support for LINK and UNLINK requests. (Konstantin Haase)
 
@@ -259,7 +259,7 @@
  * Exceptions in `after` filter are now handled like any other exception.
    (Nathan Esquenazi)
 
-= 1.3.6 (backport release) / 2013-03-15
+## 1.3.6 (backport release) / 2013-03-15
 
 Backported from 1.4.0:
 
@@ -269,7 +269,7 @@ Backported from 1.4.0:
 
  * No longer override `define_singleton_method`. (Konstantin Haase)
 
-= 1.3.5 / 2013-02-25
+## 1.3.5 / 2013-02-25
 
  * Fix for RubyGems 2.0 (Uchio KONDO)
 
@@ -277,7 +277,7 @@ Backported from 1.4.0:
 
  * No longer override `define_singleton_method`. (Konstantin Haase)
 
-= 1.3.4 / 2013-01-26
+## 1.3.4 / 2013-01-26
 
  * Improve documentation. (Kashyap, Stanislav Chistenko, Konstantin Haase,
    ymmtmsys, Anurag Priyam)
@@ -294,7 +294,7 @@ Backported from 1.4.0:
  * Status, headers and body will be set correctly in an after filter when using
    halt in a before filter or route. (Konstantin Haase)
 
-= 1.3.3 / 2012-08-19
+## 1.3.3 / 2012-08-19
 
  * Improved documentation. (burningTyger, Konstantin Haase, Gabriel Andretta,
    Anurag Priyam, michelc)
@@ -321,7 +321,7 @@ Backported from 1.4.0:
  * When protecting against CSRF attacks, drop the session instead of refusing
    the request. (Konstantin Haase)
 
-= 1.3.2 / 2011-12-30
+## 1.3.2 / 2011-12-30
 
  * Don't automatically add `Rack::CommonLogger` if `Rack::Server` is adding it,
    too. (Konstantin Haase)
@@ -348,7 +348,7 @@ Backported from 1.4.0:
 
  * Improved MagLev support. (Tim Felgentreff)
 
-= 1.3.1 / 2011-10-05
+## 1.3.1 / 2011-10-05
 
  * Support adding more than one callback to the stream object. (Konstantin
    Haase)
@@ -356,7 +356,7 @@ Backported from 1.4.0:
  * Fix for infinite loop when streaming on 1.9.2 with Thin from a modular
    application (Konstantin Haase)
 
-= 1.3.0 / 2011-09-30
+## 1.3.0 / 2011-09-30
 
  * Added `stream` helper method for easily creating streaming APIs, Server
    Sent Events or even WebSockets. See README for more on that topic.
@@ -483,7 +483,7 @@ Backported from 1.4.0:
  * Fix handling of broken query params when displaying exceptions. (Luke
    Jahnke)
 
-= 1.2.9 (backports release) / 2013-03-15
+## 1.2.9 (backports release) / 2013-03-15
 
 IMPORTANT: THIS IS THE LAST 1.2.x RELEASE, PLEASE UPGRADE.
 
@@ -497,14 +497,14 @@ IMPORTANT: THIS IS THE LAST 1.2.x RELEASE, PLEASE UPGRADE.
 
  * Add backports library so we can still run on Ruby 1.8.6. (Konstantin Haase)
 
-= 1.2.8 (backports release) / 2011-12-30
+## 1.2.8 (backports release) / 2011-12-30
 
 Backported from 1.3.2:
 
 * Fix bug where rendering a second template in the same request after the
   first one raised an exception skipped the default layout (Nathan Baum)
 
-= 1.2.7 (backports release) / 2011-09-30
+## 1.2.7 (backports release) / 2011-09-30
 
 Custom changes:
 
@@ -537,16 +537,16 @@ Backported from 1.3.0:
  * Fix handling of broken query params when displaying exceptions. (Luke
    Jahnke)
 
-= 1.2.6 / 2011-05-01
+## 1.2.6 / 2011-05-01
 
  * Fix broken delegation, backport delegation tests from Sinatra 1.3.
    (Konstantin Haase)
 
-= 1.2.5 / 2011-04-30
+## 1.2.5 / 2011-04-30
 
  * Restore compatibility with Ruby 1.8.6. (Konstantin Haase)
 
-= 1.2.4 / 2011-04-30
+## 1.2.4 / 2011-04-30
 
  * Sinatra::Application (classic style) does not use a session secret in
    development mode, so sessions are not invalidated after every request when
@@ -570,7 +570,7 @@ Backported from 1.3.0:
  * Remove HEAD request logic and let Rack::Head handle it instead. (Paolo
    "Nusco" Perrotta)
 
-= 1.2.3 / 2011-04-13
+## 1.2.3 / 2011-04-13
 
  * This release is compatible with Tilt 1.3, it will still work with Tilt 1.2.2,
    however, if you want to use a newer Tilt version, you have to upgrade to at
@@ -579,7 +579,7 @@ Backported from 1.3.0:
  * Helpers dealing with time, like `expires`, handle objects that pretend to be
    numbers, like `ActiveSupport::Duration`, better. (Konstantin Haase)
 
-= 1.2.2 / 2011-04-08
+## 1.2.2 / 2011-04-08
 
  * The `:provides => :js` condition now matches both `application/javascript`
    and `text/javascript`. The `:provides => :xml` condition now matches both
@@ -607,7 +607,7 @@ Backported from 1.3.0:
  * In development environment, when running under a nested path, the image URIs
    on the error pages are set properly. (Konstantin Haase)
 
-= 1.2.1 / 2011-03-17
+## 1.2.1 / 2011-03-17
 
  * Use a generated session secret when using `enable :sessions`. (Konstantin
    Haase)
@@ -620,7 +620,7 @@ Backported from 1.3.0:
  * README translations improved (Gabriel Andretta, burningTyger, Sylvain Desvé,
    Gregor Schmidt)
 
-= 1.2.0 / 2011-03-03
+## 1.2.0 / 2011-03-03
 
  * Added `slim` rendering method for rendering Slim templates. (Steve
    Hodgkiss)
@@ -669,11 +669,11 @@ Backported from 1.3.0:
  * Sinatra now ships with a Gemfile for development dependencies, since it eases
    supporting different platforms, like JRuby. (Konstantin Haase)
 
-= 1.1.4 (backports release) / 2011-04-13
+## 1.1.4 (backports release) / 2011-04-13
 
  * Compatible with Tilt 1.3. (Konstantin Haase)
 
-= 1.1.3 / 2011-02-20
+## 1.1.3 / 2011-02-20
 
  * Fixed issues with `user_agent` condition if the user agent header is missing.
    (Konstantin Haase)
@@ -692,11 +692,11 @@ Backported from 1.3.0:
    a rendering engine - it was not possible to register ".html.erb" without
    tricks. (Konstantin Haase)
 
-= 1.1.2 / 2010-10-25
+## 1.1.2 / 2010-10-25
 
 Like 1.1.1, but with proper CHANGES file.
 
-= 1.1.1 / 2010-10-25
+## 1.1.1 / 2010-10-25
 
  * README has been translated to Russian (Nickolay Schwarz, Vasily Polovnyov)
    and Portuguese (Luciano Sousa).
@@ -728,7 +728,7 @@ Like 1.1.1, but with proper CHANGES file.
    honor default_encoding and URLs support unicode characters. (Konstantin
    Haase)
 
-= 1.1.0 / 2010-10-24
+## 1.1.0 / 2010-10-24
 
  * Before and after filters now support pattern matching, including the
    ability to use captures: "before('/user/:name') { |name| ... }". This
@@ -834,7 +834,7 @@ Like 1.1.1, but with proper CHANGES file.
  * Sinatra now depends on Rack 1.1 or higher. Rack 1.0 is no longer supported.
    (Konstantin Haase)
 
-= 1.0 / 2010-03-23
+## 1.0 / 2010-03-23
 
  * It's now possible to register blocks to run after each request using
    after filters. After filters run at the end of each request, after
@@ -977,7 +977,7 @@ the 1.0 release:
  * The `:methodoverride' option to enable/disable the POST _method hack is
    obsolete; use `:method_override` instead.
 
-= 0.9.2 / 2009-05-18
+## 0.9.2 / 2009-05-18
 
  * This version is compatible with Rack 1.0. [Rein Henrichs]
 
@@ -1058,12 +1058,12 @@ the 1.0 release:
  * Fix in-file templates __END__ detection when __END__ exists with
    other stuff on a line [Yoji Shidara]
 
-= 0.9.1.1 / 2009-03-09
+## 0.9.1.1 / 2009-03-09
 
  * Fix directory traversal vulnerability in default static files
    route. See [#177] for more info.
 
-= 0.9.1 / 2009-03-01
+## 0.9.1 / 2009-03-01
 
  * Sinatra now runs under Ruby 1.9.1 [#61]
 
@@ -1133,7 +1133,7 @@ the 1.0 release:
  * Fixed that "." in route patterns erroneously matched any character
    instead of a literal ".". [#124]
 
-= 0.9.0.4 / 2009-01-25
+## 0.9.0.4 / 2009-01-25
 
  * Using halt with more than 1 args causes ArgumentError [#131]
  * using halt in a before filter doesn't modify response [#127]
@@ -1142,7 +1142,7 @@ the 1.0 release:
  * Preserve non-nested params in nested params hash [#117]
  * Fix backtrace dump with Rack::Lint [#116]
 
-= 0.9.0.3 / 2009-01-21
+## 0.9.0.3 / 2009-01-21
 
  * Fall back on mongrel then webrick when thin not found. [#75]
  * Use :environment instead of :env in test helpers to
@@ -1151,12 +1151,12 @@ the 1.0 release:
  * Fix app_file detection on windows [#118]
  * Fix static files with Rack::Lint in pipeline [#121]
 
-= 0.9.0.2 / 2009-01-18
+## 0.9.0.2 / 2009-01-18
 
  * Halting a before block should stop processing of routes [#85]
  * Fix redirect/halt in before filters [#85]
 
-= 0.9.0 / 2009-01-18
+## 0.9.0 / 2009-01-18
 
  * Works with and requires Rack >= 0.9.1
 
@@ -1249,7 +1249,7 @@ the 1.0 release:
    subclass of Sinatra::Base; each request is processed within an
    instance.
 
-= 0.3.3 / 2009-01-06
+## 0.3.3 / 2009-01-06
 
  * Pin to Rack 0.4.0 (this is the last release on Rack 0.4)
 
@@ -1267,7 +1267,7 @@ the 1.0 release:
  * BUG: Sinatra detects the app file and root path when run under
    thin/passenger.
 
-= 0.3.2
+## 0.3.2
 
  * BUG: Static and send_file read entire file into String before
    sending. Updated to stream with 8K chunks instead.
@@ -1277,11 +1277,11 @@ the 1.0 release:
 
  * Various minor doc fixes.
 
-= 0.3.1
+## 0.3.1
 
  * Unbreak optional path parameters [jeremyevans]
 
-= 0.3.0
+## 0.3.0
 
  * Add sinatra.gemspec w/ support for github gem builds. Forks can now
    enable the build gem option in github to get free username-sinatra.gem
@@ -1338,10 +1338,10 @@ the 1.0 release:
 
  * Fix for escaped paths not resolving static files [Matthew Walker]
 
-= 0.2.1
+## 0.2.1
 
  * File upload fix and minor tweaks.
 
-= 0.2.0
+## 0.2.0
 
  * Initial gem release of 0.2 codebase.


### PR DESCRIPTION
This way, services like https://allmychanges.com will be easier to parse file. And GitHub will render it properly.