### PR TITLE
CI: Update matrix versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.5.5
+  - 2.6.2
   - ruby-head
   - rbx-3
-  - jruby-9.2..0
+  - jruby-9.2.6.0
   - jruby-head
 
 script: ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ addons:
 rvm:
   - 2.2.10
   - 2.3.8
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
   - 2.6.2
   - ruby-head
   - rbx-3
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - jruby-head
 
 script: ./.travis.sh
@@ -35,7 +35,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
     - rvm: rbx-3
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 
 dist: trusty
-sudo: false
 
 before_install:
   - if [ "$TRAVIS_RUBY_VERSION" = "2.2.10" ]; then
@@ -24,10 +23,10 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
   - ruby-head
   - rbx-3
-  - jruby-9.2.5.0
+  - jruby-9.2..0
   - jruby-head
 
 script: ./.travis.sh
@@ -36,7 +35,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
     - rvm: rbx-3
 
 notifications:


### PR DESCRIPTION
  - drop the sudo: false directive which now does nothing

---

This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)