### PR TITLE
Restore some CSP defaults

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1691,6 +1691,10 @@ module Sinatra
       def setup_protection(builder)
         return unless protection?
         options = Hash === protection ? protection.dup : {}
+        options = {
+          img_src:  "'self' data:",
+          font_src: "'self'"
+        }.merge options
 
         protect_session = options.fetch(:session) { sessions? }
         options[:without_session] = !protect_session


### PR DESCRIPTION
The recent upgrade of rack-protect brought in some new backwards-incompatible
defaults. Notably, they break the Sidekiq web UI (see mperham/sidekiq#3070),
and could have a similar impact broadly. This should restore enough access
to get Sidekiq et al. (mostly) working.