### PR TITLE
fix issue when modifying params in before filters

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
 # external dependencies
@@ -1001,7 +1002,7 @@ module Sinatra
       values += match.captures.map! { |v| force_encoding URI_INSTANCE.unescape(v) if v }
 
       if values.any?
-        original, @params = params, params.merge('splat' => [], 'captures' => values)
+        @params = params.merge('splat' => [], 'captures' => values)
         keys.zip(values) { |k,v| Array === @params[k] ? @params[k] << v : @params[k] = v if v }
       end
 
@@ -1013,7 +1014,10 @@ module Sinatra
       @env['sinatra.error.params'] = @params
       raise
     ensure
-      @params = original if original
+      if values.any?
+        @params.delete('splat')
+        @params.delete('captures')
+      end
     end
 
     # No matching route was found or all routes passed. The default

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -144,6 +144,21 @@ class BeforeFilterTest < Minitest::Test
     assert_body 'bar'
   end
 
+  it 'can add params when request path contains named params' do
+    mock_app do
+      before '/hello/:person' do
+        params['foo'] = 'bar'
+      end
+      get '/hello/:person' do
+        params['foo']
+      end
+    end
+
+    get '/hello/mary'
+    assert_body 'bar'
+  end
+
+
   it 'can remove params' do
     mock_app do
       before { params.delete('foo') }
@@ -151,6 +166,20 @@ class BeforeFilterTest < Minitest::Test
     end
 
     get '/?foo=bar'
+    assert_body ''
+  end
+
+  it 'can remove params when request path contains named params' do
+    mock_app do
+      before '/hello/:person' do
+        params.delete('foo')
+      end
+      get '/hello/:person' do
+        params['foo'].to_s
+      end
+    end
+
+    get '/hello/mary'
     assert_body ''
   end
 


### PR DESCRIPTION
When before filters contain splat or captures, the modification to params will not work. Example below:

``` ruby
require 'sinatra/base'

class TestMe < Sinatra::Base
  before '/hello/:name' do
    params[:foo] = :bar
  end

  get '/hello/:name' do
    "foo: #{params[:foo]}" # ==> "foo: "
  end

  run!
end
```

This patch fixes the issue and also sorts out some tests for before_filter from after_filter tests. 
