### PR TITLE
Fix misspellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,7 +614,7 @@ Backported from 1.3.0:
 
  * The request object was shared between multiple Sinatra instances in the
    same middleware chain. This caused issues if any non-sinatra routing
-   happend in-between two of those instances, or running a request twice
+   happened in-between two of those instances, or running a request twice
    against an application (described in the README). The caching was reverted.
    See GH#239 and GH#256 for more infos. (Konstantin Haase)
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1434,7 +1434,7 @@ module Sinatra
         return unless running?
         # Use Thin's hard #stop! if available, otherwise just #stop.
         running_server.respond_to?(:stop!) ? running_server.stop! : running_server.stop
-        $stderr.puts "== Sinatra has ended his set (crowd applauds)" unless supress_messages?
+        $stderr.puts "== Sinatra has ended his set (crowd applauds)" unless suppress_messages?
         set :running_server, nil
         set :handler_name, nil
       end
@@ -1520,7 +1520,7 @@ module Sinatra
         prototype
         # Run the instance we created:
         handler.run(self, server_settings) do |server|
-          unless supress_messages?
+          unless suppress_messages?
             $stderr.puts "== Sinatra (v#{Sinatra::VERSION}) has taken the stage on #{port} for #{environment} with backup from #{handler_name}"
           end
 
@@ -1533,7 +1533,7 @@ module Sinatra
         end
       end
 
-      def supress_messages?
+      def suppress_messages?
         handler_name =~ /cgi/i || quiet
       end
 

--- a/sinatra-contrib/lib/sinatra/runner.rb
+++ b/sinatra-contrib/lib/sinatra/runner.rb
@@ -36,7 +36,7 @@ module Sinatra
   #
   # **Don't forget to override #app_file specific to your application!**
   #
-  # Whereever you need this test backend, here's how you manage it. The following example assumes you
+  # Wherever you need this test backend, here's how you manage it. The following example assumes you
   # have a test in your app that needs to be run against your test backend.
   #
   #   runner = ServerRunner.new


### PR DESCRIPTION
This PR fixes a few misspellings.

- renames a private method
- fixes a typo in CHANGELOG
- fixes a typo in a documentation comment
