### PR TITLE
avoid multiple errors even if `params` contains special values

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1089,7 +1089,12 @@ module Sinatra
 
     # Dispatch a request with error handling.
     def dispatch!
-      @params.merge!(@request.params).each { |key, val| @params[key] = val && force_encoding(val.dup) }
+      # Avoid passing frozen string in force_encoding
+      @params.merge!(@request.params).each do |key, val|
+        next unless val.respond_to?(:force_encoding)
+        val = val.dup if val.frozen?
+        @params[key] = force_encoding(val)
+      end
 
       invoke do
         static! if settings.static? && (request.get? || request.head?)

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -78,4 +78,23 @@ class MiddlewareTest < Minitest::Test
     @app.use FreezeMiddleware
     get '/Foo'
   end
+
+  class SpecialConstsMiddleware < MockMiddleware
+    def call(env)
+      req = Rack::Request.new(env)
+      req.update_param('s', :s)
+      req.update_param('i', 1)
+      req.update_param('c', 3.to_c)
+      req.update_param('t', true)
+      req.update_param('f', false)
+      req.update_param('n', nil)
+      super
+    end
+  end
+
+  it "handles params when the params contains true/false values" do
+    @app.use SpecialConstsMiddleware
+    get '/'
+  end
+
 end


### PR DESCRIPTION
The original fixes are #1506 and #1517.
This commit considers `FrozenError` and `TypeEror` for the case.

`Object#dup` has a possibility of raising `TypeError` when ruby <= 2.3 and the receiver is a special const.
What's special const? It depends on the ruby version. Currently, it's defined [here](https://github.com/ruby/ruby/blob/cf781b0871cb8d6b7135fa74d9549ca1cdb2a846/object.c#L355).
In the ruby-2.3.8, it's defined in other place.

To fix this issue, I had an option which is managing the special const mapping in our code, but it's very hard to manage, and there is a possibility of  increasing complexity. . So I would like to handle the issue by `rescue`ing `TypeError` in this case.

What do you think? Any opinions or any ideas?
