### PR TITLE
Remove a line for "require 'bundler/setup'".

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,8 +12,6 @@ Encoding.default_external = "UTF-8" if defined? Encoding
 
 RUBY_ENGINE = 'ruby' unless defined? RUBY_ENGINE
 
-require 'bundler'
-require 'bundler/setup'
 require 'rack'
 
 testdir = File.dirname(__FILE__)

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -2,7 +2,6 @@
 #
 # We don't need the full test helper for this standalone class.
 #
-require 'bundler/setup'
 require 'minitest/autorun' unless defined?(Minitest)
 
 require_relative '../lib/sinatra/indifferent_hash'


### PR DESCRIPTION
Though it is small thing, I wonder if "require 'bundler/setup'" is needed in the tests.

Because when I removed the lines in the tests, all the test was passed.
And `bundler/setup` has already been loaded by `bundle` command at least on my local environment.
See below commands.

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ bundler -v
Bundler version 1.14.6

$ bundle exec ruby -e 'ENV.each {|name, value| puts "#{name}=#{value}" }' | grep RUBYOPT
RUBYOPT=-rbundler/setup
```
