### PR TITLE
Raise errors when raise_errors option set true

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1148,9 +1148,10 @@ module Sinatra
         halt status
       end
 
+      raise boom if settings.raise_errors? or settings.show_exceptions?
+
       res = error_block!(boom.class, boom) || error_block!(status, boom)
       return res if res or not server_error?
-      raise boom if settings.raise_errors? or settings.show_exceptions?
       error_block! Exception, boom
     end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1844,7 +1844,10 @@ class HelpersTest < Minitest::Test
     end
 
     it 'is case-insensitive' do
-      mock_app { get('/:foo') { uri params[:foo] }}
+      mock_app do
+        disable :raise_errors
+        get('/:foo') { uri params[:foo] }
+      end
       assert_equal get('HtTP://google.com').body, get('http://google.com').body
     end
 

--- a/test/mapped_error_test.rb
+++ b/test/mapped_error_test.rb
@@ -107,22 +107,20 @@ class MappedErrorTest < Minitest::Test
       assert_raises(FooError) { get '/' }
     end
 
-    it "calls error handlers before raising errors even when raise_errors is set" do
+    it "raises errors in spite of error handlers defined when raise_errors is set" do
       mock_app do
         set :raise_errors, true
         error(FooError) { "she's there." }
         get('/') { raise FooError }
       end
-      get '/'
-      assert_equal 500, status
+      assert_raises(FooError) { get '/' }
     end
 
-    it "never raises Sinatra::NotFound beyond the application" do
+    it "raises Sinatra::NotFound beyond the application" do
       mock_app(Sinatra::Application) do
         get('/') { raise Sinatra::NotFound }
       end
-      get '/'
-      assert_equal 404, status
+      assert_raises(Sinatra::NotFound) { get '/' }
     end
 
     it "cascades for subclasses of Sinatra::NotFound" do
@@ -131,17 +129,12 @@ class MappedErrorTest < Minitest::Test
         error(FooNotFound) { "foo! not found." }
         get('/') { raise FooNotFound }
       end
-      get '/'
-      assert_equal 404, status
-      assert_equal 'foo! not found.', body
+      assert_raises(FooNotFound) { get '/' }
     end
 
     it 'has a not_found method for backwards compatibility' do
       mock_app { not_found { "Lost, are we?" } }
-
-      get '/test'
-      assert_equal 404, status
-      assert_equal "Lost, are we?", body
+      assert_raises(Sinatra::NotFound) { get '/test' }
     end
 
     it 'inherits error mappings from base class' do


### PR DESCRIPTION
According to https://github.com/sinatra/sinatra/blob/master/test/mapped_error_test.rb#L110, error handlers catch errors in spite of `raise_errors` option enabled.
I think errors should ignore handlers and raise at the time.