### PR TITLE
rack-protection: Don't track the Accept-Language header by default

### DIFF
--- a/rack-protection/lib/rack/protection/session_hijacking.rb
+++ b/rack-protection/lib/rack/protection/session_hijacking.rb
@@ -14,7 +14,7 @@ module Rack
     class SessionHijacking < Base
       default_reaction :drop_session
       default_options :tracking_key => :tracking, :encrypt_tracking => true,
-        :track => %w[HTTP_USER_AGENT HTTP_ACCEPT_LANGUAGE]
+        :track => %w[HTTP_USER_AGENT]
 
       def accepts?(env)
         session = session env

--- a/rack-protection/spec/lib/rack/protection/session_hijacking_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/session_hijacking_spec.rb
@@ -23,27 +23,6 @@ describe Rack::Protection::SessionHijacking do
     expect(session).not_to be_empty
   end
 
-  it "denies requests with a changing Accept-Language header" do
-    session = {:foo => :bar}
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'a'
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'b'
-    expect(session).to be_empty
-  end
-
-  it "accepts requests with the same Accept-Language header" do
-    session = {:foo => :bar}
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'a'
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'a'
-    expect(session).not_to be_empty
-  end
-
-  it "comparison of Accept-Language header is not case sensitive" do
-    session = {:foo => :bar}
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'a'
-    get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_LANGUAGE' => 'A'
-    expect(session).not_to be_empty
-  end
-
   it "accepts requests with a changing Version header"do
     session = {:foo => :bar}
     get '/', {}, 'rack.session' => session, 'HTTP_VERSION' => '1.0'


### PR DESCRIPTION
The existing default is inappropriate for any applications that accept websocket connections.

Some browsers (e.g., Safari 12, Chrome 71) don't set the `Accept-Language` header for websocket requests. A mixture of requests with and without this header results in unavailable sessions in websocket handlers. This affects both Sinatra apps and other websocket apps using rack-protection in their middleware stack.

Considering the partial nature ("this will not prevent determined hijacking attempts") of the employed defense mechanism and current proliferation of TLS support on the web, I propose relaxing the defaults (the attached patch) or disabling the middleware altogether (happy to help with that too).

Attaching request dumps for 3 modern browsers retrieved by running `socket = new WebSocket("ws://localhost:4669")` from the Developer Console against a local netcat server (`nc -l 127.0.0.1 4669`).

### Safari 12:

```
GET / HTTP/1.1
Upgrade: websocket
Connection: Upgrade
Host: localhost:4669
Origin: http://localhost:4666
Pragma: no-cache
Cache-Control: no-cache
Sec-WebSocket-Key: SeL+g6qVeCy+TSczXF7Wjw==
Sec-WebSocket-Version: 13
Sec-WebSocket-Extensions: x-webkit-deflate-frame
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.2 Safari/605.1.15
Cookie: [concealed]


```

### Chrome 71:

```
GET / HTTP/1.1
Upgrade: websocket
Connection: Upgrade
Host: localhost:4669
Origin: http://localhost:4666
Pragma: no-cache
Cache-Control: no-cache
Sec-WebSocket-Key: JfgrzYvGA1oPtZLasrWOMQ==
Sec-WebSocket-Version: 13
Sec-WebSocket-Extensions: x-webkit-deflate-frame
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.2 Safari/605.1.15
Cookie: [concealed]

```

### Firefox 63:

```
GET / HTTP/1.1
Host: localhost:4669
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:63.0) Gecko/20100101 Firefox/63.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Sec-WebSocket-Version: 13
Origin: http://localhost:4666
Sec-WebSocket-Extensions: permessage-deflate
Sec-WebSocket-Key: 06XKqwIb6Vs6idQ7ilvv5w==
Connection: keep-alive, Upgrade
Cookie: [concealed]
Pragma: no-cache
Cache-Control: no-cache
Upgrade: websocket

```