### PR TITLE
Spec: Rename a local p to path

### DIFF
--- a/sinatra-contrib/spec/respond_with_spec.rb
+++ b/sinatra-contrib/spec/respond_with_spec.rb
@@ -28,9 +28,9 @@ describe Sinatra::RespondWith do
   end
 
   def req(*types)
-    p = types.shift if types.first.is_a? String and types.first.start_with? '/'
+    path = types.shift if types.first.is_a?(String) && types.first.start_with?('/')
     accept = types.map { |t| Sinatra::Base.mime_type(t).to_s }.join ','
-    get (p || '/'), {}, 'HTTP_ACCEPT' => accept
+    get (path || '/'), {}, 'HTTP_ACCEPT' => accept
   end
 
   describe "Helpers#respond_to" do


### PR DESCRIPTION
This PR has a single cleanup change in a spec file: Avoid the local name `p` for a variable.

This change promotes the `p` to the name `path`. ([`Kernel#p`](https://ruby-doc.org/core-2.4.1/Kernel.html#method-i-p) exists, and there's room for the more descriptive name.)