### PR TITLE
Add specs for Response#finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 
 dist: trusty
-group: edge
 
 before_install:
   - rvm get head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ sudo: true
 before_install:
   - rvm get head
   - gem install bundler
+  - export CXX="g++-4.8"
+
+addons:
+ apt:
+  sources:
+  - ubuntu-toolchain-r-test
+  packages:
+  - g++-4.8
 
 rvm:
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: ruby
 
 dist: trusty
+sudo: true
 
 before_install:
   - rvm get head

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ track patch requests.
   is where the website sources are managed. There are almost always people in
   `#sinatra` that are happy to discuss, apply, and publish website patches.
 
-* [The Book](http://sinatra-book.gittr.com/) has its own [Git
+* [The Book](http://sinatra-org-book.herokuapp.com/) has its own [Git
   repository](http://github.com/sinatra/sinatra-book/) and build process but is
   managed the same as the website and project codebase.
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gemspec
 
 gem 'rake'
 gem 'rack', github: 'rack/rack'
-gem 'tilt', github: 'rtomayko/tilt'
 gem 'rack-test', '>= 0.6.2'
 gem "minitest", "~> 5.0"
 gem 'tool', '~> 0.2'

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -27,11 +27,24 @@ class ResponseTest < Minitest::Test
     assert_equal 'Hello World', @response.body.join
   end
 
-  [204, 304].each do |status_code|
+  [204, 205, 304].each do |status_code|
     it "removes the Content-Type header and body when response status is #{status_code}" do
       @response.status = status_code
       @response.body = ['Hello World']
       assert_equal [status_code, {}, []], @response.finish
+    end
+  end
+
+  [200, 201, 202, 301, 302, 400, 401, 403, 404, 500].each do |status_code|
+    it "will not removes the Content-Type header and body when response status
+        is #{status_code}" do
+      @response.status = status_code
+      @response.body   = ['Hello World']
+      assert_equal [
+        status_code,
+        { 'Content-Type' => 'text/html', 'Content-Length' => '11' },
+        ['Hello World']
+      ], @response.finish
     end
   end
 


### PR DESCRIPTION
1. With status code _205_, `Response#finish` will remove **Content-Type** and **body** as well.

2. Other than status code _204_, _205_, and _304_, `Response#finish` will not remove **Content-Type** and **body**.