### PR TITLE
avoid logging to stderr when loading config files

### DIFF
--- a/sinatra-contrib/lib/sinatra/config_file.rb
+++ b/sinatra-contrib/lib/sinatra/config_file.rb
@@ -129,7 +129,7 @@ module Sinatra
         paths.each do |pattern|
           Dir.glob(pattern) do |file|
             raise UnsupportedConfigType unless ['.yml', '.erb'].include?(File.extname(file))
-            $stderr.puts "loading config file '#{file}'" if logging?
+            logger.info "loading config file '#{file}'" if logging? && respond_to?(:logger)
             document = ERB.new(IO.read(file)).result
             yaml = config_for_env(YAML.load(document)) || {}
             yaml.each_pair do |key, value|


### PR DESCRIPTION
Fixes #1142 
This patch makes `ConfigFile` output loading info only when `:logger` and `:logging` are enabled.
Maybe, other extensions can also be combined with `Sinatra::CustomLogger`.