### PR TITLE
Lock celluloid 0.16.0 and fix rack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ if RUBY_ENGINE == "ruby"
   gem 'haml', '>= 3.0'
   gem 'sass'
   gem 'reel-rack'
+  gem 'celluloid', '~> 0.16.0'
 end
 
 if RUBY_ENGINE == "rbx"

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
 
   s.required_ruby_version = '>= 2.2.0'
 
-  s.add_dependency 'rack', '= 2.0.0.alpha'
+  s.add_dependency 'rack', '= 2.0.0.rc1'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '~> 1.5'
   s.add_dependency 'mustermann',  '~> 0.4'


### PR DESCRIPTION
Various tests aren't executed on travis ci since we supported the reel.

The test result of [Add Reel support. ](https://travis-ci.org/sinatra/sinatra/jobs/106012045)
```
575 runs, 906 assertions, 0 failures, 0 errors, 0 skips
```

Previous test result https://travis-ci.org/sinatra/sinatra/jobs/106007160
```
1083 runs, 2376 assertions, 0 failures, 0 errors, 0 skips
```
So, I fixed the issue by disabling reel as default web server. Thoughts?