### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - rbx-3
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
   - jruby-head
 
 script: ./.travis.sh
@@ -31,7 +31,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
     - rvm: rbx-3
 
 notifications:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html