### PR TITLE
CI matrix: add 2.6.0, update JRuby to 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
   - ruby-head
   - rbx-3
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
   - jruby-head
 
 script: ./.travis.sh
@@ -31,7 +32,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
     - rvm: rbx-3
 
 notifications:


### PR DESCRIPTION
This PR **updates the CI matrix** to 

- use latest [JRuby 9.2.5.0 - release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)
- add 2.6.0

