### PR TITLE
add :strict_paths option for managing trailing slashes

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1029,6 +1029,7 @@ module Sinatra
     def process_route(pattern, conditions, block = nil, values = [])
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
+      route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
       return unless params = pattern.params(route)
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes
@@ -1845,6 +1846,7 @@ module Sinatra
     set :absolute_redirects, true
     set :prefixed_redirects, false
     set :empty_path_info, nil
+    set :strict_paths, true
 
     set :app_file, nil
     set :root, Proc.new { app_file && File.expand_path(File.dirname(app_file)) }

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1499,4 +1499,20 @@ class RoutingTest < Minitest::Test
     get '/foo/'
     assert_equal 'Foo with a slash', body
   end
+
+  it 'does not treat routes with and without trailing slashes differently if :strict_paths is disabled' do
+    mock_app do
+      disable :strict_paths
+
+      get '/foo' do
+        'foo'
+      end
+    end
+
+    get '/foo'
+    assert_equal 'foo', body
+
+    get '/foo/'
+    assert_equal 'foo', body
+  end
 end


### PR DESCRIPTION
ref #1107 
I've tried to implement first logic.
This approach is same with [padrino](https://github.com/padrino/padrino-framework/blob/master/padrino-core/lib/padrino-core/path_router/matcher.rb#L24).