### PR TITLE
Fix issue with custom error handler on bad request

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -915,6 +915,7 @@ module Sinatra
 
     def call!(env) # :nodoc:
       @env      = env
+      @params   = IndifferentHash.new
       @request  = Request.new(env)
       @response = Response.new
       template_cache.clear if settings.reload_templates
@@ -1086,7 +1087,7 @@ module Sinatra
 
     # Dispatch a request with error handling.
     def dispatch!
-      force_encoding(@params = IndifferentHash[@request.params])
+      force_encoding(@params.merge!(@request.params))
 
       invoke do
         static! if settings.static? && (request.get? || request.head?)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -201,6 +201,21 @@ class RoutingTest < Minitest::Test
     assert_equal "This is not a drill either", response.body
   end
 
+  it "captures the custom exception message of a BadRequest" do
+    mock_app {
+      get('/') {}
+
+      error Sinatra::BadRequest do
+        'This is not a drill either'
+      end
+    }
+
+    get "/", "foo" => "", "foo[]" => ""
+    assert_equal "26", response["Content-Length"]
+    assert_equal 400, status
+    assert_equal "This is not a drill either", response.body
+  end
+
   it "uses 404 error handler for not matching route" do
     mock_app {
       not_found do


### PR DESCRIPTION
Make sure `@params` are initialized for an app, so that they exist if processing a request with a custom error handler. Currently if params are invalid an error is raised before `@params` is set, causing a `NoMethodError` for `nil:NilClass` down the chain. Fixes #1350.