### PR TITLE
Support for parameters in mime types.

### DIFF
--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -102,4 +102,24 @@ class RequestTest < Minitest::Test
     request = Sinatra::Request.new 'HTTP_ACCEPT' => 'application/json'
     assert !request.accept?('text/html')
   end
+
+  it 'will accept types that fulfill HTTP_ACCEPT parameters' do
+    request = Sinatra::Request.new 'HTTP_ACCEPT' => 'application/rss+xml; version="http://purl.org/rss/1.0/"'
+
+    assert request.accept?('application/rss+xml; version="http://purl.org/rss/1.0/"')
+    assert request.accept?('application/rss+xml; version="http://purl.org/rss/1.0/"; charset=utf-8')
+    assert !request.accept?('application/rss+xml; version="https://cyber.harvard.edu/rss/rss.html"')
+  end
+
+  it 'will accept more generic types that include HTTP_ACCEPT parameters' do
+    request = Sinatra::Request.new 'HTTP_ACCEPT' => 'application/rss+xml; charset=utf-8; version="http://purl.org/rss/1.0/"'
+
+    assert request.accept?('application/rss+xml')
+    assert request.accept?('application/rss+xml; version="http://purl.org/rss/1.0/"')
+  end
+
+  it 'will accept types matching HTTP_ACCEPT when parameters in arbitrary order' do
+    request = Sinatra::Request.new 'HTTP_ACCEPT' => 'application/rss+xml; charset=utf-8; version="http://purl.org/rss/1.0/"'
+    assert request.accept?('application/rss+xml; version="http://purl.org/rss/1.0/"; charset=utf-8')
+  end
 end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1230,6 +1230,29 @@ class RoutingTest < Minitest::Test
     assert_body 'text/xml;charset=utf-8'
   end
 
+  it 'matches content-type to mime_type' do
+    mime_type = 'application/rss+xml;version="http://purl.org/rss/1.0/"'
+    mock_app do
+      configure { mime_type(:rss10, mime_type) }
+      get('/', :provides => [:rss10]) { content_type }
+    end
+
+    get '/', {}, { 'HTTP_ACCEPT' => 'application/rss+xml' }
+    assert ok?
+    assert_body mime_type
+  end
+
+  it 'handles missing mime_types with 404' do
+    mock_app do
+      configure { mime_type(:rss10, 'application/rss+xml') }
+      get('/', :provides => [:jpg]) { content_type }
+    end
+
+    get '/', {}, { 'HTTP_ACCEPT' => 'application/rss+xml' }
+    assert_equal 404, status
+    assert_equal 'text/html;charset=utf-8', response['Content-Type']
+  end
+
   it 'passes a single url param as block parameters when one param is specified' do
     mock_app {
       get '/:foo' do |foo|


### PR DESCRIPTION
Fixes https://github.com/sinatra/sinatra/issues/1141.

Adds support for parameters when creating new mime types.

Previously, the user could declare a mime type with parameters like this:

```ruby
configure do
  mime_type :rss10, 'application/rss+xml; version="http://purl.org/rss/1.0/"'
end

get '/feed', :provides => [:rss10] do
  # ...
end
```

But the route would 404 when the version was missing from the accept header:

```bash
curl -H 'Accept: application/rss+xml' -I [host]/feed

HTTP/1.1 404 Not Found 
Content-Type: text/html;charset=utf-8
```

This change allows the route to respond, including the more specific parameters in the Content-Type header.

```bash
curl -H 'Accept: application/rss+xml' -I [host]/feed

HTTP/1.1 200 OK 
Content-Type: application/rss+xml; version="http://purl.org/rss/1.0/"
``` 

Accept headers that include all, some or none of the specified parameters are OK, but those that specify different values are not.

```ruby
configure do
  mime_type :rss10, 'application/rss+xml; version="http://purl.org/rss/1.0/"; charset=utf-8'
end
```
```bash
# OK
curl -H 'Accept: application/rss+xml' -I [host]/feed
curl -H 'Accept: application/rss+xml; version="http://purl.org/rss/1.0/"' -I [host]/feed
curl -H 'Accept: application/rss+xml; version="http://purl.org/rss/1.0/"; charset=utf-8' -I [host]/feed
curl -H 'Accept: application/rss+xml; charset=utf-8; something=else' -I [host]/feed

# Not OK
curl -H 'Accept: application/rss+xml; version="https://cyber.harvard.edu/rss/rss.html"' -I [host]/feed
```