### PR TITLE
Add erubi for rbx test to fix failed tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ if RUBY_ENGINE == "rbx"
   gem 'json'
   gem 'rubysl'
   gem 'rubysl-test-unit'
+  gem 'erubi'
 end
 
 platforms :jruby do


### PR DESCRIPTION
Right now `rbx-3` is available. but the test is failed.
https://travis-ci.org/sinatra/sinatra/jobs/249874847

This PR is to check if the `rbx-3` test is succeeded.

