### PR TITLE
Fix broken build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 
 if RUBY_ENGINE == "ruby"
   gem 'less', '~> 2.0'
-  gem 'mini_racer'
+  gem 'therubyracer'
   gem 'redcarpet'
   gem 'wlang', '>= 2.0.1'
   gem 'bluecloth'

--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -559,7 +559,7 @@ describe Sinatra::Cookies do
     it 'checks response cookies' do
       jar = cookies
       jar['foo'] = 'bar'
-      expect(jar).to include(:foo)
+      expect(jar).to include('foo')
     end
 
     it 'does not use deleted cookies' do


### PR DESCRIPTION
The latest version of `mini_racer` does not support ruby 2.2 so that build was failing. There was also a broken `Sinatra::Cookie` spec that I'm wondering if is related to changes to `Sinatra::IndifferentHash`.

cc: @mwpastore @namusyaka 