### PR TITLE
Change default ERB template engine to erubi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ if RUBY_ENGINE == "ruby"
   gem 'stylus'
   gem 'rabl'
   gem 'builder'
+  gem 'erubi'
   gem 'erubis'
   gem 'haml', '>= 3.0'
   gem 'sass'

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -679,7 +679,8 @@ module Sinatra
     end
 
     def erb(template, options = {}, locals = {}, &block)
-      render(:erb, template, options, locals, &block)
+      require 'erubi'
+      render(:erubi, template, options, locals, &block)
     end
 
     def erubis(template, options = {}, locals = {})


### PR DESCRIPTION
[Erubi](https://github.com/jeremyevans/erubi) is a simplified fork of Erubis, Erubi is faster than erubis and erb.

In rails, default ERB template engine is erubi from rails 5.1([Change ActionView ERB Handler from Erubis to Erubi by jeremyevans · Pull Request #27757 · rails/rails](https://github.com/rails/rails/pull/27757)).

Erubi offers the following advantages for erubis:
- Handles postfix conditionals when using escaping (e.g. <%= foo if bar %>)
- Supports frozen_string_literal: true in templates via :freeze option
- Works with ruby's –enable-frozen-string-literal option
- Automatically freezes strings for template text when ruby optimizes it (on ruby 2.1+)
- Escapes ' (apostrophe) when escaping for better XSS protection
- Has 6x faster escaping on ruby 2.3+ by using cgi/escape
- Has 86% smaller memory footprint
- Does no monkey patching (Erubis adds a method to Kernel)
- Uses an immutable design (all options passed to the constructor, which returns a frozen object)
- Has simpler internals (1 file, <150 lines of code)
- Is not dead (Erubis hasn't been updated since 2011)

