### PR TITLE
Remove useless private clause

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -81,8 +81,6 @@ module Sinatra
       raise BadRequest, "Invalid query parameters: #{e.message}"
     end
 
-    private
-
     class AcceptEntry
       attr_accessor :params
       attr_reader :entry
@@ -646,8 +644,6 @@ module Sinatra
       @params = original if original
     end
   end
-
-  private
 
   # Template rendering methods. Each method takes the name of a template
   # to render as a Symbol and returns a String with the rendered output,


### PR DESCRIPTION
I removed useless `private` declares.
When `private` was declared, instance methods which are define after that become private-method.
But, not-instance method (classes and modules) objects are able to load from out side of the module.

```rb
require 'sinatra/base'
Sinatra::Request::AcceptEntry # => Success to load
```