### PR TITLE
Fixed twitter-text version to 1.14.0

### DIFF
--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 gem 'sinatra', path: '..'
 gem 'rack-protection', path: '../rack-protection'
+gem "twitter-text", "1.14.0"
 
 group :development, :test do
   platform :jruby do
@@ -42,4 +43,3 @@ repos = { 'tilt' => 'rtomayko/tilt', 'rack' => 'rack/rack' }
   dep = {:github => repos[lib], :branch => dep} if dep and dep !~ /(\d+\.)+\d+/
   gem lib, dep if dep
 end
-


### PR DESCRIPTION
https://github.com/sinatra/sinatra/pull/1225#issuecomment-269749927

Now, sinatra-contrib  spec is still failing.

I remove `Gemfile.lock` and run `bundle exec rake`, then occured fails from:

```rb
Tilt[:mediawiki]
```

So, I fixed twitter-text gem version using sinatra-contrib same as sinatra Gemfile.

cf: cf2a240a43fcaffb35e3b8b427558e0a84e378d3

it will passes all tests.