### PR TITLE
Add explicit set method to contrib/cookies

### DIFF
--- a/sinatra-contrib/lib/sinatra/cookies.rb
+++ b/sinatra-contrib/lib/sinatra/cookies.rb
@@ -86,7 +86,7 @@ module Sinatra
       end
 
       def []=(key, value)
-        @response.set_cookie key.to_s, @options.merge(:value => value)
+        set(key, value: value)
       end
 
       def assoc(key)
@@ -239,6 +239,10 @@ module Sinatra
       end
 
       alias select! keep_if if Hash.method_defined? :select!
+
+      def set(key, options = {})
+        @response.set_cookie key.to_s, @options.merge(options)
+      end
 
       def shift
         key, value = to_hash.shift

--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -719,6 +719,29 @@ describe Sinatra::Cookies do
     end
   end
 
+  describe :set do
+    it 'sets a cookie' do
+      cookie_route { cookies.set('foo', value: 'bar') }
+      expect(cookie_jar['foo']).to eq('bar')
+    end
+
+    it 'sets a cookie with HttpOnly' do
+      expect(cookie_route do
+        request.script_name = '/foo'
+        cookies.set('foo', value: 'bar', httponly: true)
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
+      end).to include('HttpOnly')
+    end
+
+    it 'sets a cookie without HttpOnly' do
+      expect(cookie_route do
+        request.script_name = '/foo'
+        cookies.set('foo', value: 'bar', httponly: false)
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
+      end).not_to include('HttpOnly')
+    end
+  end
+
   describe :select do
     it 'removes entries from new hash' do
       jar = cookies('foo=bar', 'bar=baz')


### PR DESCRIPTION
This adds an explicit `set` method to contrib/cookies which allows you to override the default or application-wide cookie settings.

I was running into an issue where I wanted to set one cookie as HttpOnly, and allow one to be accessible via JavaScript. I didn't see an easy way to do that with the existing `[]=` method. This way, if someone wants to set cookies with different options, they can pass them to the `set` method, and `[]=` is defined in terms of `set`.

