### PR TITLE
Use avaiable rbx-3 instead of rbx that is not available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - rbx
+  - rbx-3
   - jruby-9.1.8.0
   - jruby-head
 
@@ -31,7 +31,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx
+    - rvm: rbx-3
 
 notifications:
   slack:


### PR DESCRIPTION
Right now `rbx` test for current master branch, always does not work.
Ref: https://travis-ci.org/sinatra/sinatra/jobs/236187983

In my memory, `rbx` does not work on both Default Ubuntu OS and Trusty OS.
But `rbx-3` with latest version, works on Trusty OS.
So, I think changing `rbx-3` is better than current situation.
