### PR TITLE
Fix rendering string templates in nested namespaces

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -305,6 +305,13 @@ module Sinatra
         @pattern
       end
 
+      # because caller_locations is defined privately and method_missing calls
+      # send this will end up using ruby's caller_locations instead of
+      # calling base.method_missing back up to the sinatra definition.
+      def caller_locations
+        base.caller_locations
+      end
+
       private
 
       def app

--- a/sinatra-contrib/spec/namespace_spec.rb
+++ b/sinatra-contrib/spec/namespace_spec.rb
@@ -702,6 +702,28 @@ describe Sinatra::Namespace do
             expect(send(verb, '/').body).to eq 'Hello World!'
             expect(send(verb, '/foo').body).to eq 'Hi World!'
           end
+
+          specify 'can render strings' do
+            mock_app do
+              namespace '/foo' do
+                send(verb) { erb 'foo' }
+              end
+            end
+
+            expect(send(verb, '/foo').body).to eq 'foo'
+          end
+
+          specify 'can render strings nested' do
+            mock_app do
+              namespace '/foo' do
+                namespace '/bar' do
+                  send(verb) { erb 'bar' }
+                end
+              end
+            end
+
+            expect(send(verb, '/foo/bar').body).to eq 'bar'
+          end
         end
       end
 


### PR DESCRIPTION
Rendering string templates (i.e. `erb "Foo"`) is broken when inside a nested namespace. Namespaces are anonymous modules and rely on recursively calling `method_missing` when nested to call methods defined in `Base`. Rendering string templates calls `caller_locations` here: https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb?utf8=%E2%9C%93#L882. `Base` overrides `caller_locations` which is also defined (privately) on anonymous modules (and everything else I believe, i.e. `Object.new.send(:caller_locations)`). Since `method_missing` uses `send` the recursion doesn't work after being nested once as it will call the privately defined `caller_locations`  on the parent anonymous module instead of recursing back up the overridden method on `Base`.

The fix here is the most straightforward I could think of -- just define `caller_locations` inside `Namespace` and force it to call `base.caller_locations` instead of relying on `method_missing`.

A better way to fix this issue might be to not override `caller_locations` on `Base` (just change the name to something else). It doesn't really seem to be intended to be a replacement for the core `caller_locations` anyways since it changes the return value in an incompatible way, but that seemed like it could be a controversial change.