### PR TITLE
Use inline conditional instead of Object#try

### DIFF
--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -110,7 +110,7 @@ module Sinatra
       end
       result.strip.empty? && @capture ? @capture : result
     ensure
-      buffer.replace(old_buffer) if buffer
+      buffer.replace(old_buffer) if buffer.respond_to?(:replace)
     end
 
     def capture_later(&block)

--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -105,7 +105,7 @@ module Sinatra
         dummy      = DUMMIES.fetch(current_engine)
         options    = { :layout => false, :locals => {:args => args, :block => block }}
 
-        buffer.clear if buffer
+        buffer.clear if buffer.respond_to?(:clear)
         result = render(current_engine, dummy, options, &block)
       end
       result.strip.empty? && @capture ? @capture : result

--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'sinatra/engine_tracking'
-require 'active_support/core_ext/object/try.rb'
 
 module Sinatra
   #
@@ -106,12 +105,12 @@ module Sinatra
         dummy      = DUMMIES.fetch(current_engine)
         options    = { :layout => false, :locals => {:args => args, :block => block }}
 
-        buffer.try :clear
+        buffer.clear if buffer
         result = render(current_engine, dummy, options, &block)
       end
       result.strip.empty? && @capture ? @capture : result
     ensure
-      buffer.try :replace, old_buffer
+      buffer.replace(old_buffer) if buffer
     end
 
     def capture_later(&block)

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -39,7 +39,6 @@ EOF
   s.add_dependency "sinatra", version
   s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", ">= 2.8.2"
-  s.add_dependency "activesupport", ">= 4.0.0"
   s.add_dependency "tilt",      ">= 1.3", "< 3"
   s.add_dependency "rack-protection", version
   s.add_dependency "multi_json"


### PR DESCRIPTION
If I'm correct these two lines are the only reason ActiveSupport is a dependency of sinatra-contrib. If so this change adds 10 bytes source code to get rid of 5MB dependencies.