### PR TITLE
avoid executing filters even if prefix matched with other namespace

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -333,7 +333,7 @@ module Sinatra
       end
 
       def prefixed(method, pattern = nil, conditions = {}, &block)
-        default = /.*/ if method == :before or method == :after
+        default = %r{(?:/.*)?} if method == :before or method == :after
         pattern, conditions = compile pattern, conditions, default
         result = base.send(method, pattern, conditions, &block)
         invoke_hook :route_added, method.to_s.upcase, pattern, block

--- a/sinatra-contrib/spec/namespace_spec.rb
+++ b/sinatra-contrib/spec/namespace_spec.rb
@@ -787,5 +787,36 @@ describe Sinatra::Namespace do
       expect(get('/foo/bar').status).to eq(200)
       expect(last_response.body).to eq('true')
     end
+
+    it 'avoids executing filters even if prefix matches with other namespace' do
+      mock_app do
+        helpers do
+          def dump_args(*args)
+            args.inspect
+          end
+        end
+
+        namespace '/foo' do
+          helpers do
+            def dump_args(*args)
+              super(:foo, *args)
+            end
+          end
+          get('') { dump_args }
+        end
+
+        namespace '/foo-bar' do
+          helpers do
+            def dump_args(*args)
+              super(:foo_bar, *args)
+            end
+          end
+          get('') { dump_args }
+        end
+      end
+
+      get '/foo-bar'
+      expect(last_response.body).to eq('[:foo_bar]')
+    end
   end
 end


### PR DESCRIPTION
Fixes #1251 

@mwpastore @zzak Could you confirm this?