### PR TITLE
Fix rubygems LoadError.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,6 @@ end
 
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
-  t.ruby_opts = ['-rubygems'] if defined? Gem
   t.ruby_opts << '-I.'
   t.warning = true
 end
@@ -41,7 +40,6 @@ Rake::TestTask.new(:"test:core") do |t|
      readme request response result route_added_hook
      routing server settings sinatra static templates]
   t.test_files = core_tests.map {|n| "test/#{n}_test.rb"}
-  t.ruby_opts = ["-rubygems"] if defined? Gem
   t.ruby_opts << "-I."
   t.warning = true
 end


### PR DESCRIPTION
I got below error on my local environment.

```
$ bundle exec rake test
Traceback (most recent call last):
  1: from /usr/local/ruby-2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/usr/local/ruby-2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
rake aborted!
Command failed with status (1)
/home/jaruga/git/sinatra/vendor/bundle/ruby/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/ruby-2.5.1/bin/bundle:23:in `load'
/usr/local/ruby-2.5.1/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

This logic is old when rubygem was not included as a stdlib, isn't it?
I removed this logic :)
How do you think?