### PR TITLE
Add Rack::Protection::ReferrerPolicy

### DIFF
--- a/rack-protection/lib/rack/protection.rb
+++ b/rack-protection/lib/rack/protection.rb
@@ -14,6 +14,7 @@ module Rack
     autoload :IPSpoofing,            'rack/protection/ip_spoofing'
     autoload :JsonCsrf,              'rack/protection/json_csrf'
     autoload :PathTraversal,         'rack/protection/path_traversal'
+    autoload :ReferrerPolicy,        'rack/protection/referrer_policy'
     autoload :RemoteReferrer,        'rack/protection/remote_referrer'
     autoload :RemoteToken,           'rack/protection/remote_token'
     autoload :SessionHijacking,      'rack/protection/session_hijacking'
@@ -35,6 +36,7 @@ module Rack
         use ::Rack::Protection::CookieTossing,         options if use_these.include? :cookie_tossing
         use ::Rack::Protection::ContentSecurityPolicy, options if use_these.include? :content_security_policy
         use ::Rack::Protection::FormToken,             options if use_these.include? :form_token
+        use ::Rack::Protection::ReferrerPolicy,        options if use_these.include? :referrer_policy
         use ::Rack::Protection::RemoteReferrer,        options if use_these.include? :remote_referrer
         use ::Rack::Protection::StrictTransport,       options if use_these.include? :strict_transport
 

--- a/rack-protection/lib/rack/protection/referrer_policy.rb
+++ b/rack-protection/lib/rack/protection/referrer_policy.rb
@@ -1,0 +1,25 @@
+require 'rack/protection'
+
+module Rack
+  module Protection
+    ##
+    # Prevented attack::   Secret leakage, third party tracking
+    # Supported browsers:: mixed support
+    # More infos::         https://www.w3.org/TR/referrer-policy/
+    #                      https://caniuse.com/#search=referrer-policy
+    #
+    # Sets Referrer-Policy header to tell the browser to limit the Referer header.
+    #
+    # Options:
+    # referrer_policy:: The policy to use (default: 'strict-origin-when-cross-origin')
+    class ReferrerPolicy < Base
+      default_options :referrer_policy => 'strict-origin-when-cross-origin'
+
+      def call(env)
+        status, headers, body = @app.call(env)
+        headers['Referrer-Policy'] ||= options[:referrer_policy]
+        [status, headers, body]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi everyone. I decided to implement the Referrer-Policy header for rack-protection. It's a really simple header with just a string value, more information:

- https://www.w3.org/TR/referrer-policy/
- https://caniuse.com/#search=referrer-policy

I considered making it enabled by default, since it has low risk of breaking the web, but I want your opinion first.

Worth noting is that the default value I picked, "strict-origin-when-cross-origin", does not work in Chrome at the moment. I picked it as it will be the most sensible default in the future, especially if this is enabled by default. See this bug: https://bugs.chromium.org/p/chromium/issues/detail?id=627968