### PR TITLE
Update `rack` dependency to accept the final `2.0.x` releases.

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
 
   s.required_ruby_version = '>= 2.2.0'
 
-  s.add_dependency 'rack', '= 2.0.0.rc1'
+  s.add_dependency 'rack', '~> 2.0'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '~> 1.5'
   s.add_dependency 'mustermann',  '~> 0.4'


### PR DESCRIPTION
https://rubygems.org/gems/rack/versions/2.0.1

I'm not sure how restrictive/flexible you folks want the final dependency on Rack to be, so let me know if I should change this one to be `~> 2.0.0` or something else.