### PR TITLE
remove the roll your own part of docs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -3210,43 +3210,6 @@ Jetzt kannst du deine Applikation starten:
 bundle exec ruby myapp.rb
 ```
 
-### Eigenes Repository
-
-Um auf dem neuesten Stand von Sinatras Code zu sein, kann eine lokale Kopie
-angelegt werden. Gestartet wird in der Anwendung mit dem `sinatra/lib`-Ordner
-im `LOAD_PATH`:
-
-```shell
-cd myapp
-git clone git://github.com/sinatra/sinatra.git
-ruby -I sinatra/lib myapp.rb
-```
-
-Um Sinatra-Code von Zeit zu Zeit zu aktualisieren:
-
-```shell
-cd myproject/sinatra
-git pull
-```
-
-### Gem erstellen
-
-Aus der eigenen lokalen Kopie kann nun auch ein globales Gem gebaut werden:
-
-```shell
-git clone git://github.com/sinatra/sinatra.git
-cd sinatra
-rake sinatra.gemspec
-rake install
-```
-
-Falls Gems als Root installiert werden sollen, sollte die letzte Zeile
-folgendermaßen lauten:
-
-```shell
-sudo rake install
-```
-
 ## Versions-Verfahren
 
 Sinatra folgt dem sogenannten [Semantic Versioning](http://semver.org/), d.h.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ pick up if available.
     * [Requirement](#requirement)
     * [The Bleeding Edge](#the-bleeding-edge)
         * [With Bundler](#with-bundler)
-        * [Roll Your Own](#roll-your-own)
-        * [Install Globally](#install-globally)
     * [Versioning](#versioning)
     * [Further Reading](#further-reading)
 
@@ -3125,41 +3123,6 @@ Now you can run your app like this:
 
 ```shell
 bundle exec ruby myapp.rb
-```
-
-### Roll Your Own
-
-Create a local clone and run your app with the `sinatra/lib` directory
-on the `$LOAD_PATH`:
-
-```shell
-cd myapp
-git clone git://github.com/sinatra/sinatra.git
-ruby -I sinatra/lib myapp.rb
-```
-
-To update the Sinatra sources in the future:
-
-```shell
-cd myapp/sinatra
-git pull
-```
-
-### Install Globally
-
-You can build the gem on your own:
-
-```shell
-git clone git://github.com/sinatra/sinatra.git
-cd sinatra
-rake sinatra.gemspec
-rake install
-```
-
-If you install gems as root, the last step should be:
-
-```shell
-sudo rake install
 ```
 
 ## Versioning


### PR DESCRIPTION
This part is very specific and probably never used. If you're new to sinatra this shouldn't be kept in the Readme.