### PR TITLE
[issue-1275] add rake task to generate rack-protection docs, similar to sinatra-contrib

### DIFF
--- a/rack-protection/.gitignore
+++ b/rack-protection/.gitignore
@@ -1,3 +1,4 @@
 # please add general patterns to your global ignore list
 # see https://github.com/github/gitignore#readme
 Gemfile.lock
+doc/

--- a/rack-protection/Rakefile
+++ b/rack-protection/Rakefile
@@ -11,6 +11,25 @@ end
 desc "run specs"
 task(:spec) { ruby '-S rspec spec' }
 
+namespace :doc do
+  task :readmes do
+    Dir.glob 'lib/rack/protection/*.rb' do |file|
+      excluded_files = %w[lib/rack/protection/base.rb lib/rack/protection/version.rb]
+      next if excluded_files.include?(file)
+      doc  = File.read(file)[/^  module Protection(\n)+(    #[^\n]*\n)*/m].scan(/^ *#(?!#) ?(.*)\n/).join("\n")
+      file = "doc/#{file[4..-4].tr("/_", "-")}.rdoc"
+      Dir.mkdir "doc" unless File.directory? "doc"
+      puts "writing #{file}"
+      File.open(file, "w") { |f| f << doc }
+    end
+  end
+
+  task :all => [:readmes]
+end
+
+desc "generate documentation"
+task :doc => 'doc:all'
+
 desc "generate gemspec"
 task 'rack-protection.gemspec' do
   require 'rack/protection/version'


### PR DESCRIPTION
Copied over rake task from `sinatra-contrib`. Part of #1275 