### PR TITLE
Rebase: Make #has_key? also indifferent in access

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -240,6 +240,18 @@ module Sinatra
     def http_status; 404 end
   end
 
+  class IndifferentHash < Hash
+    def [](key)
+      value = super(key)
+      return super(key.to_s) if value.nil? && Symbol === key
+      value
+    end
+
+    def has_key?(key)
+      super(key) || (Symbol === key && super(key.to_s))
+    end
+  end
+
   # Methods available to routes, before/after filters, and views.
   module Helpers
     # Set or retrieve the response status code.
@@ -1070,7 +1082,7 @@ module Sinatra
     def indifferent_params(object)
       case object
       when Hash
-        new_hash = indifferent_hash
+        new_hash = IndifferentHash.new
         object.each { |key, value| new_hash[key] = indifferent_params(value) }
         new_hash
       when Array
@@ -1078,11 +1090,6 @@ module Sinatra
       else
         object
       end
-    end
-
-    # Creates a Hash with indifferent access.
-    def indifferent_hash
-      Hash.new { |hash, key| hash[key.to_s] if Symbol === key }
     end
 
     # Run the block with 'throw :halt' support and apply result to the response.

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -38,7 +38,7 @@ class RequestTest < Minitest::Test
       'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
       'rack.input' => StringIO.new('foo=bar')
     )
-    Sinatra::Base.new!.send(:indifferent_hash).replace(request.params)
+    Sinatra::IndifferentHash.new.replace(request.params)
     dumped = Marshal.dump(request.params)
     assert_equal 'bar', Marshal.load(dumped)['foo']
   end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -271,7 +271,9 @@ class RoutingTest < Minitest::Test
     mock_app {
       get '/:foo' do
         assert_equal 'bar', params['foo']
+        assert params.has_key?('foo')
         assert_equal 'bar', params[:foo]
+        assert params.has_key?(:foo)
         'well, alright'
       end
     }


### PR DESCRIPTION
Rebases https://github.com/sinatra/sinatra/pull/1169 by @singpolyma without the docs update, as it's part of the [Sinatra 2.0](https://github.com/sinatra/sinatra/milestone/18) milestone.

From original PR:

> With the old strategy for indifferent access, one still had to use the
> correct one of String or Symbol to ask if params#has_key? -- this fixes
> that so that access is more truly indifferent.

