### PR TITLE
Fix authenticity token compatibility with Rails

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -70,7 +70,7 @@ module Rack
 
       def accepts?(env)
         session = session env
-        session[:csrf] ||= self.class.random_token(token_length)
+        session[:csrf] ||= session.fetch(:_csrf_token) { session[:_csrf_token] = self.class.random_token(token_length) }
 
         safe?(env) ||
           valid_token?(session, env['HTTP_X_CSRF_TOKEN']) ||

--- a/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
@@ -56,6 +56,7 @@ describe Rack::Protection::AuthenticityToken do
   it "sets a new csrf token for the session in env, even after a 'safe' request" do
     get('/', {}, {})
     expect(env['rack.session'][:csrf]).not_to be_nil
+    expect(env['rack.session'][:_csrf_token]).not_to be_nil
   end
 
   describe ".random_token" do


### PR DESCRIPTION
In aac8e3bce4d5c1be211fe25a1ea012572b841df8, I accidently introduced a regression by breaking Rails compatibility with authenticity token protection. Rails sets the authenticity token in session[:_csrf_token] so if that is set, it should be used as the value for session[:csrf].

I've added a regression test to help prevent that from happening again.