### PR TITLE
Encode route parameters using :default_encoding setting

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1023,13 +1023,14 @@ module Sinatra
       return unless params = pattern.params(route)
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes
+      force_encoding(params)
       original, @params = @params, @params.merge(params) if params.any?
 
       regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? {|subpattern| subpattern.is_a?(Mustermann::Regular)} )
       if regexp_exists
         captures           = pattern.match(route).captures
         values            += captures
-        @params[:captures] = captures unless captures.nil? || captures.empty?
+        @params[:captures] = force_encoding(captures) unless captures.nil? || captures.empty?
       else
         values += params.values.flatten
       end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -352,6 +352,19 @@ class RoutingTest < Minitest::Test
     assert_equal "foo=;bar=", body
   end
 
+  it "uses the default encoding for named params" do
+    mock_app {
+      set :default_encoding ,'ISO-8859-1'
+
+      get '/:foo/:bar' do
+        "foo=#{params[:foo].encoding};bar=#{params[:bar].encoding}"
+      end
+    }
+    get '/f%C3%B6%C3%B6/b%C3%B6%C3%B6'
+    assert ok?
+    assert_equal 'foo=ISO-8859-1;bar=ISO-8859-1', body
+  end
+
   it "supports named captures like %r{/hello/(?<person>[^/?#]+)}" do
     mock_app {
       get Regexp.new('/hello/(?<person>[^/?#]+)') do
@@ -380,6 +393,19 @@ class RoutingTest < Minitest::Test
     get '/page'
     assert ok?
     assert_equal "format=", body
+  end
+
+  it 'uses the default encoding for named captures' do
+    mock_app {
+      set :default_encoding ,'ISO-8859-1'
+
+      get Regexp.new('/page(?<format>.[^/?#]+)?') do
+        "format=#{params[:format].encoding};captures=#{params[:captures][0].encoding}"
+      end
+    }
+    get '/page.f%C3%B6'
+    assert ok?
+    assert_equal 'format=ISO-8859-1;captures=ISO-8859-1', body
   end
 
   it 'does not concatenate params with the same name' do
@@ -1334,6 +1360,19 @@ class RoutingTest < Minitest::Test
     get '/bar/foo/bling/baz/boom'
     assert ok?
     assert_equal 'looks good', body
+  end
+
+  it "uses the default encoding for block parameters" do
+    mock_app {
+      set :default_encoding ,'ISO-8859-1'
+
+      get '/:foo/:bar' do |foo, bar|
+        "foo=#{foo.encoding};bar=#{bar.encoding}"
+      end
+    }
+    get '/f%C3%B6%C3%B6/b%C3%B6%C3%B6'
+    assert ok?
+    assert_equal 'foo=ISO-8859-1;bar=ISO-8859-1', body
   end
 
   it 'raises an ArgumentError with block arity > 1 and too many values' do


### PR DESCRIPTION
Honor the :default_encoding setting for any extracted parameters from the URL.  The force_encoding was scoped to modify only the necessary items for performance.  In the test, be explicit about our dependency on this value.

Fixes #1362.