### PR TITLE
Add option to set the session middleware when enabling sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,7 +1413,7 @@ enable :sessions
 set :session_store, Rack::Session::Pool
 ```
 
-Or to enable sessions with a hash of options:
+Or to set up sessions with a hash of options:
 
 ```ruby
 set :sessions, :expire_after => 2592000
@@ -1421,13 +1421,9 @@ set :session_store, Rack::Session::Pool
 ```
 
 Another option is to **not** call `enable :sessions`, but instead pull in your
-middleware of choice as you would any other middleware:
+middleware of choice as you would any other middleware.
 
-```ruby
-use Rack::Session::Pool, :expire_after => 2592000
-```
-
-It is important to note that when using this method, session based protection (see 'Configuring attack protection') will not be enabled by default. The Rack middleware to do that will also need to be added:
+It is important to note that when using this method, session based protection (see 'Configuring attack protection') **will not be enabled by default**. The Rack middleware to do that will also need to be added:
 
 ```ruby
 use Rack::Session::Pool, :expire_after => 2592000

--- a/README.md
+++ b/README.md
@@ -2111,7 +2111,14 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 ```
 
 By default, Sinatra will only set up session based protection if `:sessions`
-have been enabled. See 'Using Sessions'.
+have been enabled. See 'Using Sessions'. Sometimes you may want to set up
+sessions "outside" of the Sinatra app, such as in the config.ru or with a
+separate Rack::Builder instance. In that case you can still set up session
+based protection by passing the `:session` option:
+
+```ruby
+set :protection, :session => true
+```
 
 ### Available Settings
 

--- a/README.md
+++ b/README.md
@@ -1380,11 +1380,12 @@ end
 Note that `enable :sessions` actually stores all data in a cookie. This
 might not always be what you want (storing lots of data will increase your
 traffic, for instance). You can use any Rack session middleware: in order to
-do so, do **not** call `enable :sessions`, but instead pull in your
-middleware of choice as you would any other middleware:
+do so, do **not** call `enable :sessions`, but instead call `set
+:sessions` with your middleware of choice passed in as the value for
+`:session_store` along with any other options:
 
 ```ruby
-use Rack::Session::Pool, :expire_after => 2592000
+set :sessions, :session_store => Rack::Session::Pool, :expire_after => 2592000
 
 get '/' do
   "value = " << session[:value].inspect
@@ -2098,14 +2099,7 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 ```
 
 By default, Sinatra will only set up session based protection if `:sessions`
-has been enabled. Sometimes you want to set up sessions on your own, though. In
-that case you can get it to set up session based protections by passing the
-`:session` option:
-
-```ruby
-use Rack::Session::Pool
-set :protection, :session => true
-```
+has been enabled.
 
 ### Available Settings
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ pick up if available.
     * [Filters](#filters)
     * [Helpers](#helpers)
         * [Using Sessions](#using-sessions)
+        	* [Choosing Your Own Session Middleware](#choosing-your-own-session-middleware)
         * [Halting](#halting)
         * [Passing](#passing)
         * [Triggering Another Route](#triggering-another-route)
@@ -1377,25 +1378,6 @@ get '/:value' do
 end
 ```
 
-Note that `enable :sessions` actually stores all data in a cookie. This
-might not always be what you want (storing lots of data will increase your
-traffic, for instance). You can use any Rack session middleware: in order to
-do so, do **not** call `enable :sessions`, but instead call `set
-:sessions` with your middleware of choice passed in as the value for
-`:session_store` along with any other options:
-
-```ruby
-set :sessions, :session_store => Rack::Session::Pool, :expire_after => 2592000
-
-get '/' do
-  "value = " << session[:value].inspect
-end
-
-get '/:value' do
-  session['value'] = params['value']
-end
-```
-
 To improve security, the session data in the cookie is signed with a session
 secret. A random secret is generated for you by Sinatra. However, since this
 secret will change with every start of your application, you might want to
@@ -1417,6 +1399,40 @@ domain with a *.* like this instead:
 
 ```ruby
 set :sessions, :domain => '.foo.com'
+```
+
+#### Choosing Your Own Session Middleware
+
+Note that `enable :sessions` actually stores all data in a cookie. This
+might not always be what you want (storing lots of data will increase your
+traffic, for instance). You can use any Rack session middleware: in order to
+do so, one of the following methods can be used:
+
+```ruby
+enable :sessions
+set :session_store, Rack::Session::Pool
+```
+
+Or to enable sessions with a hash of options:
+
+```ruby
+set :sessions, :expire_after => 2592000
+set :session_store, Rack::Session::Pool
+```
+
+Another option is to **not** call `enable :sessions`, but instead pull in your
+middleware of choice as you would any other middleware:
+
+```ruby
+use Rack::Session::Pool, :expire_after => 2592000
+```
+
+It is important to note that when using this method, session based protection (see 'Configuring attack protection') will not be enabled by default. The Rack middleware to do that will also need to be added:
+
+```ruby
+use Rack::Session::Pool, :expire_after => 2592000
+use Rack::Protection::RemoteToken
+use Rack::Protection::SessionHijacking
 ```
 
 ### Halting
@@ -2099,7 +2115,7 @@ set :protection, :except => [:path_traversal, :session_hijacking]
 ```
 
 By default, Sinatra will only set up session based protection if `:sessions`
-has been enabled.
+have been enabled. See 'Using Sessions'.
 
 ### Available Settings
 
@@ -2229,6 +2245,9 @@ has been enabled.
     Enable cookie-based sessions support using <tt>Rack::Session::Cookie</tt>.
     See 'Using Sessions' section for more information.
   </dd>
+
+  <dt>session_store</dt>
+  <dd>The Rack session middleware used. Defaults to <tt>Rack::Session::Cookie</tt>. See 'Using Sessions' section for more information.</dd>
 
   <dt>show_exceptions</dt>
   <dd>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1709,7 +1709,6 @@ module Sinatra
         options = {}
         options[:secret] = session_secret if session_secret?
         options.merge! sessions.to_hash if sessions.respond_to? :to_hash
-        session_store = options.delete(:session_store) { Rack::Session::Cookie }
         builder.use session_store, options
       end
 
@@ -1782,6 +1781,7 @@ module Sinatra
     set :dump_errors, Proc.new { !test? }
     set :show_exceptions, Proc.new { development? }
     set :sessions, false
+    set :session_store, Rack::Session::Cookie
     set :logging, false
     set :protection, true
     set :method_override, false

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1709,7 +1709,8 @@ module Sinatra
         options = {}
         options[:secret] = session_secret if session_secret?
         options.merge! sessions.to_hash if sessions.respond_to? :to_hash
-        builder.use Rack::Session::Cookie, options
+        session_store = options.delete(:session_store) { Rack::Session::Cookie }
+        builder.use session_store, options
       end
 
       def detect_rack_handler

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -565,6 +565,14 @@ class SettingsTest < Minitest::Test
       end
     end
 
+    it 'sets up RemoteToken if sessions are enabled with a custom session store' do
+      MiddlewareTracker.track do
+        Sinatra.new { set :sessions, :session_store => Rack::Session::Pool }.new
+        assert_include MiddlewareTracker.used, Rack::Session::Pool
+        assert_include MiddlewareTracker.used, Rack::Protection::RemoteToken
+      end
+    end
+
     it 'does not set up RemoteToken if sessions are disabled' do
       MiddlewareTracker.track do
         Sinatra.new.new

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -567,7 +567,10 @@ class SettingsTest < Minitest::Test
 
     it 'sets up RemoteToken if sessions are enabled with a custom session store' do
       MiddlewareTracker.track do
-        Sinatra.new { set :sessions, :session_store => Rack::Session::Pool }.new
+        Sinatra.new {
+          enable :sessions
+          set :session_store, Rack::Session::Pool
+        }.new
         assert_include MiddlewareTracker.used, Rack::Session::Pool
         assert_include MiddlewareTracker.used, Rack::Protection::RemoteToken
       end


### PR DESCRIPTION
By setting the session middleware as an option, rack protection for
sessions will be enabled by default and other session settings will be
applied to the middleware. Fixes #1038.

Example:

```
 set :sessions, :session_store => Rack::Session::Pool, :expire_after => 2592000
```