### PR TITLE
Revert back to using include matcher

### DIFF
--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -559,7 +559,7 @@ describe Sinatra::Cookies do
     it 'checks response cookies' do
       jar = cookies
       jar['foo'] = 'bar'
-      expect(jar).to be_include(:foo)
+      expect(jar).to include(:foo)
     end
 
     it 'does not use deleted cookies' do


### PR DESCRIPTION
A regression was fixed in Rspec so the include matcher once again works as expected.

See https://github.com/rspec/rspec-expectations/pull/1073