### PR TITLE
sinatra-namespace: Allow for `set :<engine>`

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -225,6 +225,12 @@ module Sinatra
       include SharedMethods
       attr_reader :base, :templates
 
+      ALLOWED_ENGINES = [
+        :erb, :erubi, :erubis, :haml, :hamlit, :builder, :nokogiri, :sass, :scss,
+        :less, :liquid, :markdown, :textile, :rdoc, :asciidoc, :radius, :markaby,
+        :rabl, :slim, :creole, :mediawiki, :coffee, :stylus, :yajl, :wlang
+      ]
+
       def self.prefixed(*names)
         names.each { |n| define_method(n) { |*a, &b| prefixed(n, *a, &b) }}
       end
@@ -279,7 +285,7 @@ module Sinatra
       end
 
       def set(key, value = self, &block)
-        raise ArgumentError, "may not set #{key}" if key != :views
+        raise ArgumentError, "may not set #{key}" unless ([:views] + ALLOWED_ENGINES).include?(key)
         return key.each { |k,v| set(k, v) } if block.nil? and value == self
         block ||= proc { value }
         singleton_class.send(:define_method, key, &block)

--- a/sinatra-contrib/spec/namespace_spec.rb
+++ b/sinatra-contrib/spec/namespace_spec.rb
@@ -788,4 +788,14 @@ describe Sinatra::Namespace do
       expect(last_response.body).to eq('true')
     end
   end
+
+  it 'forbids unknown engine settings' do
+    expect {
+      mock_app do
+        namespace '/foo' do
+          set :unknownsetting
+        end
+      end
+    }.to raise_error(ArgumentError, 'may not set unknownsetting')
+  end
 end


### PR DESCRIPTION
This allows to set render engine options local to a namespace

Fixes #1254 