### PR TITLE
[sinatra-contrib] Ignore decompile.rb while generating docs

### DIFF
--- a/sinatra-contrib/Rakefile
+++ b/sinatra-contrib/Rakefile
@@ -11,7 +11,7 @@ task(:default => :spec)
 namespace :doc do
   task :readmes do
     Dir.glob 'lib/sinatra/*.rb' do |file|
-      excluded_files = %w[lib/sinatra/contrib.rb lib/sinatra/capture.rb lib/sinatra/engine_tracking.rb]
+      excluded_files = %w[lib/sinatra/contrib.rb lib/sinatra/capture.rb lib/sinatra/decompile.rb lib/sinatra/engine_tracking.rb]
       next if excluded_files.include?(file)
       doc  = File.read(file)[/^module Sinatra(\n)+(  #[^\n]*\n)*/m].scan(/^ *#(?!#) ?(.*)\n/).join("\n")
       file = "doc/#{file[4..-4].tr("/_", "-")}.rdoc"


### PR DESCRIPTION
Rake task `bundle exec rake doc` is failing.

```sh
sinatra/sinatra-contrib git:(master)> be rake doc
writing doc/sinatra-config-file.rdoc
writing doc/sinatra-content-for.rdoc
writing doc/sinatra-cookies.rdoc
writing doc/sinatra-custom-logger.rdoc
rake aborted!
NoMethodError: undefined method `scan' for nil:NilClass
/Users/yuva/clients/opensource/sinatra/sinatra-contrib/Rakefile:16:in `block (3 levels) in <top (required)>'
/Users/yuva/clients/opensource/sinatra/sinatra-contrib/Rakefile:13:in `glob'
/Users/yuva/clients/opensource/sinatra/sinatra-contrib/Rakefile:13:in `block (2 levels) in <top (required)>'
/Users/yuva/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/Users/yuva/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => doc => doc:all => doc:readmes
(See full trace by running task with --trace)
```

This PR fixes it.