### PR TITLE
Add xml content-types to valid html_types for Rack::Protection

### DIFF
--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -13,7 +13,7 @@ module Rack
         :session_key => 'rack.session',    :status    => 403,
         :allow_empty_referrer => true,
         :report_key           => "protection.failed",
-        :html_types           => %w[text/html application/xhtml]
+        :html_types           => %w[text/html application/xhtml text/xml application/xml]
       }
 
       attr_reader :app, :options

--- a/rack-protection/spec/lib/rack/protection/protection_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/protection_spec.rb
@@ -69,6 +69,16 @@ describe Rack::Protection do
       it { is_expected.to be_truthy }
     end
 
+    context "given an appropriate content-type header of text/xml" do
+      subject { Rack::Protection::Base.new(nil).html? 'content-type' => "text/xml" }
+      it { is_expected.to be_truthy }
+    end
+
+    context "given an appropriate content-type header of application/xml" do
+      subject { Rack::Protection::Base.new(nil).html? 'content-type' => "application/xml" }
+      it { is_expected.to be_truthy }
+    end
+
     context "given an inappropriate content-type header" do
       subject { Rack::Protection::Base.new(nil).html? 'content-type' => "image/gif" }
       it { is_expected.to be_falsey }


### PR DESCRIPTION
Javascript can run in XML by defining an HTML namespace.  Example: `<script xmlns="http://www.w3.org/1999/xhtml">alert(1)</script>`.  Request is adding text/xml and application/xml to :html_types to include protection for these content types.

Example
```
Payload:
http://localhost:4567?example_rxss_param=]]%3E%3Cscript%20xmlns=%22http://www.w3.org/1999/xhtml%22%3Ealert(1)%3C/script%3E%3C![CDATA[

Response:
<![CDATA[]]>
<script xmlns="http://www.w3.org/1999/xhtml">alert(1)</script>
<![CDATA[]>
```