### PR TITLE
Fix Sinatra::RequiredParams implementation

### DIFF
--- a/sinatra-contrib/lib/sinatra/required_params.rb
+++ b/sinatra-contrib/lib/sinatra/required_params.rb
@@ -60,7 +60,7 @@ module Sinatra
         elsif key.is_a?(Array)
           _required_params(p, *key)
         else
-          halt 400 unless p.has_key?(key.to_s)
+          halt 400 unless p && p.respond_to?(:has_key?) && p.has_key?(key.to_s)
         end
       end
       true

--- a/sinatra-contrib/spec/required_params_spec.rb
+++ b/sinatra-contrib/spec/required_params_spec.rb
@@ -41,6 +41,10 @@ describe Sinatra::RequiredParams do
         get('/', :p1 => 1, :p2 => {:p21 => 21})
         expect(last_response.status).to eq(200)
       end
+      it 'return 400 if p2 is not a hash' do
+        get('/', :p1 => 1, :p2 => 2)
+        expect(last_response.status).to eq(400)
+      end
     end
     context "complex keys" do
       before do


### PR DESCRIPTION
Currently, when required_params is called in such a way that it expects a key in the params to be a hash, it fails with error

`undefined method has_key?`

when it is not indeed a hash in the params in a request.

Now, it's been ensured that the key can respond to `has_key?` before `has_key?` is called on it.

So,

`required_params :p1, :p2 => [:p3]`

now works properly even if `:p2` turns out not to point to a hash, e. g. if the params hash is

```
{ p1: 2, p2: 3 }
```
it will properly halt with status 400.

A unit test has also been added to `required_params_spec.rb`. It failed before the fix, but now passes.