### PR TITLE
automate patch-level release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,10 @@ matrix:
 notifications:
   slack:
     secure: 6E+GuZId5GcVLgiOKZnE9ZAnJTa+K2Fxqb0KfrECtskviylcPF1OmX36+y7xGUS0P0pGNyWQThe0zCBMpszno/KbvUdIs6jXbOImkFMuo65//4YcivK0rVaYh9uh2S1K3ycaDeUPDf0ulc/AwHnxWGR6yBD2N5idTwt1bsULdy0=
+
+jobs:
+  include:
+    -
+      if: branch = master
+      stage: Patch Version Release
+      script: ./release.sh

--- a/Rakefile
+++ b/Rakefile
@@ -200,6 +200,17 @@ if defined?(Gem)
       end
     end
 
+    desc "Prepares for the patch release"
+    task :travis do
+      load "ci/release.rb"
+      sh <<-SH
+        echo "---\n:rubygems_api_key: #{ENV['RUBYGEMS_API_KEY']}" > ~/.gem/credentials
+        cat ~/.gem/credentials
+        chmod 0600 ~/.gem/credentials
+        sed -i "s/.*VERSION.*/  VERSION = '#{source_version}'/" lib/sandbox/version.rb
+      SH
+    end
+
     desc "Commits the version to github repository"
     task :commit_version do
       sh <<-SH

--- a/ci/release.rb
+++ b/ci/release.rb
@@ -1,0 +1,198 @@
+require 'octokit'
+
+module Release
+  # Config represents configuration struct for use in application.
+  Config = Struct.new(:repository, :github_access_token, :branch, :pull_request_branch, :commit_message) do
+    # Returns true if the current build is eligible for release.
+    # @return [TrueClass, FalseClass]
+    def build_target?
+      branch == 'master' && pull_request_branch == '' && pr_no != 0
+    end
+
+    # Gets the pull request number from the current commit message.
+    # Returns zero if the pull request number cannot be found.
+    # @return [Integer]
+    def pull_request_number
+      Release.pr_no_from(commit_message)
+    end
+    alias pr_no pull_request_number
+  end
+
+  # Changelog represents the change log abstraction, it's used for
+  # generating valid section for `path`.
+  Changelog = Struct.new(:name, :path, :version, :pull_requests) do
+    # Insert a section in `path` before top section.
+    def update!
+      File.open(path, 'r+') do |f|
+        line = f.read
+        f.seek(0)
+        f.puts(to_s)
+        f.write(line)
+      end
+    end
+
+    # Converts into section which is consist of heading and release notes.
+    # @return [String]
+    def to_s
+      heading = "# v#{version} / #{Time.now.strftime('%Y-%m-%d')}"
+      heading + "\n\n" + release_note + "\n\n"
+    end
+
+    private
+
+    def release_note
+      return "Nothing" if pull_requests.length.zero?
+      pull_requests.map { |pull_request|
+        entry = "* #{pull_request.title.capitalize}"
+        entry += " [##{pull_request.number}](https://github.com/#{name}/pull/#{pull_request.number}) by"
+        entry += " [@#{pull_request.user.login}](https://github.com/#{pull_request.user.login})"
+      }.join(?\n)
+    end
+  end
+
+  class API
+    attr_reader :client, :repository
+
+    def initialize(name, access_token)
+      @client = Octokit::Client.new(access_token: access_token)
+      @repository = @client.repo name
+    end
+
+    def get_pull_request(pr_no)
+      fetch { repository.rels[:issues].get(uri: { number: pr_no }) }
+    end
+
+    def get_latest_version
+      return unless data = fetch { repository.rels[:tags].get }
+      data.first.name
+    end
+
+    def get_commits_between(base:, head: 'master')
+      return [] unless data = fetch { repository.rels[:compare].get(uri: { base: base, head: head }) }
+      data.commits.map(&:commit)
+    end
+
+    private
+
+    def fetch
+      response = yield
+      response.status == 200 ? response.data : nil
+    end
+  end
+
+  module Helpers
+    def pull_request_number_from_commit_message(message)
+      matched = message.match(%r{Merge pull request #(\d+) from})
+      return 0 unless matched
+      matched[1].to_i
+    end
+    alias pr_no_from pull_request_number_from_commit_message
+
+    # Increments version to next release version
+    #
+    # @example
+    #   increment_version(2.0.1, candidate: false) => 2.0.2
+    #   increment_version(2.0.1, candidate: true) => 2.0.2.rc
+    #   increment_version(2.0.1.rc, candidate: false) => 2.0.1
+    #   increment_version(2.0.1.rc, candidate: true) => 2.0.1.rc1
+    #   increment_version(2.0.1.rc1, candidate: false) => 2.0.1
+    #   increment_version(2.0.1.rc1, candidate: true) => 2.0.1.rc2
+    #   increment_version(2.0.1.rc2, candidate: false) => 2.0.1
+    #   increment_version(2.0.1.rc2, candidate: true) => 2.0.1.rc3
+    #   increment_version(2.0.1.beta1, candidate: false) => 2.0.1
+    #   increment_version(2.0.1.beta1, candidate: true) => 2.0.1.beta2
+    #   increment_version(2.0.1.beta2, candidate: false) => 2.0.1
+    #   increment_version(2.0.1.beta2, candidate: true) => 2.0.1.beta3
+    def increment_version(version, candidate: false)
+      major, minor, patch, suffix = version.split(?., 4)
+      major = major.slice(1..-1) if version.start_with?(?v)
+      matched = (suffix || '').match(%r{(rc|beta)([\d]*)\z})
+      # Bump patch version to next unless previous version doesn't have any candidate suffixes.
+      patch = patch.to_i.next unless matched
+      if candidate
+        suffix = matched ? "#{matched[1]}#{matched[2].to_i.next}" : 'rc'
+      else
+        suffix = nil
+      end
+      "#{major}.#{minor}.#{patch}#{".#{suffix}" if suffix && !suffix.empty?}"
+    end
+
+    def config
+      @config ||= Config.new
+    end
+
+    def say(message)
+      puts message.strip
+      exit 0
+    end
+  end
+
+  extend self
+  extend Helpers
+
+  def run!
+    # Validate current build whether it is targed for releasing patch version
+    say <<-EOS unless config.build_target?
+      Auto release doesn't proceed releasing if the trigger commit isn't merge commit. 
+    EOS
+
+    # Generate API client
+    api = API.new(config.repository, config.github_access_token)
+
+    # Abort if a pull request cannot be found by given pr no.
+    say <<-EOS unless pull_request = api.get_pull_request(config.pr_no)
+      Cannot detect a pull request ##{config.pr_no}
+    EOS
+
+    # Abort if the "release/patch" label cannot be found from the pull request.
+    say <<-EOS unless pull_request.labels.any? { |label| label.name == 'release/patch' }
+      Cannot detect the "release/patch" label in pull request ##{config.pr_no}
+    EOS
+
+    # Release candidate version if the pull request has the 'release/candidate' label.
+    candidate = pull_request.labels.any? { |label| label.name == 'release/candidate' }
+
+    # Abort if available tag does not exist.
+    say <<-EOS unless latest_version = api.get_latest_version
+      Cannot detect any tags
+    EOS
+
+    # Get targeted commits between latest version and head.
+    commits = api.get_commits_between(base: latest_version)
+    # Select pull requests for updating changelog
+    pull_requests = commits.each_with_object([]) do |commit, pull_requests|
+      # Skip non-merge commit
+      next unless commit.committer.name == "GitHub" && commit.committer.email == "noreply@github.com"
+      # Skip if the pull request number cannot be found
+      pr_no = pr_no_from(commit.message)
+      next if pr_no == 0
+      # Skip if the pull request cannot be found by given number
+      next unless pull_request = api.get_pull_request(pr_no)
+      # Skip if the pull request does not contains the "release-note" label
+      next unless pull_request.labels.any? { |label| label.name == 'release-note' }
+      pull_requests << pull_request
+    end
+
+    # Bump version to next version
+    next_version = increment_version(latest_version, candidate: candidate)
+    changelog = Changelog.new(config.repository, 'CHANGELOG.md', next_version, pull_requests).update!
+
+    # Bump VERSION to next
+    File.write('VERSION', next_version)
+  end
+
+  def configure
+    yield(config)
+  end
+end
+
+# Configure required values
+Release.configure do |cfg|
+  cfg.repository          = ENV['TRAVIS_REPO_SLUG']
+  cfg.branch              = ENV['TRAVIS_BRANCH']
+  cfg.commit_message      = ENV['TRAVIS_COMMIT_MESSAGE']
+  cfg.pull_request_branch = ENV['TRAVIS_PULL_REQUEST_BRANCH']
+  cfg.github_access_token = ENV['GITHUB_ACCESS_TOKEN']
+end
+
+Release.run!

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -evu
+
+owner=sinatra
+repository=sinatra
+
+function halt() {
+  echo 1>&2 $*
+  exit 0
+}
+
+function say() {
+  echo 1>&2 $*
+}
+
+# To decrypt a private key for use in github.
+say "Configures settings for connecting to github remotely.."
+# TODO(namusyaka): we need update following line after adding sinatra-bot as a collaborator and executing `travis encrypt-file sinatra-bot`
+openssl aes-256-cbc -K $encrypted_5b48ddf2a81f_key -iv $encrypted_5b48ddf2a81f_iv -in sinatra-bot.enc -out ~/.ssh/id_rsa -d
+chmod 600 ~/.ssh/id_rsa
+echo -e "Host github.com\n\tStrictHostKeyChecking no\n\nIdentityFile ~/.ssh/id_rsa\n" >> ~/.ssh/config
+
+# Configure release commit author.
+git config --global user.name "Sinatra Bot"
+git config --global user.email "namusyaka+sinatra@gmail.com"
+say "done."
+
+say "Makes sure the rubygems credentials exists in correct place.."
+mkdir -p ~/.gem && touch ~/.gem/credentials
+say "done."
+
+say "Clones a tartget repository.."
+git clone git@github.com:$owner/$repository.git -b master
+say "done."
+
+cd $repository
+bundle install
+say "Generates new entry in CHANGELOG.md and Bumps version to new.."
+bundle exec rake release:travis
+say "done."
+
+if git diff --exit-code; then
+  halt "changes seem not to be detected, finished."
+fi
+
+say "Releases new versions.."
+bundle exec rake release:all
+say "done."


### PR DESCRIPTION
Hello @sinatra friends!
I've been working on the automation recently, and right now I confirmed the automation works correctly, so I would like to get your feedback!

Background: #1510 

This change offers two features.
1. Automate to upgrade `CHANGELOG.md` and `VERSION` for next patch level release.
2. Execute `rake release:all` to publish all gems.

We're now able to cut a patch-level release easily by using github labels:

### `release/patch`
- If the pull request has this label and gets merged, new patch version will be released. (e.g. `v2.0.6`)

### `release/candidate`
- If the pull request has this label and gets merged, new version will be released as release-candidate. (e.g. `v2.0.6.rc`)

### `release-note`
- The automation script will automatically generate the CHANGELOG entry.
- The script will collect pull requests for generating entry by whether the label has been attached or not.
---
Before merging this, we need to check some points for reducing troubles.

We need to check that required access has been granted for @sinatra-bot.
@sinatra-bot should be:
- Added as a `collaborator` (read/write) into this repository
- Added an owner to `sinatra`, `sinatra-contrib` and `rack-protection` gems in rubygems.org.

Then, I have a private key for @sinatra-bot, and it must be encrypted and be committed to this repository for accessing to this repository from travisci, so we need encrypt the private key by `travis encrypt-file [PEM]`. You can see more details in .travis.yml and release.sh.

---
Last, thanks for taking a look at this pull request. If you have more time, please review the codes, the structure, and actual automation workflow at https://github.com/sinatra-bot/sandbox.
I'm looking forward to get your feedback!

Thanks,