### PR TITLE
Fix to ignore empty captures from params

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1029,7 +1029,7 @@ module Sinatra
       if regexp_exists
         captures           = pattern.match(route).captures
         values            += captures
-        @params[:captures] = captures
+        @params[:captures] = captures unless captures.nil? || captures.empty?
       else
         values += params.values.flatten
       end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -216,6 +216,21 @@ class RoutingTest < Minitest::Test
     assert_equal "This is not a drill either", response.body
   end
 
+  it "returns empty when unmatched with any regex captures" do
+    mock_app do
+      before do
+        # noop
+      end
+
+      get '/hello' do
+        params.to_s
+      end
+    end
+
+    assert get('/hello').ok?
+    assert_body '{}'
+  end
+
   it "uses 404 error handler for not matching route" do
     mock_app {
       not_found do


### PR DESCRIPTION
I'm trying to fix #1388 

`params` should be empty hash if requests doesn't matches any regex of routings. But It was returned `{"captures" => []}`. so I fixed to return empty hash object.

```rb
before do
  # noop
end

get "/" do
  params.to_s # returns `{}`
end
```