### PR TITLE
Fixed the wrong link in the "Rack Middleware" section of the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2579,7 +2579,7 @@ typically don't have to `use` them explicitly.
 
 You can find useful middleware in
 [rack](https://github.com/rack/rack/tree/master/lib/rack),
-[rack-contrib](https://github.com/rack/rack-contrib#readm),
+[rack-contrib](https://github.com/rack/rack-contrib#readme),
 or in the [Rack wiki](https://github.com/rack/rack/wiki/List-of-Middleware).
 
 ## Testing


### PR DESCRIPTION
From  `[rack-contrib](https://github.com/rack/rack-contrib#readm)`
To `[rack-contrib](https://github.com/rack/rack-contrib#readme)`