### PR TITLE
Initialize middleware before first request, as is the case with direct Rack usage. Fixes #1205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
  * Ensure template is cached only once #1021 by Patrik Rak.
 
+ * Rack middleware is initialized at server runtime rather than after receiving first request #1205 by Itamar Turner-Trauring.
+
 ## 1.4.7 / 2016-01-24
 
  * Add Ashley Williams, Trevor Bramble, and Kashyap Kondamudi to team Sinatra.

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 # external dependencies
@@ -1532,6 +1533,10 @@ module Sinatra
 
       # Starts the server by running the Rack Handler.
       def start_server(handler, server_settings, handler_name)
+        # Ensure we initialize middleware before startup, to match standard Rack
+        # behavior, by ensuring an instance exists:
+        prototype
+        # Run the instance we created:
         handler.run(self, server_settings) do |server|
           unless supress_messages?
             $stderr.puts "== Sinatra (v#{Sinatra::VERSION}) has taken the stage on #{port} for #{environment} with backup from #{handler_name}"

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -54,6 +54,25 @@ class ServerTest < Minitest::Test
     @app.run! :server => %w[foo bar mock]
   end
 
+  it "initializes Rack middleware immediately on server run" do
+    class MyMiddleware
+      @@initialized = false
+      def initialize(app)
+        @@initialized = true
+      end
+      def self.initialized
+        @@initialized
+      end
+      def call(env)
+      end
+    end
+
+    @app.use MyMiddleware
+    assert_equal(MyMiddleware.initialized, false)
+    @app.run!
+    assert_equal(MyMiddleware.initialized, true)
+  end
+
   describe "Quiet mode" do
     it "sends data to stderr when server starts and stops" do
       @app.run!


### PR DESCRIPTION
Fix for #1205, with test and changelog entry.