### PR TITLE
Stop to overwrite max-age on Cache-Control header

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -497,18 +497,13 @@ module Sinatra
     #   => Expires: Mon, 08 Jun 2009 08:50:17 GMT
     #
     def expires(amount, *values)
-      values << {} unless values.last.kind_of?(Hash)
+      cache_control(*values)
 
       if amount.is_a? Integer
         time    = Time.now + amount.to_i
-        max_age = amount
       else
         time    = time_for amount
-        max_age = time - Time.now
       end
-
-      values.last.merge!(:max_age => max_age)
-      cache_control(*values)
 
       response['Expires'] = time.httpdate
     end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -487,13 +487,13 @@ module Sinatra
       response['Cache-Control'] = values.join(', ') if values.any?
     end
 
-    # Set the Expires header and Cache-Control/max-age directive. Amount
+    # Set the Expires header and Cache-Control header. Amount
     # can be an integer number of seconds in the future or a Time object
     # indicating when the response should be considered "stale". The remaining
     # "values" arguments are passed to the #cache_control helper:
     #
     #   expires 500, :public, :must_revalidate
-    #   => Cache-Control: public, must-revalidate, max-age=500
+    #   => Cache-Control: public, must-revalidate
     #   => Expires: Mon, 08 Jun 2009 08:50:17 GMT
     #
     def expires(amount, *values)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -987,7 +987,7 @@ class HelpersTest < Minitest::Test
 
     it 'sets the Cache-Control header' do
       get '/foo'
-      assert_equal ['public', 'no-cache', 'max-age=60'], response['Cache-Control'].split(', ')
+      assert_equal ['public', 'no-cache'], response['Cache-Control'].split(', ')
     end
 
     it 'sets the Expires header' do
@@ -1007,7 +1007,7 @@ class HelpersTest < Minitest::Test
 
     it 'accepts values pretending to be a Numeric (like ActiveSupport::Duration)' do
       get '/blah'
-      assert_equal ['public', 'no-cache', 'max-age=60'], response['Cache-Control'].split(', ')
+      assert_equal ['public', 'no-cache'], response['Cache-Control'].split(', ')
     end
 
     it 'fails when Time.parse raises an ArgumentError' do


### PR DESCRIPTION
See issue https://github.com/sinatra/sinatra/issues/1403

I fixed to stops overwriting `max-age` values.

What do you think? @namusyaka 