### PR TITLE
Fix tests for routing

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -204,7 +204,7 @@ end
 Routen mit regulären Ausdrücken sind auch möglich:
 
 ```ruby
-get /\A\/hallo\/([\w]+)\z/ do
+get /\/hallo\/([\w]+)/ do
   "Hallo, #{params['captures'].first}!"
 end
 ```
@@ -389,7 +389,7 @@ end
 Oder unter Verwendung eines negativen look ahead:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.es.md
+++ b/README.es.md
@@ -117,7 +117,7 @@ end
 Rutas con Expresiones Regulares:
 
 ```ruby
-get /\A\/hola\/([\w]+)\z/ do
+get /\/hola\/([\w]+)/ do
   "Hola, #{params['captures'].first}!"
 end
 ```
@@ -282,7 +282,7 @@ end
 O, usando un lookahead negativo:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.fr.md
+++ b/README.fr.md
@@ -209,7 +209,7 @@ end
 Une route peut aussi être définie par une expression régulière :
 
 ```ruby
-get /\A\/bonjour\/([\w]+)\z/ do
+get /\/bonjour\/([\w]+)/ do
   "Bonjour, #{params['captures'].first} !"
 end
 ```
@@ -390,7 +390,7 @@ end
 Ou bien en utilisant cette expression regulière :
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.hu.md
+++ b/README.hu.md
@@ -88,7 +88,7 @@ Az útvonalmintákban szerepelhetnek joker paraméterek is, melyeket a
 Reguláris kifejezéseket is felvehetünk az útvonalba:
 
 ```ruby
-  get /\A\/hello\/([\w]+)\z/ do
+  get /\/hello\/([\w]+)/ do
     "Helló, #{params['captures'].first}!"
   end
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -217,7 +217,7 @@ end
 ルーティングを正規表現にマッチさせることもできます。
 
 ```ruby
-get /\A\/hello\/([\w]+)\z/ do
+get /\/hello\/([\w]+)/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -374,7 +374,7 @@ end
 または、否定先読みを使って:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -207,7 +207,7 @@ end
 라우터는 정규표현식으로 매치할 수 있습니다.
 
 ```ruby
-get /\A\/hello\/([\w]+)\z/ do
+get /\/hello\/([\w]+)/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -374,7 +374,7 @@ end
 또는 거꾸로 탐색(negative look ahead)할 수도 있습니다.
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ end
 Route matching with Regular Expressions:
 
 ```ruby
-get /\A\/hello\/([\w]+)\z/ do
+get /\/hello\/([\w]+)/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -394,7 +394,7 @@ end
 Or, using negative look ahead:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -180,7 +180,7 @@ end
 Rotas podem casar com expressões regulares:
 
 ```ruby
-get /\A\/ola\/([\w]+)\z/ do
+get /\/ola\/([\w]+)/ do
   "Olá, #{params['captures'].first}!"
 end
 ```
@@ -362,7 +362,7 @@ end
 Ou, usando algo mais denso à frente:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -88,7 +88,7 @@ end
 Rotas correspondem-se com expressões regulares:
 
 ```ruby
-get /\A\/ola\/([\w]+)\z/ do
+get /\/ola\/([\w]+)/ do
   "Olá, #{params['captures'].first}!"
 end
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -208,7 +208,7 @@ end
 Регулярные выражения в качестве шаблонов маршрутов:
 
 ```ruby
-get /\A\/hello\/([\w]+)\z/ do
+get /\/hello\/([\w]+)/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -377,7 +377,7 @@ end
 Или с использованием негативного просмотра вперед:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,7 +205,7 @@ end
 通过正则表达式匹配路由：
 
 ```ruby
-get /\A\/hello\/([\w]+)\z/ do
+get /\/hello\/([\w]+)/ do
   "Hello, #{params['captures'].first}!"
 end
 ```
@@ -372,7 +372,7 @@ end
 或者，使用消极向前查找:
 
 ```ruby
-get %r{^(?!/index$)} do
+get %r{(?!/index)} do
   # ...
 end
 ```

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org" unless ENV['QUICK']
 gemspec
 
 gem 'mustermann', github: 'sinatra/mustermann'
+gem "rack-protection", github: "sinatra/rack-protection"
 gem 'sinatra', path: '..'
 
 group :development, :test do
@@ -41,4 +42,3 @@ repos = { 'tilt' => 'rtomayko/tilt', 'rack' => 'rack/rack' }
   dep = {:github => repos[lib], :branch => dep} if dep and dep !~ /(\d+\.)+\d+/
   gem lib, dep if dep
 end
-

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -578,7 +578,7 @@ class RoutingTest < Minitest::Test
 
   it 'supports regular expressions' do
     mock_app {
-      get(/^\/foo...\/bar$/) do
+      get(/\/foo...\/bar/) do
         'Hello World'
       end
     }
@@ -590,7 +590,7 @@ class RoutingTest < Minitest::Test
 
   it 'makes regular expression captures available in params[:captures]' do
     mock_app {
-      get(/^\/fo(.*)\/ba(.*)/) do
+      get(/\/fo(.*)\/ba(.*)/) do
         assert_equal ['orooomma', 'f'], params[:captures]
         'right on'
       end
@@ -1228,7 +1228,7 @@ class RoutingTest < Minitest::Test
 
   it 'passes regular expression captures as block parameters' do
     mock_app {
-      get(/^\/fo(.*)\/ba(.*)/) do |foo, bar|
+      get(/\/fo(.*)\/ba(.*)/) do |foo, bar|
         assert_equal 'orooomma', foo
         assert_equal 'f', bar
         'looks good'


### PR DESCRIPTION
There are 3 failing test examples in master branch. All of them are related to Mustermann way of handling regular expressions.

From Mustermann documentation:

> The pattern string (or actual Regexp instance) should not contain anchors (^ outside of square   brackets, $, \A, \z, or \Z).


This PR updates specs and examples in README files to be compatible with Mustermann.