### PR TITLE
Add metadata link to gemspec

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name        = "rack-protection"
   s.version     = version
   s.description = "Protect against typical web attacks, works with all Rack apps, including Rails."
-  s.homepage    = "http://www.sinatrarb.com/protection/"
+  s.homepage    = "http://sinatrarb.com/protection/"
   s.summary     = s.description
   s.license     = 'MIT'
   s.authors     = ["https://github.com/sinatra/sinatra/graphs/contributors"]
@@ -17,6 +17,11 @@ Gem::Specification.new do |s|
     "Gemfile",
     "rack-protection.gemspec"
   ]
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/sinatra/sinatra/tree/master/rack-protection'
+    'homepage_uri'      => 'http://sinatrarb.com/protection/',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/rack-protection'
+  }
 
   # dependencies
   s.add_dependency "rack"

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -17,11 +17,21 @@ Gem::Specification.new do |s|
     "Gemfile",
     "rack-protection.gemspec"
   ]
-  s.metadata = {
-    'source_code_uri' => 'https://github.com/sinatra/sinatra/tree/master/rack-protection'
-    'homepage_uri'      => 'http://sinatrarb.com/protection/',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/rack-protection'
-  }
+
+  if s.respond_to?(:metadata)
+    s.metadata = {
+      'source_code_uri'   => 'https://github.com/sinatra/sinatra/tree/master/rack-protection',
+      'homepage_uri'      => 'http://sinatrarb.com/protection/',
+      'documentation_uri' => 'https://www.rubydoc.info/gems/rack-protection'
+    }
+  else
+    raise <<-EOF
+RubyGems 2.0 or newer is required to protect against public gem pushes. You can update your rubygems version by running:
+  gem install rubygems-update
+  update_rubygems:
+  gem update --system
+EOF
+  end
 
   # dependencies
   s.add_dependency "rack"

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name        = "sinatra-contrib"
   s.version     = version
   s.description = "Collection of useful Sinatra extensions"
-  s.homepage    = "http://www.sinatrarb.com/contrib/"
+  s.homepage    = "http://sinatrarb.com/contrib/"
   s.license     = "MIT"
   s.summary     = s.description
   s.authors     = ["https://github.com/sinatra/sinatra/graphs/contributors"]
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
     "ideas.md",
     "sinatra-contrib.gemspec"
   ]
+  s.metadata = {
+    'source_code_uri'   => 'https://github.com/sinatra/sinatra/tree/master/sinatra-contrib'
+    'homepage_uri'      => 'http://sinatrarb.com/contrib/',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra-contrib'
+  }
 
   s.required_ruby_version = '>= 2.2.0'
 

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -18,11 +18,21 @@ Gem::Specification.new do |s|
     "ideas.md",
     "sinatra-contrib.gemspec"
   ]
-  s.metadata = {
-    'source_code_uri'   => 'https://github.com/sinatra/sinatra/tree/master/sinatra-contrib'
-    'homepage_uri'      => 'http://sinatrarb.com/contrib/',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra-contrib'
-  }
+
+  if s.respond_to?(:metadata)
+    s.metadata = {
+      'source_code_uri'   => 'https://github.com/sinatra/sinatra/tree/master/sinatra-contrib',
+      'homepage_uri'      => 'http://sinatrarb.com/contrib/',
+      'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra-contrib'
+    }
+  else
+    raise <<-EOF
+RubyGems 2.0 or newer is required to protect against public gem pushes. You can update your rubygems version by running:
+  gem install rubygems-update
+  update_rubygems:
+  gem update --system
+EOF
+  end
 
   s.required_ruby_version = '>= 2.2.0'
 

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new 'sinatra', version do |s|
   s.summary           = "Classy web-development dressed in a DSL"
   s.authors           = ["Blake Mizerany", "Ryan Tomayko", "Simon Rozet", "Konstantin Haase"]
   s.email             = "sinatrarb@googlegroups.com"
-  s.homepage          = "http://www.sinatrarb.com/"
+  s.homepage          = "http://sinatrarb.com/"
   s.license           = 'MIT'
   s.files             = Dir['README*.md', 'lib/**/*', 'examples/*'] + [
     ".yardopts",
@@ -22,6 +22,14 @@ Gem::Specification.new 'sinatra', version do |s|
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
+  s.metadata = {
+    'source_code_uri'   => 'https://github.com/sinatra/sinatra',
+    'changelog_uri'     => 'https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md',
+    'homepage_uri'      => 'http://sinatrarb.com/',
+    'bug_tracker_uri'   => 'https://github.com/sinatra/sinatra/issues',
+    'mailing_list_uri'  => 'http://groups.google.com/group/sinatrarb',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
+  }
 
   s.required_ruby_version = '>= 2.2.0'
 

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -22,14 +22,29 @@ Gem::Specification.new 'sinatra', version do |s|
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
   s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
-  s.metadata = {
-    'source_code_uri'   => 'https://github.com/sinatra/sinatra',
-    'changelog_uri'     => 'https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md',
-    'homepage_uri'      => 'http://sinatrarb.com/',
-    'bug_tracker_uri'   => 'https://github.com/sinatra/sinatra/issues',
-    'mailing_list_uri'  => 'http://groups.google.com/group/sinatrarb',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
-  }
+
+  if s.respond_to?(:metadata)
+    s.metadata = {
+      'source_code_uri'   => 'https://github.com/sinatra/sinatra',
+      'changelog_uri'     => 'https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md',
+      'homepage_uri'      => 'http://sinatrarb.com/',
+      'bug_tracker_uri'   => 'https://github.com/sinatra/sinatra/issues',
+      'mailing_list_uri'  => 'http://groups.google.com/group/sinatrarb',
+      'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
+    }
+  else
+    msg = "RubyGems 2.0 or newer is required to protect against public "\
+          "gem pushes. You can update your rubygems version by running:\n\n"\
+          "gem install rubygems-update\n"\
+          "update_rubygems\n"\
+          "gem update --system"
+    raise <<-EOF
+RubyGems 2.0 or newer is required to protect against public gem pushes. You can update your rubygems version by running:
+  gem install rubygems-update
+  update_rubygems:
+  gem update --system
+EOF
+  end
 
   s.required_ruby_version = '>= 2.2.0'
 


### PR DESCRIPTION
Specifying metadata links in the gemspec replaces specifying them through the Rubygems web UI (which will soon be deprecated).