### PR TITLE
Fix issue with passed routes and provides

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -968,10 +968,14 @@ module Sinatra
           returned_pass_block = process_route(pattern, keys, conditions) do |*args|
             env['sinatra.route'] = block.instance_variable_get(:@route_name)
             route_eval { block[*args] }
+            # prevent passed route from pinning the content type
+            response['Content-Type'] = nil
           end
 
-          # don't wipe out pass_block in superclass
-          pass_block = returned_pass_block if returned_pass_block
+          if returned_pass_block
+            # don't wipe out pass_block in superclass
+            pass_block = returned_pass_block
+          end
         end
       end
 


### PR DESCRIPTION
This patch addresses an oddball issue that was the source of much hair-pulling this evening. Because the `provides` condition both branches on **and** mutates `response['Content-Type']`, a passed route with a `provides` condition can interfere with the `provides` condition of a later route (assuming both the initial and later routes match the requested path).

Consider an example:

```ruby
get '/:id', :provides => :json do
  pass if params[:id] =~ /\D/

  # some processing
end

get '/foo', :provides => :text do
  # some other processing
end
```

A `GET` request to `/foo` with an `Accept` header of `application/json,text/plain` will always return 404. Why? Because the compiled `provides` condition of the first route will set `response['Content-Type']` to `application/json` ([here](https://github.com/sinatra/sinatra/blob/56a6141789b808ffb27b985243aab086d62f8803/lib/sinatra/base.rb#L1573)), and subsequent compiled `provides` conditions will short-circuit any attempts to re-examine the preferred types ([here](https://github.com/sinatra/sinatra/blob/56a6141789b808ffb27b985243aab086d62f8803/lib/sinatra/base.rb#L1569)).

Workarounds:
- Don't use a `:provides` condition; instead, use `Sinatra::Request#preferred_type` to inspect the `Accept` header on the request and `Sinatra::Base#content_type` to set the `Content-Type` header on the response.
- Structure routes to prevent pattern overlap.
- When there is pattern overlap and matching depends on the exact format of the path, use a regular expression and `params['captures']` (or a block parameter) instead of regular route parameters.
- When there is pattern overlap, combine the logic into a single route (perhaps using helpers) instead of passing to another route.
- Manually clear `request['Content-Type']` before calling `pass`.

Solutions:

1. Clear `request['Content-Type']` when throwing `:pass`
2. Clear `request['Content-Type']` when catching `:pass`
3. Clear `request['Content-Type']` in-between route iterations (maybe?)

This patch implements solution 1 but I'm interested in your feedback.

Thank you in advance!