### PR TITLE
Remove outdated code for Tilt 1.x versions 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ if RUBY_ENGINE == "ruby"
   gem 'sass'
   gem 'reel-rack'
   gem 'celluloid', '~> 0.16.0'
+  gem 'commonmarker', '~> 0.20.0'
   gem 'simplecov', require: false
 end
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -786,15 +786,8 @@ module Sinatra
     def find_template(views, name, engine)
       yield ::File.join(views, "#{name}.#{@preferred_extension}")
 
-      if Tilt.respond_to?(:mappings)
-        Tilt.mappings.each do |ext, engines|
-          next unless ext != @preferred_extension and engines.include? engine
-          yield ::File.join(views, "#{name}.#{ext}")
-        end
-      else
-        Tilt.default_mapping.extensions_for(engine).each do |ext|
-          yield ::File.join(views, "#{name}.#{ext}") unless ext == @preferred_extension
-        end
+      Tilt.default_mapping.extensions_for(engine).each do |ext|
+        yield ::File.join(views, "#{name}.#{ext}") unless ext == @preferred_extension
       end
     end
 

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -173,16 +173,12 @@ module Sinatra
           settings.template_engines[ext].each { |e| possible << [e, name] }
         end
         possible.each do |engine, template|
-          # not exactly like Tilt[engine], but does not trigger a require
-          if Tilt.respond_to?(:mappings)
-            klass = Tilt.mappings[Tilt.normalize(engine)].first
-          else
-            begin
-              klass = Tilt[engine]
-            rescue LoadError
-              next
-            end
+          begin
+            klass = Tilt[engine]
+          rescue LoadError
+            next
           end
+
           find_template(settings.views, template, klass) do |file|
             next unless File.exist? file
             return settings.rendering_method(engine) << template.to_sym

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -39,7 +39,7 @@ EOF
   s.add_dependency "sinatra", version
   s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", ">= 2.8.2"
-  s.add_dependency "tilt",      ">= 1.3", "< 3"
+  s.add_dependency "tilt", "~> 2.0"
   s.add_dependency "rack-protection", version
   s.add_dependency "multi_json"
 

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -198,7 +198,7 @@ class StaticTest < Minitest::Test
   it 'sets cache control headers on static files if set' do
     @app.set :static_cache_control, :public
     env = Rack::MockRequest.env_for("/#{File.basename(__FILE__)}")
-    status, headers, body = @app.call(env)
+    _, headers, _ = @app.call(env)
     assert headers.has_key?('Cache-Control')
     assert_equal headers['Cache-Control'], 'public'
 
@@ -207,7 +207,7 @@ class StaticTest < Minitest::Test
       [:public, :must_revalidate, {:max_age => 300}]
     )
     env = Rack::MockRequest.env_for("/#{File.basename(__FILE__)}")
-    status, headers, body = @app.call(env)
+    _, headers, _ = @app.call(env)
     assert headers.has_key?('Cache-Control')
     assert_equal(
       headers['Cache-Control'],


### PR DESCRIPTION
I found out that Sinatra codebase still contains a code for handling both versions of Tilt (1.x and 2.x), however starting from Sinatra 2.0 the minimally required version of Tilt is 2.0 as well.

I've also added `commonmarker` gem because otherwise it triggers warnings during a test run and does not generate tests for this markdown engine.


