### PR TITLE
relax mustermann dependency

### DIFF
--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
 
   s.add_dependency "sinatra", Sinatra::VERSION
-  s.add_dependency "mustermann",  "1.0.0"
+  s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", ">= 2.0"
   s.add_dependency "tilt",      ">= 1.3", "< 3"
   s.add_dependency "rack-protection", Sinatra::VERSION

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.add_dependency 'rack', '~> 2.0'
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', '2.0.0.rc2'
-  s.add_dependency 'mustermann',  '1.0.0'
+  s.add_dependency 'mustermann', '~> 1.0'
 end


### PR DESCRIPTION
@zzak `< 1.0.0` may be invalid because a few bugs and features hasn't been ported.
I understand what you say?