### PR TITLE
Optional trailing slash in path can now be used correctly if strict_paths = false

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1019,8 +1019,15 @@ module Sinatra
     def process_route(pattern, conditions, block = nil, values = [])
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
-      route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
-      route = route[0...-1] if route.end_with?('/')
+
+      if !settings.strict_paths? && route != '/'
+        if pattern.to_s.end_with?('/') && !route.end_with?('/')
+          route << '/'
+        elsif !pattern.to_s.end_with?('/') && route.end_with?('/')
+           route = route[0..-2]
+        end
+      end
+
       return unless params = pattern.params(route)
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1020,6 +1020,7 @@ module Sinatra
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
       route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
+      route = route[0...-1] if route.end_with?('/')
       return unless params = pattern.params(route)
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1019,7 +1019,6 @@ module Sinatra
     def process_route(pattern, conditions, block = nil, values = [])
       route = @request.path_info
       route = '/' if route.empty? and not settings.empty_path_info?
-
       if !settings.strict_paths? && route != '/'
         if pattern.to_s.end_with?('/') && !route.end_with?('/')
           route << '/'
@@ -1027,7 +1026,6 @@ module Sinatra
            route = route[0..-2]
         end
       end
-
       return unless params = pattern.params(route)
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1592,11 +1592,27 @@ class RoutingTest < Minitest::Test
     assert_equal 'Foo with a slash', body
   end
 
-  it 'does not treat routes with and without trailing slashes differently if :strict_paths is disabled' do
+  it 'does not treat routes without trailing slashes differently if :strict_paths is disabled' do
     mock_app do
       disable :strict_paths
 
       get '/foo' do
+        'foo'
+      end
+    end
+
+    get '/foo'
+    assert_equal 'foo', body
+
+    get '/foo/'
+    assert_equal 'foo', body
+  end
+
+  it 'does not treat routes with trailing slashes differently if :strict_paths is disabled' do
+    mock_app do
+      disable :strict_paths
+
+      get '/foo/' do
         'foo'
       end
     end


### PR DESCRIPTION
This PR was created due to [issue #1426](https://github.com/sinatra/sinatra/issues/1426).

I noticed that in order to make the use of the trailing slash at the end of a URL optional, i.e. treating _/helloworld_ and _/helloworld/_ as the same path, without using _/?_ at the end of the route pattern declaration, strict_paths should be set to false, as how someone suggested in [issue #1107](https://github.com/sinatra/sinatra/issues/1107).


This worked correctly in this case:
```ruby
 get '/helloworld' do
    "Hello, world!"
  end
```
* /helloworld - works
* /helloworld/ - works

However, if the case was:
```ruby
 get '/helloworld/' do
    "Hello, world!"
  end
```
* /helloworld - doesn't work
* /helloworld/ - doesn't work

This PR fixes this, allowing the optional trailing slash to be used correctly **when strict_paths is set to false in base.rb**