### PR TITLE
WIP: Fix Stream API

### DIFF
--- a/examples/reel_chat.rb
+++ b/examples/reel_chat.rb
@@ -1,0 +1,143 @@
+# chat.rb
+require 'sinatra/base'
+# this also loads celluloid io, let's keep that in mind
+require 'celluloid/current'
+require 'reel'
+
+# The chat server, an IO Event Loop held by the actor
+# Collects connections (Reel Event Streams)
+# 
+# Contrary to EventMachine, there is no event callback for
+# when the user disconnects, writes will just fail, we 
+# therefore only remove these connections when writes fail.
+#
+class ChatServer
+  include Celluloid::IO
+  attr_reader :connections
+  def initialize
+    @connections = []
+  end
+
+  def listen(connection)
+    @connections << connection
+  end
+
+  def broadcast(message)
+    # TODO: improve this
+    # consider that the connections has 10000 clients
+    # we spend most of the team iterating and creating 10000 
+    # celluloid tasks/fibers, starving resources while only do
+    # stuff in the end. 
+    # improvement: take it in batches of N connections, async/unicast
+    # them, and then sleep, so that the allocated tasks can be run
+    @connections.each do |connection|
+      async(:unicast, connection, message)
+    end
+  end
+
+  def unicast(connection, message)
+    connection.write(message)
+  rescue Reel::SocketError
+    @connections.delete(connection)
+  end
+
+end
+
+# Supervise all the things
+config = Celluloid::Supervision::Configuration.new
+config.define type: ChatServer, as: :chat_server
+config.deploy
+
+# Somehow Celluloid IO doesn't work well with sinatra classic applications, supervisor blows up. 
+class Server < Sinatra::Base
+  set server: 'puma',
+      chat_server: Celluloid::Actor[:chat_server]
+      
+  get '/' do
+    halt erb(:login) unless params[:user]
+    erb :chat, locals: { user: params[:user].gsub(/\W/, '') }
+  end
+  
+
+  # This is the secret sauce, we just reuse the reel
+  # built-in Classes to act on this. From the puma perspective,
+  # we hijack the socket and pass it to the reel connection, which 
+  # will later pass it to our chat server above. Puma worker is free. 
+  get '/stream', provides: 'text/event-stream' do
+    io = env['rack.hijack'].call
+    io = ::Celluloid::IO::TCPSocket.new(io)
+    writer = Reel::Response::Writer.new(io)
+  
+  
+    event_stream = ::Reel::EventStream.new do |event_stream|
+      settings.chat_server.async(:listen, event_stream)
+    end
+    resp = Reel::StreamResponse.new(:ok,
+           {
+             'Content-Type' => 'text/event-stream; charset=utf-8',
+             'Cache-Control' => 'no-cache',
+             'X-Accel-Buffering' => 'no'
+           },
+           event_stream)
+  
+    writer.handle_response(resp)
+    resp
+  end
+  
+  post '/' do
+    settings.chat_server.async(:broadcast, "data: #{params[:msg]}\n\n")
+    204 # response without entity body
+  end
+
+  template :layout do
+<<-HTML
+<html>
+  <head> 
+    <title>Super Simple Chat with Sinatra</title> 
+    <meta charset="utf-8" />
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script> 
+  </head> 
+  <body><%= yield %></body>
+</html>
+HTML
+  end
+  template :login do
+<<-HTML
+<form action='/'>
+  <label for='user'>User Name:</label>
+  <input name='user' value='' />
+  <input type='submit' value="GO!" />
+</form>
+HTML
+  end
+  
+  template :chat do
+<<-HTML
+<pre id='chat'></pre>
+
+<form>
+  <input id='msg' placeholder='type message here...' />
+</form>
+
+<script>
+  // reading
+  var es = new EventSource('/stream');
+  es.onmessage = function(e) { $('#chat').append(e.data + "\\n") };
+
+  // writing
+  $("form").on("submit", function(e) {
+    $.post('/', {msg: "<%= user %>: " + $('#msg').val()});
+    $('#msg').val(''); $('#msg').focus();
+    e.preventDefault();
+    return false;
+  });
+</script>
+HTML
+  end
+end
+
+# config.ru
+require_relative "chat.rb"
+run Server
+
+# run this with rack and puma

--- a/examples/stream.ru
+++ b/examples/stream.ru
@@ -8,17 +8,20 @@
 #   puma stream.ru                # gem install puma
 
 require 'sinatra/base'
+require 'sinatra/stream/reel'
 
 class Stream < Sinatra::Base
   get '/' do
-    content_type :txt
+    #content_type :txt
 
-    stream do |out|
-      out << "It's gonna be legen -\n"
+    #stream do |out|
+    Rack::StreamingResponse.new do |out|
+      out.hijack!(env)
+      out.write "It's gonna be legen -\n"
       sleep 0.5
-      out << " (wait for it) \n"
+      out.write " (wait for it) \n"
       sleep 1
-      out << "- dary!\n"
+      out.write "- dary!\n"
     end
   end
 end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -404,7 +404,7 @@ module Sinatra
       def self.schedule(*) yield end
       def self.defer(*)    yield end
 
-      def initialize(scheduler = self.class, keep_open = false, &back)
+      def initialize(scheduler = self.class, keep_open = false, env = {}, &back)
         @back, @scheduler, @keep_open = back.to_proc, scheduler, keep_open
         @callbacks, @closed = [], false
       end
@@ -453,7 +453,7 @@ module Sinatra
     def stream(keep_open = false)
       scheduler = env['async.callback'] ? EventMachine : Stream
       current   = @params.dup
-      body Stream.new(scheduler, keep_open) { |out| with_params(current) { yield(out) } }
+      body Stream.new(scheduler, keep_open, env) { |out| with_params(current) { yield(out) } }
     end
 
     # Specify response freshness policy for HTTP caches (Cache-Control header).

--- a/lib/sinatra/stream/reel.rb
+++ b/lib/sinatra/stream/reel.rb
@@ -1,0 +1,73 @@
+class Rack::ChunkedResponse < Rack::Response
+  extend Forwardable
+  def_delegators :@io, :read, :write, :read_nonblock, :write_nonblock, :flush, 
+		       :close, :close_read, :close_write, :closed?
+
+  def schedule
+    yield
+  end 
+
+  class Writer
+    extend Forwardable
+    def_delegators :@io, :read, :write, :read_nonblock, :write_nonblock, :flush, 
+		         :close, :close_read, :close_write, :closed?
+
+    def initialize(io, context)
+      @io = io
+      @context = context
+    end
+
+    def write(data)
+      @context.schedule { @io.write(data) }
+    end
+    alias :<< :write
+
+    def callback(&block)
+      @callbacks << block
+    end
+    
+    def close
+      @io.close unless @io.closed?
+      @callbacks.each do |c|
+        @context.schedule { c.call }
+      end
+    end
+    
+    def closed? ; !@io or @io.closed? ; end
+
+    alias :errback :callback
+  end
+end
+
+ 
+class Rack::StreamingResponse < Rack::ChunkedResponse
+  CRLF = "\r\n"
+
+  STREAMINGHEADERS={
+    "Content-Type"       => "text/event-stream",
+    "Transfer-Encoding"  => "identity",
+    "Cache-Control"      => "no-cache"
+  }
+
+  def hijack!(env)
+    return if @io
+    env['rack.hijack'].call
+    @io = Writer.new(env['rack.hijack_io'], self)
+    @io.write render_header
+  end
+
+  private
+
+  def render_header
+    response_header = "#{version} #{status}#{CRLF}"
+    unless headers.empty?
+      response_header << headers.merge(STREAMINGHEADERS).map do |header, value|
+        "#{header}: #{value}"
+      end.join(CRLF) << CRLF
+    end
+    response_header << CRLF
+  end
+
+  # TODO: should be supplied by or passed to the web server
+  def version ; "HTTP/1.1" ; end
+end


### PR DESCRIPTION
As discussed in #1035 

Plan is to create a better abstraction of Streaming Responses. Most web servers get away with chunked responses, but fail (except EventMachine) to keep the stream open. Most web servers don't have an event loop or abstraction to pass tasks to its workers (when they have them), and only rely on the rack hijack API to "delegate" this task to another component.

This means (IMO) that the Stream class must accomodate the common use case, that means, it has to be able to:
-  keep the IO
- write the relevant headers ([here is an example of a class which does it](https://github.com/celluloid/reel/blob/master/lib/reel/stream.rb#L86-L112))
- schedule tasks to be executed by the event loop and by threaded workers (defer/schedule)
- handle the case when the socket is closed (according to Rack spec, an open stream object can't respond to close)

Still in progress
