### PR TITLE
Drop activesupport dependency from sinatra-contrib

### DIFF
--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'sinatra/engine_tracking'
-require 'active_support/core_ext/object/try.rb'
 
 module Sinatra
   #
@@ -106,12 +105,12 @@ module Sinatra
         dummy      = DUMMIES.fetch(current_engine)
         options    = { :layout => false, :locals => {:args => args, :block => block }}
 
-        buffer.try :clear
+        buffer.clear unless buffer.nil?
         result = render(current_engine, dummy, options, &block)
       end
       result.strip.empty? && @capture ? @capture : result
     ensure
-      buffer.try :replace, old_buffer
+      buffer.replace(old_buffer) unless buffer.nil?
     end
 
     def capture_later(&block)

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra", version
   s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", ">= 2.8.2"
-  s.add_dependency "activesupport", ">= 4.0.0"
   s.add_dependency "tilt",      ">= 1.3", "< 3"
   s.add_dependency "rack-protection", version
   s.add_dependency "multi_json"


### PR DESCRIPTION
ActiveSupport was being loaded to provide `Object#try`. It's a very large dependency that can monkey patch many core classes, and although the require in `sinatra-contrib` is targeted and doesn't load all of ActiveSupport, once the gem is on the load path some other libraries will opportunistically load more of it.

`Object#try` is only used twice, maybe it's ok to live with a manual check for nil for now? `sinatra-contrib` currently requires ruby 2.2 or better - once the minimum is lifted to 2.3, Object#try will be provided by ruby core.