### PR TITLE
Drop symbolization in #generate_method

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1624,7 +1624,6 @@ module Sinatra
       end
 
       def generate_method(method_name, &block)
-        method_name = method_name.to_sym
         define_method(method_name, &block)
         method = instance_method method_name
         remove_method method_name


### PR DESCRIPTION
JRuby-9.1.0 seems to fix [this problem](https://github.com/jruby/jruby/issues/1285).