### PR TITLE
Spec: add parentheses to avoid Ruby warning

### DIFF
--- a/sinatra-contrib/spec/namespace_spec.rb
+++ b/sinatra-contrib/spec/namespace_spec.rb
@@ -137,7 +137,7 @@ describe Sinatra::Namespace do
 
         describe 'helpers' do
           it 'are defined using the helpers method' do
-            namespace /\/foo\/([^\/&?]+)\/bar\/([^\/&?]+)\// do
+            namespace(/\/foo\/([^\/&?]+)\/bar\/([^\/&?]+)\//) do
               helpers do
                 def foo
                   'foo'


### PR DESCRIPTION
This PR adds parenthesees around a RegExp literal.

This avoids the warning

> ambiguous first argument; put parentheses or a space even after / operator