### PR TITLE
Updated test:coverage rake task to use simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg
 /doc/api
 /Gemfile.lock
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ if RUBY_ENGINE == "ruby"
   gem 'sass'
   gem 'reel-rack'
   gem 'celluloid', '~> 0.16.0'
+  gem 'simplecov', require: false
 end
 
 if RUBY_ENGINE == "rbx"

--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,8 @@ namespace :test do
   desc 'Measures test coverage'
   task :coverage do
     rm_f "coverage"
-    sh "rcov -Ilib test/*_test.rb"
+    ENV['COVERAGE'] = '1'
+    Rake::Task['test'].invoke
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,12 @@
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/test/'
+    add_group 'sinatra-contrib', 'sinatra-contrib'
+    add_group 'rack-protection', 'rack-protection'
+  end
+end
+
 ENV['APP_ENV'] = 'test'
 Encoding.default_external = "UTF-8" if defined? Encoding
 


### PR DESCRIPTION
Right now the test:coverage task is expecting to use rcov, so I've updated it to use simplecov instead. Hopefully that's helpful.

As a follow up I could look into sending the coverage info to codeclimate or coveralls as part of the CI build.
