### PR TITLE
[rack-protection] Drop Ruby 1.8 compat code

### DIFF
--- a/rack-protection/lib/rack/protection/path_traversal.rb
+++ b/rack-protection/lib/rack/protection/path_traversal.rb
@@ -19,18 +19,10 @@ module Rack
       end
 
       def cleanup(path)
-        if path.respond_to?(:encoding)
-          # Ruby 1.9+ M17N
-          encoding = path.encoding
-          dot   = '.'.encode(encoding)
-          slash = '/'.encode(encoding)
-          backslash = '\\'.encode(encoding)
-        else
-          # Ruby 1.8
-          dot   = '.'
-          slash = '/'
-          backslash = '\\'
-        end
+        encoding = path.encoding
+        dot   = '.'.encode(encoding)
+        slash = '/'.encode(encoding)
+        backslash = '\\'.encode(encoding)
 
         parts     = []
         unescaped = path.gsub(/%2e/i, dot).gsub(/%2f/i, slash).gsub(/%5c/i, backslash)

--- a/rack-protection/spec/lib/rack/protection/path_traversal_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/path_traversal_spec.rb
@@ -24,16 +24,14 @@ describe Rack::Protection::PathTraversal do
     end
   end
 
-  if "".respond_to?(:encoding)  # Ruby 1.9+ M17N
-    context "PATH_INFO's encoding" do
-      before do
-        @app = Rack::Protection::PathTraversal.new(proc { |e| [200, {'Content-Type' => 'text/plain'}, [e['PATH_INFO'].encoding.to_s]] })
-      end
+  context "PATH_INFO's encoding" do
+    before do
+      @app = Rack::Protection::PathTraversal.new(proc { |e| [200, {'Content-Type' => 'text/plain'}, [e['PATH_INFO'].encoding.to_s]] })
+    end
 
-      it 'should remain unchanged as ASCII-8BIT' do
-        body = @app.call({ 'PATH_INFO' => '/'.encode('ASCII-8BIT') })[2][0]
-        expect(body).to eq('ASCII-8BIT')
-      end
+    it 'should remain unchanged as ASCII-8BIT' do
+      body = @app.call({ 'PATH_INFO' => '/'.encode('ASCII-8BIT') })[2][0]
+      expect(body).to eq('ASCII-8BIT')
     end
   end
 end


### PR DESCRIPTION
This PR cleans up Ruby 1.8 compatibility code.

Same kind of thing as https://github.com/sinatra/sinatra/pull/1527