### PR TITLE
remove warnings and deprecated methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ if RUBY_ENGINE == "ruby"
   gem 'stylus'
   gem 'rabl'
   gem 'builder'
-  gem 'erubis'
   gem 'haml', '>= 3.0'
   gem 'sass'
   gem 'reel-rack'

--- a/README.de.md
+++ b/README.de.md
@@ -570,12 +570,11 @@ get('/') { markdown :index }
 <table>
   <tr>
     <td>Abhängigkeit</td>
-    <td><a href="http://www.kuwata-lab.com/erubis/">erubis</a> oder erb
-    (Standardbibliothek von Ruby)</td>
+    <td>erb aus Rubys Standardbibliothek</td>
   </tr>
   <tr>
     <td>Dateierweiterungen</td>
-    <td><tt>.erb</tt>, <tt>.rhtml</tt> oder <tt>.erubis</tt> (nur Erubis)</td>
+    <td><tt>.erb</tt> oder <tt>.rhtml</tt></td>
   </tr>
   <tr>
     <td>Beispiel</td>

--- a/README.md
+++ b/README.md
@@ -589,14 +589,11 @@ get('/') { markdown :index }
 <table>
   <tr>
     <td>Dependency</td>
-    <td>
-      <a href="http://www.kuwata-lab.com/erubis/" title="erubis">erubis</a>
-      or erb (included in Ruby)
-    </td>
+    <td>erb (included in Ruby)</td>
   </tr>
   <tr>
     <td>File Extensions</td>
-    <td><tt>.erb</tt>, <tt>.rhtml</tt> or <tt>.erubis</tt> (Erubis only)</td>
+    <td><tt>.erb</tt> or <tt>.rhtml</tt></td>
   </tr>
   <tr>
     <td>Example</td>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -937,12 +937,6 @@ module Sinatra
       self.class.settings
     end
 
-    def options
-      warn "Sinatra::Base#options is deprecated and will be removed, " \
-        "use #settings instead."
-      settings
-    end
-
     # Exit the current block, halts any further processing
     # of the request, and returns the specified response.
     def halt(*response)
@@ -1179,12 +1173,6 @@ module Sinatra
         /src\/kernel\/bootstrap\/[A-Z]/                     # maglev kernel files
       ]
 
-      # contrary to what the comment said previously, rubinius never supported this
-      if defined?(RUBY_IGNORE_CALLERS)
-        warn "RUBY_IGNORE_CALLERS is deprecated and will no longer be supported by Sinatra 2.0"
-        CALLERS_TO_IGNORE.concat(RUBY_IGNORE_CALLERS)
-      end
-
       attr_reader :routes, :filters, :templates, :errors
 
       # Removes all routes, filters, middleware and extension hooks from the
@@ -1370,11 +1358,6 @@ module Sinatra
       # block returns false.
       def condition(name = "#{caller.first[/`.*'/]} condition", &block)
         @conditions << generate_method(name, &block)
-      end
-
-      def public=(value)
-        warn ":public is no longer used to avoid overloading Module#public, use :public_folder or :public_dir instead"
-        set(:public_folder, value)
       end
 
       def public_dir=(value)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 # external dependencies

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -675,12 +675,6 @@ module Sinatra
       render(:erb, template, options, locals, &block)
     end
 
-    def erubis(template, options = {}, locals = {})
-      warn "Sinatra::Templates#erubis is deprecated and will be removed, use #erb instead.\n" \
-        "If you have Erubis installed, it will be used automatically."
-      render :erubis, template, options, locals
-    end
-
     def haml(template, options = {}, locals = {}, &block)
       render(:haml, template, options, locals, &block)
     end

--- a/test/compile_test.rb
+++ b/test/compile_test.rb
@@ -1,4 +1,3 @@
-# I like coding: UTF-8
 require File.expand_path('../helper', __FILE__)
 
 class CompileTest < Minitest::Test

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require File.expand_path('../helper', __FILE__)
 require 'erb'
 

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -104,13 +104,3 @@ class ERBTest < Minitest::Test
     assert_body "<h1>Title</h1>\n<h2>Subtitle</h2>\n<p>Contents.</p>\n"
   end
 end
-
-
-begin
-  require 'erubis'
-  class ErubisTest < ERBTest
-    def engine; Tilt::ErubisTemplate end
-  end
-rescue LoadError
-  warn "#{$!.to_s}: skipping erubis tests"
-end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -424,7 +424,7 @@ class HelpersTest < Minitest::Test
 
       get '/'
       assert_equal 404, status
-      assert_equal nil, response.headers['X-Cascade']
+      assert_nil response.headers['X-Cascade']
     end
   end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -81,7 +81,7 @@ class RoutingTest < Minitest::Test
     }
     get '/bar'
     assert_equal 404, status
-    assert_equal nil, response.headers['X-Cascade']
+    assert_nil response.headers['X-Cascade']
   end
 
 

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -162,8 +162,7 @@ class StaticTest < Minitest::Test
         response.status,
         "Invalid range '#{http_range}' should be ignored"
       )
-      assert_equal(
-        nil,
+      assert_nil(
         response['Content-Range'],
         "Invalid range '#{http_range}' should be ignored"
       )


### PR DESCRIPTION
Here are a couple of commits that may or may not be a good idea to pull.

I removed deprecated methods and erubis and made the tests ready for Minitest 6.