### PR TITLE
Fix Cache-Control header docs [ci skip]

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -461,7 +461,7 @@ module Sinatra
     # Specify response freshness policy for HTTP caches (Cache-Control header).
     # Any number of non-value directives (:public, :private, :no_cache,
     # :no_store, :must_revalidate, :proxy_revalidate) may be passed along with
-    # a Hash of value directives (:max_age, :min_stale, :s_maxage).
+    # a Hash of value directives (:max_age, :s_maxage).
     #
     #   cache_control :public, :must_revalidate, :max_age => 60
     #   => Cache-Control: public, must-revalidate, max-age=60


### PR DESCRIPTION
I saw RFC 2616 and RFC 7234(latest...?), response `Cache-Control` min-stale  directive does not exist. So I updated `Cache-Control` docs.