### PR TITLE
Update RSpec 3 for rack-protection to use latest version.

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   # dependencies
   s.add_dependency "rack"
   s.add_development_dependency "rack-test"
-  s.add_development_dependency "rspec", "~> 3.0.0"
+  s.add_development_dependency "rspec", "~> 3.6"
 end


### PR DESCRIPTION
Hello,

I want to use RSpec 3 latest version for rack-protection.

The reason why I used `~> 3.6` instead of `~> 3.6.0` is to prevent below warning message.

```
$ gem build rack-protection.gemspec
WARNING:  description and summary are identical
WARNING:  open-ended dependency on rack (>= 0) is not recommended
  if rack is semantically versioned, use:
    add_runtime_dependency 'rack', '~> 0'
WARNING:  open-ended dependency on rack-test (>= 0, development) is not recommended
  if rack-test is semantically versioned, use:
    add_development_dependency 'rack-test', '~> 0'
WARNING:  pessimistic dependency on rspec (~> 3.6.0, development) may be overly strict
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rack-protection
  Version: 2.0.0
  File: rack-protection-2.0.0.gem
```
