### PR TITLE
IndifferentHash monkeypatch warning improvements

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -1,22 +1,11 @@
 # frozen_string_literal: true
-if !$LOAD_PATH.grep(%r{gems/activesupport}).empty? && $LOADED_FEATURES.grep(%r{active_support/core_ext/hash}).empty?
-  puts <<-EOF
+$stderr.puts <<EOF if !Hash.method_defined?(:slice) && !$LOAD_PATH.grep(%r{gems/activesupport}).empty? && ENV['SINATRA_ACTIVESUPPORT_WARNING'] != 'false'
 WARNING: If you plan to load any of ActiveSupport's core extensions to Hash, be
 sure to do so *before* loading Sinatra::Application or Sinatra::Base. If not,
 you may disregard this warning.
-  EOF
-end
 
-if ENV['APP_ENV'] == 'test' && !Hash.method_defined?(:slice)
-  # Some extensions get loaded during testing (e.g. by RABL and our RABL test)
-  # that we have no control over, but we need it to load *before*
-  # IndifferentHash, so we'll do it preemptively here.
-  #
-  # Newer Rubies have these methods built-in, so the extensions are no-ops.
-  require 'active_support/core_ext/hash/conversions'
-  require 'active_support/core_ext/hash/slice'
-  require 'active_support/core_ext/hash/keys'
-end
+Set SINATRA_ACTIVESUPPORT_WARNING=false in the environment to hide this warning.
+EOF
 
 module Sinatra
   # A poor man's ActiveSupport::HashWithIndifferentAccess, with all the Rails-y

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,18 @@ $LOAD_PATH.unshift libdir unless $LOAD_PATH.include?(libdir)
 require 'minitest'
 require 'contest'
 require 'rack/test'
+
+# Some of ActiveSupport's core extensions to Hash get loaded during internal
+# testing (e.g. by RABL and our RABL test) that we have no control over, but we
+# need them to load *before* Sinatra::IndifferentHash (which is itself loaded
+# by Sinatra::Base) whenever the full test suite is executed, so we'll do it
+# preemptively here.
+#
+# Newer Rubies have these methods built-in, so the extensions are no-ops.
+require 'active_support/core_ext/hash/conversions'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/hash/keys'
+
 require 'sinatra/base'
 
 class Sinatra::Base

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -4,6 +4,10 @@
 #
 require 'minitest/autorun' unless defined?(Minitest)
 
+# Suppress the ActiveSupport warning when this test is executed independently,
+# outside of the full suite, on older Rubies.
+ENV['SINATRA_ACTIVESUPPORT_WARNING'] = 'false'
+
 require_relative '../lib/sinatra/indifferent_hash'
 
 class TestIndifferentHashBasics < Minitest::Test


### PR DESCRIPTION
* Print warning on Rubies that require monkeypatching only
* Print warning to stderr instead of stdout
* Load ActiveSupport during internal testing only
* Add SINATRA_ACTIVESUPPORT_WARNING opt-out environment variable

First spike at addressing #1476 