### PR TITLE
avoid overwriting params with falsey value

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1024,16 +1024,17 @@ module Sinatra
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes
       force_encoding(params)
-      original, @params = @params, @params.merge(params) if params.any?
 
       regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? {|subpattern| subpattern.is_a?(Mustermann::Regular)} )
       if regexp_exists
         captures           = pattern.match(route).captures
         values            += captures
-        @params[:captures] = force_encoding(captures) unless captures.nil? || captures.empty?
+        params[:captures]  = force_encoding(captures) unless captures.nil? || captures.empty?
       else
         values += params.values.flatten
       end
+
+      original, @params = @params, @params.merge(params) if values.any? && params.any?
 
       catch(:pass) do
         conditions.each { |c| throw :pass if c.bind(self).call == false }

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1607,4 +1607,18 @@ class RoutingTest < Minitest::Test
     get '/foo/'
     assert_equal 'foo', body
   end
+
+  it 'does not overwrite params with falsey value when optional param is duplicate between request body and path' do
+    mock_app do
+      post '/example/?:id?' do
+        params[:id]
+      end
+    end
+
+    post '/example', { id: 'foo' }
+    assert_equal 'foo', body
+
+    post '/example/bar', { id: 'foo' }
+    assert_equal 'bar', body
+  end
 end


### PR DESCRIPTION
This behavior arises from the commit that mustermann was introduced.
see: https://github.com/sinatra/sinatra/commit/7a9ffccdafb71fef8d33c110d03ca0654dbb9316

That breaks backward compatibility with Sinatra v1.4.X and is not intended behavior.
This changes it so that it overwrites params only if there is a possible value as a block argument.

Fixes #1417

I want a cautious review on this PR. After sufficient review, I'm planning to merge the commit.
/cc @rkh @zzak @nickpelone