### PR TITLE
Remove sass warning messages

### DIFF
--- a/test/sass_test.rb
+++ b/test/sass_test.rb
@@ -62,7 +62,7 @@ class SassTest < Minitest::Test
   it "passes SASS options to the Sass engine" do
     sass_app do
       sass(
-        "#sass\n  background-color: white\n  :color black\n",
+        "#sass\n  background-color: white\n  color: black\n",
         :style => :compact
       )
     end
@@ -73,7 +73,7 @@ class SassTest < Minitest::Test
   it "passes default SASS options to the Sass engine" do
     mock_app do
       set :sass, {:style => :compact} # default Sass style is :nested
-      get('/') { sass("#sass\n  background-color: white\n  :color black\n") }
+      get('/') { sass("#sass\n  background-color: white\n  color: black\n") }
     end
     get '/'
     assert ok?


### PR DESCRIPTION
I removed these warning messages
```
DEPRECATION WARNING on line 66 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":color black" are deprecated and will be an error in future versions of Sass.
Use "color: black" instead.

DEPRECATION WARNING on line 78 of /Users/shota-iguchi/workspace/sinatra-dev/sinatra/test/sass_test.rb:
Old-style properties like ":color black" are deprecated and will be an error in future versions of Sass.
Use "color: black" instead.
```