### PR TITLE
Unescape regex captures

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1028,7 +1028,7 @@ module Sinatra
 
       regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? {|subpattern| subpattern.is_a?(Mustermann::Regular)} )
       if regexp_exists
-        captures           = pattern.match(route).captures
+        captures           = pattern.match(route).captures.map { |c| URI_INSTANCE.unescape(c) if c }
         values            += captures
         @params[:captures] = force_encoding(captures) unless captures.nil? || captures.empty?
       else

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -660,6 +660,18 @@ class RoutingTest < Minitest::Test
     assert ok?
   end
 
+  it 'unescapes named parameters and splats' do
+    mock_app {
+      get '/:foo/*' do |a, b|
+        assert_equal "foo\x80", params['foo']
+        assert_equal ["bar\xE2\x80\x8Cbaz"], params['splat']
+      end
+    }
+
+    get '/foo%80/bar%e2%80%8cbaz'
+    assert ok?
+  end
+
   it 'supports regular expressions' do
     mock_app {
       get(/\/foo...\/bar/) do
@@ -670,6 +682,18 @@ class RoutingTest < Minitest::Test
     get '/foooom/bar'
     assert ok?
     assert_equal 'Hello World', body
+  end
+
+  it 'unescapes regular expression captures' do
+    mock_app {
+      get(/\/foo\/(.+)/) do |path|
+        path
+      end
+    }
+
+    get '/foo/bar%e2%80%8cbaz'
+    assert ok?
+    assert_equal "bar\xE2\x80\x8Cbaz", body
   end
 
   it 'makes regular expression captures available in params[:captures]' do

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -663,12 +663,14 @@ class RoutingTest < Minitest::Test
   it 'unescapes named parameters and splats' do
     mock_app {
       get '/:foo/*' do |a, b|
-        assert_equal "foo\x80", params['foo']
+        assert_equal "foo\xE2\x80\x8Cbar", params['foo']
+        assert_predicate params['foo'], :valid_encoding?
+
         assert_equal ["bar\xE2\x80\x8Cbaz"], params['splat']
       end
     }
 
-    get '/foo%80/bar%e2%80%8cbaz'
+    get '/foo%e2%80%8cbar/bar%e2%80%8cbaz'
     assert ok?
   end
 
@@ -694,6 +696,7 @@ class RoutingTest < Minitest::Test
     get '/foo/bar%e2%80%8cbaz'
     assert ok?
     assert_equal "bar\xE2\x80\x8Cbaz", body
+    assert_predicate body, :valid_encoding?
   end
 
   it 'makes regular expression captures available in params[:captures]' do


### PR DESCRIPTION
This adds tests to make sure named parameters and regex captures are unescaped, and also provides a potential fix for #1443. I'm not familiar enough with Mustermann to know if it should handle unescaping captures.