### PR TITLE
Spec: Remove unused local 'seen' to avoid Ruby warning

### DIFF
--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -412,7 +412,6 @@ describe Sinatra::Cookies do
     end
 
     it 'favors response over request cookies' do
-      seen = false
       value = nil
       cookie_route('foo=bar') do
         cookies[:foo] = 'baz'


### PR DESCRIPTION
This PR removes this warning from the test output:

`/home/travis/build/sinatra/sinatra/sinatra-contrib/spec/cookies_spec.rb:415: warning: assigned but unused variable - seen`