### PR TITLE
Always sign cookies, also in development mode for classic style apps

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1920,7 +1920,6 @@ module Sinatra
     set :logging, Proc.new { !test? }
     set :method_override, true
     set :run, Proc.new { !test? }
-    set :session_secret, Proc.new { super() unless development? }
     set :app_file, nil
 
     def self.register(*extensions, &block) #:nodoc:


### PR DESCRIPTION
Currently there is a surprising or at least undocumented difference in the behavior of modular and classic style apps: cookies are not signed for classic style applications in development mode, while for modular applications they are always signed, regardless of the environment.

The patch removes the redefinition of the `session_secret` for classic style applications that caused this behavior.

In case the current behavior is intended, at least the docs should be updated to reflect this. Right now the README generally states (see "Using Sessions"):

> To improve security, the session data in the cookie is signed with a session secret. A random secret is generated for you by Sinatra.

_Short tale of woe: I wanted to create a simple example for cookies and how they work on the HTTP level, and noticed they were not signed; then went to the docs to find out how to activate the signing of cookies; unnecessarily used `Rack::Session::Cookie` as suggested in the [FAQ](http://www.sinatrarb.com/faq.html#sessions) ("If you need to set additional parameters for sessions, like expiration date, use Rack::Session::Cookie directly"), before finding out how to set the session_secret directly; still wondering, I finally read the source. And the irony: the actual example app for my students is in modular style..._