### PR TITLE
Add tests for trailing slashes in the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ end
 Routes are matched in the order they are defined. The first route that
 matches the request is invoked.
 
+Routes with trailing slashes are different from the ones without:
+
+```ruby
+    get '/foo' do
+      # Does not match "GET /foo/"
+    end
+```
+
 Route patterns may include named parameters, accessible via the
 `params` hash:
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1452,4 +1452,23 @@ class RoutingTest < Minitest::Test
     end
     get '/users/1/status'
   end
+
+  it 'treats routes with and without trailing slashes differently' do
+    mock_app do
+      get '/foo' do
+        'Foo'
+      end
+
+      get '/foo/' do
+        'Foo with a slash'
+      end
+    end
+
+    get '/foo'
+    assert_equal 'Foo', body
+    refute_equal 'Foo with a slash', body
+
+    get '/foo/'
+    assert_equal 'Foo with a slash', body
+  end
 end


### PR DESCRIPTION
Related to #1107 

The router treats paths with trailing slashes different from the ones without. 
Add tests for this and also mention it in the README.
Following @zzak's [comment](https://github.com/sinatra/sinatra/issues/1107#issuecomment-217849114).