### PR TITLE
enhanced path validation in Windows

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1061,6 +1061,7 @@ module Sinatra
     def static!(options = {})
       return if (public_dir = settings.public_folder).nil?
       path = File.expand_path("#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}" )
+      return unless path.start_with?(public_dir)
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1061,7 +1061,6 @@ module Sinatra
     def static!(options = {})
       return if (public_dir = settings.public_folder).nil?
       path = File.expand_path("#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}" )
-      return unless path.start_with?(public_dir)
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path

--- a/rack-protection/lib/rack/protection/path_traversal.rb
+++ b/rack-protection/lib/rack/protection/path_traversal.rb
@@ -24,14 +24,17 @@ module Rack
           encoding = path.encoding
           dot   = '.'.encode(encoding)
           slash = '/'.encode(encoding)
+          backslash = '\\'.encode(encoding)
         else
           # Ruby 1.8
           dot   = '.'
           slash = '/'
+          backslash = '\\'
         end
 
         parts     = []
-        unescaped = path.gsub(/%2e/i, dot).gsub(/%2f/i, slash)
+        unescaped = path.gsub(/%2e/i, dot).gsub(/%2f/i, slash).gsub(/%5c/i, backslash)
+        unescaped = unescaped.gsub(backslash, slash)
 
         unescaped.split(slash).each do |part|
           next if part.empty? or part == dot


### PR DESCRIPTION
Due to the Windows environment, more check backslashes in `static!` method and enhanced the `path_traversal` validation in `rack-protection`