### PR TITLE
Add default_content_type setting. Fixes #1238

### DIFF
--- a/README.md
+++ b/README.md
@@ -2264,6 +2264,15 @@ set :protection, :session => true
       used for built-in server.
     </dd>
 
+  <dt>default_content_type</dt>
+  <dd>
+    Content-Type to assume if unknown (defaults to <tt>"text/html"</tt>). Set
+    to <tt>nil</tt> to not set a default Content-Type on every response; when
+    configured so, you must set the Content-Type manually when emitting content
+    or the user-agent will have to sniff it (or, if <tt>nosniff</tt> is enabled
+    in Rack::Protection::XSSHeader, assume <tt>application/octet-stream</tt>).
+  </dd>
+
   <dt>default_encoding</dt>
     <dd>Encoding to assume if unknown (defaults to <tt>"utf-8"</tt>).</dd>
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -3,7 +3,7 @@
 require File.expand_path('../helper', __FILE__)
 
 class ResponseTest < Minitest::Test
-  setup { @response = Sinatra::Response.new }
+  setup { @response = Sinatra::Response.new([], 200, { 'Content-Type' => 'text/html' }) }
 
   def assert_same_body(a, b)
     assert_equal a.to_enum(:each).to_a, b.to_enum(:each).to_a


### PR DESCRIPTION
Historically, Sinatra::Response defaults to a text/html Content-Type.
However, in practice, Sinatra immediately clears this attribute after
instantiating a new Sinatra::Response object, so this default is some-
what suspect. Let's break this behavior and have Sinatra::Response
be Content-Type-less by default, and update the tests to reflect this.

Next, let's introduce a new default_content_type setting that will be
applied (instead of text/html) if the Content-Type is not set before the
response is finalized. This will be great for e.g. JSON API developers.
Let's also make it nil-able to indicate that a default Content-Type
should never be applied.

Wherever Sinatra is emitting HTML, e.g. in error pages, force the
Content-Type to text/html.

Finally, clean up the error-handling logic to behave as follows:

* Set the X-Cascade header as early as possible.
* If an error block matches and returns a value, stop processing and
  return that value.
* If we have a not found or bad request error, inspect the exception (if
  any) for an error message and present it as the response body if it
  exists, or present a default error message.

The remaining logic is the same otherwise. This should make error
handlers simpler to write and behave more consistently by not polluting
the body with a default message when none may be necessary.