### PR TITLE
Spec: Drop unused local assistance method "provides"

### DIFF
--- a/sinatra-contrib/spec/respond_with_spec.rb
+++ b/sinatra-contrib/spec/respond_with_spec.rb
@@ -4,17 +4,11 @@ require 'spec_helper'
 require 'okjson'
 
 describe Sinatra::RespondWith do
-  def provides(*args)
-    @provides = args
-  end
-
   def respond_app(&block)
-    types = @provides
     mock_app do
       set :app_file, __FILE__
       set :views, root + '/respond_with'
       register Sinatra::RespondWith
-      respond_to(*types) if types
       class_eval(&block)
     end
   end


### PR DESCRIPTION
This PR changes the spec for `RespondWith` to avoid a Ruby warning by getting rid of unused code.

  - the "provides" method was never called, and its instance variable never set
  - this change removes warnings output from the test run