### PR TITLE
Make authenticity token length a fixed value

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -12,65 +12,28 @@ module Rack
     # Only accepts unsafe HTTP requests if a given access token matches the token
     # included in the session.
     #
-    # Compatible with Rails and rack-csrf.
+    # Compatible with rack-csrf.
     #
     # Options:
     #
     # authenticity_param: Defines the param's name that should contain the token on a request.
-    #
     class AuthenticityToken < Base
+      TOKEN_LENGTH = 32
+
       default_options :authenticity_param => 'authenticity_token',
-                      :authenticity_token_length => 32,
                       :allow_if => nil
 
-      class << self
-        def token(session)
-          mask_token(session[:csrf])
-        end
+      def self.token(session)
+        self.new(nil).mask_authenticity_token(session)
+      end
 
-        def random_token(length = 32)
-          SecureRandom.base64(length)
-        end
-
-        # Creates a masked version of the authenticity token that varies
-        # on each request. The masking is used to mitigate SSL attacks
-        # like BREACH.
-        def mask_token(token)
-          token = decode_token(token)
-          one_time_pad = SecureRandom.random_bytes(token.length)
-          encrypted_token = xor_byte_strings(one_time_pad, token)
-          masked_token = one_time_pad + encrypted_token
-          encode_token masked_token
-        end
-
-        # Essentially the inverse of +mask_token+.
-        def unmask_decoded_token(masked_token)
-          # Split the token into the one-time pad and the encrypted
-          # value and decrypt it
-          token_length = masked_token.length / 2
-          one_time_pad = masked_token[0...token_length]
-          encrypted_token = masked_token[token_length..-1]
-          xor_byte_strings(one_time_pad, encrypted_token)
-        end
-
-        def encode_token(token)
-          Base64.strict_encode64(token)
-        end
-
-        def decode_token(token)
-          Base64.strict_decode64(token)
-        end
-
-        private
-
-        def xor_byte_strings(s1, s2)
-          s1.bytes.zip(s2.bytes).map { |(c1,c2)| c1 ^ c2 }.pack('c*')
-        end
+      def self.random_token
+        SecureRandom.base64(TOKEN_LENGTH)
       end
 
       def accepts?(env)
         session = session env
-        session[:csrf] ||= self.class.random_token(token_length)
+        set_token(session)
 
         safe?(env) ||
           valid_token?(session, env['HTTP_X_CSRF_TOKEN']) ||
@@ -78,10 +41,15 @@ module Rack
           ( options[:allow_if] && options[:allow_if].call(env) )
       end
 
+      def mask_authenticity_token(session)
+        token = set_token(session)
+        mask_token(token)
+      end
+
       private
 
-      def token_length
-        options[:authenticity_token_length]
+      def set_token(session)
+        session[:csrf] ||= self.class.random_token
       end
 
       # Checks the client's masked token to see if it matches the
@@ -90,7 +58,7 @@ module Rack
         return false if token.nil? || token.empty?
 
         begin
-          token = self.class.decode_token(token)
+          token = decode_token(token)
         rescue ArgumentError # encoded_masked_token is invalid Base64
           return false
         end
@@ -102,7 +70,7 @@ module Rack
           compare_with_real_token token, session
 
         elsif masked_token?(token)
-          token = self.class.unmask_decoded_token(token)
+          token = unmask_token(token)
 
           compare_with_real_token token, session
 
@@ -111,12 +79,33 @@ module Rack
         end
       end
 
+      # Creates a masked version of the authenticity token that varies
+      # on each request. The masking is used to mitigate SSL attacks
+      # like BREACH.
+      def mask_token(token)
+        token = decode_token(token)
+        one_time_pad = SecureRandom.random_bytes(token.length)
+        encrypted_token = xor_byte_strings(one_time_pad, token)
+        masked_token = one_time_pad + encrypted_token
+        encode_token(masked_token)
+      end
+
+      # Essentially the inverse of +mask_token+.
+      def unmask_token(masked_token)
+        # Split the token into the one-time pad and the encrypted
+        # value and decrypt it
+        token_length = masked_token.length / 2
+        one_time_pad = masked_token[0...token_length]
+        encrypted_token = masked_token[token_length..-1]
+        xor_byte_strings(one_time_pad, encrypted_token)
+      end
+
       def unmasked_token?(token)
-        token.length == token_length
+        token.length == TOKEN_LENGTH
       end
 
       def masked_token?(token)
-        token.length == token_length * 2
+        token.length == TOKEN_LENGTH * 2
       end
 
       def compare_with_real_token(token, session)
@@ -124,7 +113,19 @@ module Rack
       end
 
       def real_token(session)
-        self.class.decode_token(session[:csrf])
+        decode_token(session[:csrf])
+      end
+
+      def encode_token(token)
+        Base64.strict_encode64(token)
+      end
+
+      def decode_token(token)
+        Base64.strict_decode64(token)
+      end
+
+      def xor_byte_strings(s1, s2)
+        s1.bytes.zip(s2.bytes).map { |(c1,c2)| c1 ^ c2 }.pack('c*')
       end
     end
   end

--- a/rack-protection/lib/rack/protection/form_token.rb
+++ b/rack-protection/lib/rack/protection/form_token.rb
@@ -13,7 +13,7 @@ module Rack
     # This middleware is not used when using the Rack::Protection collection,
     # since it might be a security issue, depending on your application
     #
-    # Compatible with Rails and rack-csrf.
+    # Compatible with rack-csrf.
     class FormToken < AuthenticityToken
       def accepts?(env)
         env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest" or super

--- a/rack-protection/lib/rack/protection/remote_token.rb
+++ b/rack-protection/lib/rack/protection/remote_token.rb
@@ -10,7 +10,7 @@ module Rack
     # Only accepts unsafe HTTP requests if a given access token matches the token
     # included in the session *or* the request comes from the same origin.
     #
-    # Compatible with Rails and rack-csrf.
+    # Compatible with rack-csrf.
     class RemoteToken < AuthenticityToken
       default_reaction :deny
 

--- a/rack-protection/spec/lib/rack/protection/form_token_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/form_token_spec.rb
@@ -1,6 +1,7 @@
 describe Rack::Protection::FormToken do
   let(:token) { described_class.random_token }
-  let(:bad_token) { described_class.random_token }
+  let(:masked_token) { described_class.token(session) }
+  let(:bad_token) { Base64.strict_encode64("badtoken") }
   let(:session) { {:csrf => token} }
 
   it_behaves_like "any rack application"
@@ -15,7 +16,7 @@ describe Rack::Protection::FormToken do
   end
 
   it "accepts post requests with masked X-CSRF-Token header" do
-    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => Rack::Protection::FormToken.token(session))
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => masked_token)
     expect(last_response).to be_ok
   end
 
@@ -30,7 +31,7 @@ describe Rack::Protection::FormToken do
   end
 
   it "accepts post form requests with masked authenticity_token field" do
-    post('/', {"authenticity_token" => Rack::Protection::FormToken.token(session)}, 'rack.session' => session)
+    post('/', {"authenticity_token" => masked_token}, 'rack.session' => session)
     expect(last_response).to be_ok
   end
 

--- a/rack-protection/spec/lib/rack/protection/remote_token_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/remote_token_spec.rb
@@ -1,6 +1,7 @@
 describe Rack::Protection::RemoteToken do
   let(:token) { described_class.random_token }
-  let(:bad_token) { described_class.random_token }
+  let(:masked_token) { described_class.token(session) }
+  let(:bad_token) { Base64.strict_encode64("badtoken") }
   let(:session) { {:csrf => token} }
 
   it_behaves_like "any rack application"
@@ -26,7 +27,7 @@ describe Rack::Protection::RemoteToken do
 
   it "accepts post requests with a remote referrer and masked X-CSRF-Token header" do
     post('/', {}, 'HTTP_REFERER' => 'http://example.com/foo', 'HTTP_HOST' => 'example.org',
-      'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => Rack::Protection::RemoteToken.token(session))
+      'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => masked_token)
     expect(last_response).to be_ok
   end
 
@@ -43,7 +44,7 @@ describe Rack::Protection::RemoteToken do
   end
 
   it "accepts post form requests with a remote referrer and masked authenticity_token field" do
-    post('/', {"authenticity_token" => Rack::Protection::RemoteToken.token(session)}, 'HTTP_REFERER' => 'http://example.com/foo',
+    post('/', {"authenticity_token" => masked_token}, 'HTTP_REFERER' => 'http://example.com/foo',
       'HTTP_HOST' => 'example.org', 'rack.session' => session)
     expect(last_response).to be_ok
   end


### PR DESCRIPTION
Adds a new configurable option `:csrf_key` that allows the csrf session key to be configured to be shared with other frameworks. 

For instance it could be changed to `:_csrf_token` to be compatible with Rails. This way Sinatra forms could be sent to Rails actions and pass CSRF protection and vice versa (as long as the session is shared).

`use Rack::Protection, :csrf_key => :_csrf_token`

@zzak let me know if you think any option names or method names need changed. I also tried to reduce the public API a bit in this update.
