### PR TITLE
Use Kernel#caller_locations (2.x)

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -903,9 +903,10 @@ module Sinatra
     end
 
     def compile_block_template(template, options, &body)
-      caller = settings.caller_locations.first
-      path = options[:path] || caller[0]
-      line = options[:line] || caller[1]
+      first_location = caller_locations.first
+      path, line = first_location.path, first_location.lineno
+      path = options[:path] || path
+      line = options[:line] || line
       template.new(path, line.to_i, options, &body)
     end
   end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -266,22 +266,6 @@ module Sinatra
     def http_status; 404 end
   end
 
-  module CallerLocationsShim
-    # Uses as a substitute for the built-in Thread::Backtrace::Location
-    # on Ruby versions that do not support / do not provide it
-    class Location < Struct.new(:path, :lineno)
-    end
-
-    # Like caller_files, but returning CallerLocationShim objects
-    # which work similar to https://ruby-doc.org/core-2.2.0/Thread/Backtrace/Location.html
-    def caller_locations(*)
-      call_sites = cleaned_caller 2
-      call_sites.map do |(path, lineno)|
-        Location.new(path, lineno)
-      end
-    end
-  end
-  
   # Methods available to routes, before/after filters, and views.
   module Helpers
     # Set or retrieve the response status code.
@@ -1573,14 +1557,9 @@ module Sinatra
         cleaned_caller(1).flatten
       end
 
-      # In Ruby 2.x+ a built-in implementation is provided for caller_locations.
-      # If we do not have one, use the previous variant and provide a stub
-      # for the Location objects returned by the Kernel implementation
-      if private_instance_methods.include?(:caller_locations)
-        public :caller_locations
-      else
-        include CallerLocationsShim
-      end
+      # In Ruby 2.x+ a built-in implementation is provided for caller_locations,
+      # which is used to tag templates
+      public :caller_locations
 
       private
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1557,11 +1557,7 @@ module Sinatra
         cleaned_caller(1).flatten
       end
 
-      # Like caller_files, but containing Arrays rather than strings with the
-      # first element being the file, and the second being the line.
-      def caller_locations
-        cleaned_caller 2
-      end
+      public :caller_locations
 
       private
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1576,7 +1576,7 @@ module Sinatra
       # In Ruby 2.x+ a built-in implementation is provided for caller_locations.
       # If we do not have one, use the previous variant and provide a stub
       # for the Location objects returned by the Kernel implementation
-      if private_instance_methods.include?(:zcaller_locations)
+      if private_instance_methods.include?(:caller_locations)
         public :caller_locations
       else
         include CallerLocationsShim

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -266,6 +266,22 @@ module Sinatra
     def http_status; 404 end
   end
 
+  module CallerLocationsShim
+    # Uses as a substitute for the built-in Thread::Backtrace::Location
+    # on Ruby versions that do not support / do not provide it
+    class Location < Struct.new(:path, :lineno)
+    end
+
+    # Like caller_files, but returning CallerLocationShim objects
+    # which work similar to https://ruby-doc.org/core-2.2.0/Thread/Backtrace/Location.html
+    def caller_locations(*)
+      call_sites = cleaned_caller 2
+      call_sites.map do |(path, lineno)|
+        Location.new(path, lineno)
+      end
+    end
+  end
+  
   # Methods available to routes, before/after filters, and views.
   module Helpers
     # Set or retrieve the response status code.
@@ -1557,7 +1573,14 @@ module Sinatra
         cleaned_caller(1).flatten
       end
 
-      public :caller_locations
+      # In Ruby 2.x+ a built-in implementation is provided for caller_locations.
+      # If we do not have one, use the previous variant and provide a stub
+      # for the Location objects returned by the Kernel implementation
+      if private_instance_methods.include?(:zcaller_locations)
+        public :caller_locations
+      else
+        include CallerLocationsShim
+      end
 
       private
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1558,10 +1558,6 @@ module Sinatra
         cleaned_caller(1).flatten
       end
 
-      # In Ruby 2.x+ a built-in implementation is provided for caller_locations,
-      # which is used to tag templates
-      public :caller_locations
-
       private
 
       # Starts the server by running the Rack Handler.

--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -299,8 +299,9 @@ module Sinatra
       end
 
       def template(name, &block)
-        filename, line = caller_locations.first
-        templates[name] = [block, filename, line.to_i]
+        first_location = caller_locations.first
+        filename, line = first_location.path, first_location.lineno
+        templates[name] = [block, filename, line]
       end
 
       def layout(name=:layout, &block)


### PR DESCRIPTION
Ruby 2.+ includes a Kernel implementation of `caller_locations`. This implementation differs subtly from the one in Sinatra, causing breakage when another caller tries to use `caller_locations`. Specifically, this blows up with Bootsnap as noted in https://github.com/Shopify/bootsnap/issues/183

This means that it is impossible to correctly use Sinatra in some situations when a Sinatra application is mounted within a Rails project that uses Bootsnap - which is now the default.

This PR removes the hand-rolled implementation of `caller_locations` and instead exposes the Kernel one as a public method. Since Sinatra now mandates Ruby 2.+ there should be no compatibility problems.