### PR TITLE
Fix uninitialized instance variable warnings

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -413,7 +413,7 @@ module Sinatra
       def close
         return if closed?
         @closed = true
-        @scheduler.schedule { @callbacks.each { |c| c.call }}
+        @scheduler.schedule { @callbacks.each { |c| c.call } }
       end
 
       def each(&front)

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -206,6 +206,8 @@ module Sinatra
     end
 
     def respond_to(*formats)
+      @respond_to ||= nil
+
       if formats.any?
         @respond_to ||= []
         @respond_to.concat formats

--- a/sinatra-contrib/lib/sinatra/streaming.rb
+++ b/sinatra-contrib/lib/sinatra/streaming.rb
@@ -98,6 +98,8 @@ module Sinatra
 
       def <<(data)
         raise IOError, 'not opened for writing' if closed?
+
+        @transformer ||= nil
         data = data.to_s
         data = @transformer[data] if @transformer
         @pos += data.bytesize
@@ -116,6 +118,8 @@ module Sinatra
       end
 
       def map!(&block)
+        @transformer ||= nil
+
         if @transformer
           inner, outer = @transformer, block
           block = proc { |value| outer[inner[value]] }


### PR DESCRIPTION
 I got some uninitialized instance variable warnings when I ran `RUBYOPT="-w" bundle exec rake` at under sinatra-contrib.

This pull-request fixes that warnings.