### PR TITLE
Show Gem version in badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Sinatra
 
+[![Gem Version](https://badge.fury.io/rb/sinatra.svg)](http://badge.fury.io/rb/sinatra)
 [![Build Status](https://secure.travis-ci.org/sinatra/sinatra.svg)](https://travis-ci.org/sinatra/sinatra)
 
 Sinatra is a [DSL](https://en.wikipedia.org/wiki/Domain-specific_language) for


### PR DESCRIPTION
Adds this badge to the top of the readme:

[![Gem Version](https://badge.fury.io/rb/sinatra.svg)](http://badge.fury.io/rb/sinatra)

(I always want to know the current version when adding a new gem to my Gemfile, so I can figure out what requirement to set it to.)

Additionally, if you're up for it, I'd love you to show the SemVer stability of sinatra using this badge:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=sinatra&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=sinatra&package-manager=bundler&version-scheme=semver)

I haven't included that one in this PR though, because I thought I'd ask first (I built the tool that creates those badges, so don't want to spam people with them).