### PR TITLE
rack-protection: Use a glob to select middlewares

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -54,31 +54,12 @@ Gem::Specification.new do |s|
     "konstantin.haase@gmail.com"
   ]
 
-  # generated from git ls-files
-  s.files = [
+  s.files = Dir["lib/**/*.rb"] + [
     "License",
     "README.md",
     "Rakefile",
     "Gemfile",
-    "rack-protection.gemspec",
-    "lib/rack",
-    "lib/rack/protection",
-    "lib/rack/protection/escaped_params.rb",
-    "lib/rack/protection/remote_referrer.rb",
-    "lib/rack/protection/ip_spoofing.rb",
-    "lib/rack/protection/base.rb",
-    "lib/rack/protection/session_hijacking.rb",
-    "lib/rack/protection/authenticity_token.rb",
-    "lib/rack/protection/version.rb",
-    "lib/rack/protection/path_traversal.rb",
-    "lib/rack/protection/form_token.rb",
-    "lib/rack/protection/json_csrf.rb",
-    "lib/rack/protection/http_origin.rb",
-    "lib/rack/protection/frame_options.rb",
-    "lib/rack/protection/xss_header.rb",
-    "lib/rack/protection/remote_token.rb",
-    "lib/rack/protection.rb",
-    "lib/rack-protection.rb"
+    "rack-protection.gemspec"
   ]
 
   # dependencies


### PR DESCRIPTION
StrictTransport, CookieTossing, and ContentSecurityPolicy were not listed in the gemspec and hence not packaged. Let's use a glob to select middlewares to prevent this from happening in the future!