### PR TITLE
Refactor capture method

### DIFF
--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -84,40 +84,26 @@ module Sinatra
   module Capture
     include Sinatra::EngineTracking
 
-    DUMMIES = {
-      :haml   => "!= capture_haml(*args, &block)",
-      :erubi  => "<% @capture = yield(*args) %>",
-      :erubis => "<% @capture = yield(*args) %>",
-      :slim   => "== yield(*args)"
-    }
-
     def capture(*args, &block)
-      @capture = nil
-      if current_engine == :ruby
-        result = block[*args]
-      elsif current_engine == :erb || current_engine == :slim
-        @_out_buf, _buf_was = '', @_out_buf
-        raw = block.call(*args)
-        captured = block.binding.eval('@_out_buf')
-        result = captured.empty? ? raw : captured
-        @_out_buf = _buf_was
+      return block[*args] if ruby?
+      if haml?
+        buffer = Haml::Buffer.new(nil, Haml::Options.new.for_buffer)
+        with_haml_buffer(buffer) { capture_haml(*args, &block) }
       else
-        buffer     = eval '_buf if defined?(_buf)', block.binding
-        old_buffer = buffer.dup if buffer
-        dummy      = DUMMIES.fetch(current_engine)
-        options    = { :layout => false, :locals => {:args => args, :block => block }}
-
-        buffer.clear unless buffer.nil?
-        result = render(current_engine, dummy, options, &block)
+        @_out_buf, _buf_was = '', @_out_buf
+        begin
+          raw = block[*args]
+          captured = block.binding.eval('@_out_buf')
+          captured.empty? ? raw : captured
+        ensure
+          @_out_buf = _buf_was
+        end
       end
-      result && result.strip.empty? && @capture ? @capture : result
-    ensure
-      buffer.replace(old_buffer) unless buffer.nil?
     end
 
     def capture_later(&block)
       engine = current_engine
-      proc { |*a| with_engine(engine) { @capture = capture(*a, &block) }}
+      proc { |*a| with_engine(engine) { @capture = capture(*a, &block) } }
     end
   end
 

--- a/sinatra-contrib/lib/sinatra/engine_tracking.rb
+++ b/sinatra-contrib/lib/sinatra/engine_tracking.rb
@@ -104,6 +104,11 @@ module Sinatra
       @current_engine == :creole
     end
 
+    # @return [Boolean] Returns true if current engine is `:ruby`.
+    def ruby?
+      @current_engine == :ruby
+    end
+
     def initialize(*)
       @current_engine = :ruby
       super


### PR DESCRIPTION
Simplify logic for capturing content for the different template engines. Prior complexity may have been due to encoding issues pre Ruby 2.0, but this doesn't seem to be an issue any longer.