### PR TITLE
⚠️ constant ::Fixnum is deprecated

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1088,8 +1088,8 @@ module Sinatra
     def invoke
       res = catch(:halt) { yield }
 
-      res = [res] if Fixnum === res or String === res
-      if Array === res and Fixnum === res.first
+      res = [res] if Integer === res or String === res
+      if Array === res and Integer === res.first
         res = res.dup
         status(res.shift)
         body(res.pop)
@@ -1253,7 +1253,7 @@ module Sinatra
         case value
         when Proc
           getter = value
-        when Symbol, Fixnum, FalseClass, TrueClass, NilClass
+        when Symbol, Integer, FalseClass, TrueClass, NilClass
           getter = value.inspect
         when Hash
           setter = proc do |val|


### PR DESCRIPTION
Here's a fix for Ruby 2.4 warnings.

Note that this patch slightly changes the behavior.
The previous code was ignoring Bignum values both in `invoke()` and `set()`.
But I suppose that was not intentional.