### PR TITLE
Modernize Rack::Protection::ContentSecurityPolicy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ source 'https://rubygems.org' unless ENV['QUICK']
 gemspec
 
 gem 'rake'
-gem 'rack', github: 'rack/rack'
+gem 'rack', git: 'https://github.com/rack/rack.git'
 gem 'rack-test', '>= 0.6.2'
 gem "minitest", "~> 5.0"
 

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -6,58 +6,73 @@ module Rack
     ##
     # Prevented attack::   XSS and others
     # Supported browsers:: Firefox 23+, Safari 7+, Chrome 25+, Opera 15+
-    #                      http://caniuse.com/contentsecuritypolicy
-    # More infos::         http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-    #                      http://content-security-policy.com/
     #
-    # Sets Content-Security-Policy-Report(-Only) header to tell the browser what resource are allowed to load from which domain.
+    # Description:: Content Security Policy, a mechanism web applications
+    #               can use to mitigate a broad class of content injection
+    #               vulnerabilities, such as cross-site scripting (XSS).
+    #               Content Security Policy is a declarative policy that lets
+    #               the authors (or server administrators) of a web application
+    #               inform the client about the sources from which the
+    #               application expects to load resources.
     #
-    # Options:
-    # (descriptions taken from http://www.html5rocks.com/en/tutorials/security/content-security-policy/)
+    # More info::   W3C CSP Level 1 : https://www.w3.org/TR/CSP1/ (deprecated)
+    #               W3C CSP Level 2 : https://www.w3.org/TR/CSP2/ (current)
+    #               W3C CSP Level 3 : https://www.w3.org/TR/CSP3/ (draft)
+    #               https://developer.mozilla.org/en-US/docs/Web/Security/CSP
+    #               http://caniuse.com/#search=ContentSecurityPolicy
+    #               http://content-security-policy.com/
+    #               https://securityheaders.io
+    #               https://scotthelme.co.uk/csp-cheat-sheet/
+    #               http://www.html5rocks.com/en/tutorials/security/content-security-policy/
     #
-    # connect_src:: limits the origins to which you can connect (via XHR,
-    #               WebSockets, and EventSource).
+    # Sets the 'Content-Security-Policy[-Report-Only]' header.
     #
-    # font_src::    specifies the origins that can serve web fonts. Google’s 
-    #               Web Fonts could be enabled via font-src 
-    #               https://themes.googleusercontent.com
+    # Options: ContentSecurityPolicy configuration is a complex topic with
+    #          several levels of support that has evolved over time.
+    #          See the W3C documentation and the links in the more info
+    #          section for CSP usage examples and best practices. The
+    #          CSP3 directives in the 'NO_ARG_DIRECTIVES' constant need to be
+    #          presented in the options hash with a boolean 'true' in order
+    #          to be used in a policy.
     #
-    # frame_src::   lists the origins that can be embedded as frames. For 
-    #               example: frame-src https://youtube.com would enable
-    #               embedding YouTube videos, but no other origins.
-    #
-    # img_src::     defines the origins from which images can be loaded.
-    #
-    # media_src::   restricts the origins allowed to deliver video and audio.
-    #
-    # object_src::  allows control over Flash and other plugins.
-    #
-    # style_src::   is script-src’s counterpart for stylesheets.
-    #
-    # report_uri::  instruct the browser to POST JSON-formatted violation 
-    #               reports to a location specified in a report-uri directive.
-    #
-    # report_only:: ask the browser to monitor a policy, reporting violations,
-    #               but not enforcing the restrictions.
-    #
-    # sandbox::     if the sandbox directive is present, the page will be 
-    #               treated as though it was loaded inside of an iframe with
-    #               a sandbox attribute.
     class ContentSecurityPolicy < Base
-      default_options :default_src => :none, :script_src => "'self'", :img_src => "'self'", :style_src => "'self'", :connect_src => "'self'", :report_only => false
+      default_options default_src: :none, script_src: "'self'",
+                      img_src: "'self'", style_src: "'self'",
+                      connect_src: "'self'", report_only: false
 
-      KEYS = [:default_src, :script_src, :connect_src, :font_src, :frame_src, :img_src, :media_src, :style_src, :object_src, :report_uri, :sandbox]
+      DIRECTIVES = [:base_uri, :child_src, :connect_src, :default_src,
+                    :font_src, :form_action, :frame_ancestors, :frame_src,
+                    :img_src, :manifest_src, :media_src, :object_src,
+                    :plugin_types, :referrer, :reflected_xss, :report_to,
+                    :report_uri, :require_sri_for, :sandbox, :script_src,
+                    :style_src, :worker_src].freeze
 
-      def collect_options
-        KEYS.collect do |k|
-          "#{k.to_s.sub(/_/, '-')} #{options[k]}" if options.key?(k)
-        end.compact.join('; ')
+      NO_ARG_DIRECTIVES = [:block_all_mixed_content, :disown_opener,
+                           :upgrade_insecure_requests].freeze
+
+      def csp_policy
+        directives = []
+
+        DIRECTIVES.each do |d|
+          if options.key?(d)
+            directives << "#{d.to_s.sub(/_/, '-')} #{options[d]}"
+          end
+        end
+
+        # Set these key values to boolean 'true' to include in policy
+        NO_ARG_DIRECTIVES.each do |d|
+          if options.key?(d) && options[d].is_a?(TrueClass)
+            directives << d.to_s.sub(/_/, '-')
+          end
+        end
+
+        directives.compact.sort.join('; ')
       end
 
       def call(env)
         status, headers, body = @app.call(env)
         header = options[:report_only] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy'
-        headers[header] ||= collect_options if html? headers
+        headers[header] ||= csp_policy if html? headers
         [status, headers, body]
       end
     end

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -40,15 +40,15 @@ module Rack
                       img_src: "'self'", style_src: "'self'",
                       connect_src: "'self'", report_only: false
 
-      DIRECTIVES = [:base_uri, :child_src, :connect_src, :default_src,
-                    :font_src, :form_action, :frame_ancestors, :frame_src,
-                    :img_src, :manifest_src, :media_src, :object_src,
-                    :plugin_types, :referrer, :reflected_xss, :report_to,
-                    :report_uri, :require_sri_for, :sandbox, :script_src,
-                    :style_src, :worker_src].freeze
+      DIRECTIVES = %i(base_uri child_src connect_src default_src
+                      font_src form_action frame_ancestors frame_src
+                      img_src manifest_src media_src object_src
+                      plugin_types referrer reflected_xss report_to
+                      report_uri require_sri_for sandbox script_src
+                      style_src worker_src).freeze
 
-      NO_ARG_DIRECTIVES = [:block_all_mixed_content, :disown_opener,
-                           :upgrade_insecure_requests].freeze
+      NO_ARG_DIRECTIVES = %i(block_all_mixed_content disown_opener
+                             upgrade_insecure_requests).freeze
 
       def csp_policy
         directives = []

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -4,7 +4,7 @@ describe Rack::Protection::ContentSecurityPolicy do
   it 'should set the Content Security Policy' do
     expect(
       get('/', {}, 'wants' => 'text/html').headers["Content-Security-Policy"]
-    ).to eq("default-src none; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'")
+    ).to eq("connect-src 'self'; default-src none; img-src 'self'; script-src 'self'; style-src 'self'")
   end
 
   it 'should not set the Content Security Policy for other content types' do
@@ -21,8 +21,30 @@ describe Rack::Protection::ContentSecurityPolicy do
     end
 
     headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers["Content-Security-Policy"]).to eq("default-src none; script-src https://cdn.mybank.net; connect-src https://api.mybank.com; font-src https://cdn.mybank.net; frame-src self; img-src https://cdn.mybank.net; media-src https://cdn.mybank.net; style-src https://cdn.mybank.net; object-src https://cdn.mybank.net; report-uri /my_amazing_csp_report_parser; sandbox allow-scripts")
+    expect(headers["Content-Security-Policy"]).to eq("connect-src https://api.mybank.com; default-src none; font-src https://cdn.mybank.net; frame-src self; img-src https://cdn.mybank.net; media-src https://cdn.mybank.net; object-src https://cdn.mybank.net; report-uri /my_amazing_csp_report_parser; sandbox allow-scripts; script-src https://cdn.mybank.net; style-src https://cdn.mybank.net")
     expect(headers["Content-Security-Policy-Report-Only"]).to be_nil
+  end
+
+  it 'should allow setting CSP3 no arg directives' do
+    mock_app do
+      use Rack::Protection::ContentSecurityPolicy, :block_all_mixed_content => true, :disown_opener => true, :upgrade_insecure_requests => true
+
+      run DummyApp
+    end
+
+    headers = get('/', {}, 'wants' => 'text/html').headers
+    expect(headers["Content-Security-Policy"]).to eq("block-all_mixed_content; connect-src 'self'; default-src none; disown-opener; img-src 'self'; script-src 'self'; style-src 'self'; upgrade-insecure_requests")
+  end
+
+  it 'should ignore CSP3 no arg directives unless they are set to true' do
+    mock_app do
+      use Rack::Protection::ContentSecurityPolicy, :block_all_mixed_content => false, :disown_opener => 'false', :upgrade_insecure_requests => 'foo'
+
+      run DummyApp
+    end
+
+    headers = get('/', {}, 'wants' => 'text/html').headers
+    expect(headers["Content-Security-Policy"]).to eq("connect-src 'self'; default-src none; img-src 'self'; script-src 'self'; style-src 'self'")
   end
 
   it 'should allow changing report only' do
@@ -34,7 +56,7 @@ describe Rack::Protection::ContentSecurityPolicy do
 
     headers = get('/', {}, 'wants' => 'text/html').headers
     expect(headers["Content-Security-Policy"]).to be_nil
-    expect(headers["Content-Security-Policy-Report-Only"]).to eq("default-src none; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri /my_amazing_csp_report_parser")
+    expect(headers["Content-Security-Policy-Report-Only"]).to eq("connect-src 'self'; default-src none; img-src 'self'; report-uri /my_amazing_csp_report_parser; script-src 'self'; style-src 'self'")
   end
 
   it 'should not override the header if already set' do


### PR DESCRIPTION
Issue #1201 Modernizes Rack::Protection::ContentSecurityPolicy to support current CSP2 and CSP3 directives.

Issue #1200 Fixes a minor security warning on `bundle install` in a fresh repo.

Removes inline docs which were incomplete and insufficient for what is now
quite complex in CSP2 and CSP3. Adds additional current links to excellent
doc resources and tools.