### PR TITLE
Avoid `TypeError` when params contain a key without a value on Ruby < 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Avoid `TypeError` when params contain a key without a value on Ruby < 2.4 [#1516](https://github.com/sinatra/sinatra/pull/1516) by Samuel Giddins
+
 ## 2.0.5 / 2018-12-22
 
 * Avoid FrozenError when params contains frozen value [#1506](https://github.com/sinatra/sinatra/pull/1506) by Kunpei Sakai

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1089,7 +1089,7 @@ module Sinatra
 
     # Dispatch a request with error handling.
     def dispatch!
-      @params.merge!(@request.params).each { |key, val| @params[key] = force_encoding(val.dup) }
+      @params.merge!(@request.params).each { |key, val| @params[key] = val && force_encoding(val.dup) }
 
       invoke do
         static! if settings.static? && (request.get? || request.head?)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -311,6 +311,17 @@ class RoutingTest < Minitest::Test
     assert_equal 'well, alright', body
   end
 
+  it "handles params without a value" do
+    mock_app {
+      get '/' do
+        assert_nil params.fetch('foo')
+        "Given: #{params.keys.sort.join(',')}"
+      end
+    }
+    get '/?foo'
+    assert_equal 'Given: foo', body
+  end
+
   it "merges named params and query string params in params" do
     mock_app {
       get '/:foo' do


### PR DESCRIPTION
Fixes https://github.com/sinatra/sinatra/issues/1514