### PR TITLE
Spec: Update gem twitter-text to 1.14.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'yard'
 gem "rack-protection", path: "rack-protection"
 gem "sinatra-contrib", path: "sinatra-contrib"
 
-gem "twitter-text", "1.14.0"
+gem "twitter-text", "1.14.7"
 
 if RUBY_ENGINE == 'jruby'
   gem 'nokogiri', '!= 1.5.0'

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'sinatra', path: '..'
 gem 'rack-protection', path: '../rack-protection'
-gem "twitter-text", "1.14.0"
+gem "twitter-text", "1.14.7"
 
 group :development, :test do
   platform :jruby do


### PR DESCRIPTION
This PR tries to avoid a warning in the spec output by updating a gem dependency to its latest released version.

The [`twitter-text` gem](https://github.com/twitter/twitter-text/commits/master/rb) was locked to v1.14.0 in cf2a240a43fcaffb35e3b8b427558e0a84e378d3 for build failure reasons.

The build now passes. Perhaps things have stabilized?

<details>

The current warning is:

```
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.0/lib/twitter-text/regex.rb: warning: character class has duplicated range
```

</details>

**Update**: We now know that it's possible to remove the version pin (or as I have done here, move it forwards, to the latest release).

The warning output remains:

<details>


```
/home/travis/.rvm/gems/ruby-2.4.1/gems/twitter-text-1.14.7/lib/twitter-text/regex.rb: warning: character class has duplicated range
```

</details>