### PR TITLE
getter/setter always exist

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1262,8 +1262,8 @@ module Sinatra
           end
         end
 
-        define_singleton("#{option}=", setter) if setter
-        define_singleton(option, getter) if getter
+        define_singleton("#{option}=", setter)
+        define_singleton(option, getter)
         define_singleton("#{option}?", "!!#{option}") unless method_defined? "#{option}?"
         self
       end


### PR DESCRIPTION
Before 0fb73fc2be624beaacc640264640c64b8f59376d, the getter maybe set nil in case statement. But now it is just replaced with value.inspect. So it always exists, no need to check. Same to setter.
