### PR TITLE
Remove sass warnings

### DIFF
--- a/test/sass_test.rb
+++ b/test/sass_test.rb
@@ -14,13 +14,13 @@ class SassTest < Minitest::Test
   end
 
   it 'renders inline Sass strings' do
-    sass_app { sass "#sass\n  :background-color white\n" }
+    sass_app { sass "#sass\n  background-color: white\n" }
     assert ok?
     assert_equal "#sass {\n  background-color: white; }\n", body
   end
 
   it 'defaults content type to css' do
-    sass_app { sass "#sass\n  :background-color white\n" }
+    sass_app { sass "#sass\n  background-color: white\n" }
     assert ok?
     assert_equal "text/css;charset=utf-8", response['Content-Type']
   end
@@ -28,7 +28,7 @@ class SassTest < Minitest::Test
   it 'defaults allows setting content type per route' do
     sass_app do
       content_type :html
-      sass "#sass\n  :background-color white\n"
+      sass "#sass\n  background-color: white\n"
     end
     assert ok?
     assert_equal "text/html;charset=utf-8", response['Content-Type']
@@ -36,7 +36,7 @@ class SassTest < Minitest::Test
 
   it 'defaults allows setting content type globally' do
     sass_app(:sass => { :content_type => 'html' }) {
-      sass "#sass\n  :background-color white\n"
+      sass "#sass\n  background-color: white\n"
     }
     assert ok?
     assert_equal "text/html;charset=utf-8", response['Content-Type']
@@ -62,7 +62,7 @@ class SassTest < Minitest::Test
   it "passes SASS options to the Sass engine" do
     sass_app do
       sass(
-        "#sass\n  :background-color white\n  :color black\n",
+        "#sass\n  background-color: white\n  :color black\n",
         :style => :compact
       )
     end
@@ -73,7 +73,7 @@ class SassTest < Minitest::Test
   it "passes default SASS options to the Sass engine" do
     mock_app do
       set :sass, {:style => :compact} # default Sass style is :nested
-      get('/') { sass("#sass\n  :background-color white\n  :color black\n") }
+      get('/') { sass("#sass\n  background-color: white\n  :color black\n") }
     end
     get '/'
     assert ok?

--- a/test/views/hello.sass
+++ b/test/views/hello.sass
@@ -1,2 +1,2 @@
 #sass
-  :background-color white
+  background-color: white


### PR DESCRIPTION
Fixed deprecation warning messages that occurred from `rake test` command.
```
DEPRECATION WARNING on line 91 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.

DEPRECATION WARNING on line 92 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":color black" are deprecated and will be an error in future versions of Sass.
Use "color: black" instead.

.DEPRECATION WARNING on line 24 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.

.DEPRECATION WARNING on line 77 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.

DEPRECATION WARNING on line 78 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":color black" are deprecated and will be an error in future versions of Sass.
Use "color: black" instead.

.DEPRECATION WARNING on line 32 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.

.DEPRECATION WARNING on line 65 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.

DEPRECATION WARNING on line 66 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":color black" are deprecated and will be an error in future versions of Sass.
Use "color: black" instead.

.DEPRECATION WARNING on line 40 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":background-color white" are deprecated and will be an error in future versions of Sass.
Use "background-color: white" instead.
```