### PR TITLE
Adds preload option to Rack:Protection:StrictTransport

### DIFF
--- a/rack-protection/lib/rack/protection/strict_transport.rb
+++ b/rack-protection/lib/rack/protection/strict_transport.rb
@@ -15,14 +15,16 @@ module Rack
     #
     # max_age:: How long future requests to the domain should go over HTTPS; specified in seconds
     # include_subdomains:: If all present and future subdomains will be HTTPS
+    # preload:: Allow this domain to be included in browsers HSTS preload list. See https://hstspreload.appspot.com/
 
     class StrictTransport < Base
-      default_options :max_age => 31_536_000, :include_subdomains => false
+      default_options :max_age => 31_536_000, :include_subdomains => false, :preload => false
 
       def strict_transport
         @strict_transport ||= begin
           strict_transport = 'max-age=' + options[:max_age].to_s
           strict_transport += '; includeSubDomains' if options[:include_subdomains]
+          strict_transport += '; preload' if options[:preload]
           strict_transport.to_str
         end
       end

--- a/rack-protection/spec/lib/rack/protection/strict_transport_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/strict_transport_spec.rb
@@ -22,4 +22,22 @@ describe Rack::Protection::StrictTransport do
 
     expect(get('/', {}, 'wants' => 'text/html').headers["Strict-Transport-Security"]).to eq("max-age=31536000; includeSubDomains")
   end
+
+  it 'should allow switching on the preload option' do
+    mock_app do
+      use Rack::Protection::StrictTransport, :preload => true
+      run DummyApp
+    end
+
+    expect(get('/', {}, 'wants' => 'text/html').headers["Strict-Transport-Security"]).to eq("max-age=31536000; preload")
+  end
+
+  it 'should allow switching on all the options' do
+    mock_app do
+      use Rack::Protection::StrictTransport, :preload => true, :include_subdomains => true
+      run DummyApp
+    end
+
+    expect(get('/', {}, 'wants' => 'text/html').headers["Strict-Transport-Security"]).to eq("max-age=31536000; includeSubDomains; preload")
+  end
 end


### PR DESCRIPTION
The preload option allows the domain to be included in browsers HSTS preload list. See https://hstspreload.appspot.com/