### PR TITLE
Fix warnings `Use assert_nil if expecting nil from ...`

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -424,7 +424,7 @@ class HelpersTest < Minitest::Test
 
       get '/'
       assert_equal 404, status
-      assert_equal nil, response.headers['X-Cascade']
+      assert_nil response.headers['X-Cascade']
     end
   end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -81,7 +81,7 @@ class RoutingTest < Minitest::Test
     }
     get '/bar'
     assert_equal 404, status
-    assert_equal nil, response.headers['X-Cascade']
+    assert_nil response.headers['X-Cascade']
   end
 
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -468,8 +468,8 @@ class SettingsTest < Minitest::Test
 
   describe 'root' do
     it 'is nil if app_file is not set' do
-      assert @base.root.nil?
-      assert @application.root.nil?
+      assert_nil @base.root
+      assert_nil @application.root
     end
 
     it 'is equal to the expanded basename of app_file' do
@@ -483,8 +483,8 @@ class SettingsTest < Minitest::Test
 
   describe 'views' do
     it 'is nil if root is not set' do
-      assert @base.views.nil?
-      assert @application.views.nil?
+      assert_nil @base.views
+      assert_nil @application.views
     end
 
     it 'is set to root joined with views/' do
@@ -498,8 +498,8 @@ class SettingsTest < Minitest::Test
 
   describe 'public_folder' do
     it 'is nil if root is not set' do
-      assert @base.public_folder.nil?
-      assert @application.public_folder.nil?
+      assert_nil @base.public_folder
+      assert_nil @application.public_folder
     end
 
     it 'is set to root joined with public/' do

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -162,8 +162,7 @@ class StaticTest < Minitest::Test
         response.status,
         "Invalid range '#{http_range}' should be ignored"
       )
-      assert_equal(
-        nil,
+      assert_nil(
         response['Content-Range'],
         "Invalid range '#{http_range}' should be ignored"
       )
@@ -238,9 +237,9 @@ class StaticTest < Minitest::Test
       set :static, true
       set :public_folder, File.join(File.dirname(__FILE__), 'public')
     end
-    
+
     get "/hello+world.txt"
-    
+
     real_path = File.join(File.dirname(__FILE__), 'public', 'hello+world.txt')
     assert ok?
     assert_equal File.read(real_path), body
@@ -253,9 +252,9 @@ class StaticTest < Minitest::Test
       set :static, true
       set :public_folder, File.join(File.dirname(__FILE__), 'public')
     end
-    
+
     get "/hello%2bworld.txt"
-    
+
     real_path = File.join(File.dirname(__FILE__), 'public', 'hello+world.txt')
     assert ok?
     assert_equal File.read(real_path), body


### PR DESCRIPTION
This will fail in MT6