### PR TITLE
Add pandoc support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
   - ubuntu-toolchain-r-test
   packages:
   - g++-4.8
-
+  - pandoc
 rvm:
   - 2.2.10
   - 2.3.8

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ if RUBY_ENGINE == "ruby"
   gem 'reel-rack'
   gem 'celluloid', '~> 0.16.0'
   gem 'commonmarker', '~> 0.20.0'
+  gem 'pandoc-ruby', '~> 2.0.2'
   gem 'simplecov', require: false
 end
 

--- a/README.md
+++ b/README.md
@@ -750,6 +750,8 @@ template, you almost always want to pass locals to it.
         <a href="https://github.com/ged/bluecloth" title="BlueCloth">BlueCloth</a>,
         <a href="https://kramdown.gettalong.org/" title="kramdown">kramdown</a>,
         <a href="https://github.com/bhollis/maruku" title="maruku">maruku</a>
+        <a href="https://github.com/gjtorikian/commonmarker" title="commonmarker">commonmarker</a>
+        <a href="https://github.com/alphabetum/pandoc-ruby" title="pandoc">pandoc</a>
     </td>
   </tr>
   <tr>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -722,7 +722,7 @@ module Sinatra
     end
 
     def markdown(template, options = {}, locals = {})
-      options[:default_outvar] = false
+      options[:exclude_outvar] = true
       render :markdown, template, options, locals
     end
 
@@ -819,11 +819,11 @@ module Sinatra
       content_type    = options.delete(:content_type)   || content_type
       layout_engine   = options.delete(:layout_engine)  || engine
       scope           = options.delete(:scope)          || self
-      default_outvar  = options.delete(:default_outvar) != false
+      exclude_outvar  = options.delete(:exclude_outvar)
       options.delete(:layout)
 
       # set some defaults
-      options[:outvar] ||= '@_out_buf' if default_outvar
+      options[:outvar] ||= '@_out_buf' unless exclude_outvar
       options[:default_encoding] ||= settings.default_encoding
 
       # compile and render template

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -722,6 +722,7 @@ module Sinatra
     end
 
     def markdown(template, options = {}, locals = {})
+      options[:default_outvar] = false
       render :markdown, template, options, locals
     end
 
@@ -818,10 +819,11 @@ module Sinatra
       content_type    = options.delete(:content_type)   || content_type
       layout_engine   = options.delete(:layout_engine)  || engine
       scope           = options.delete(:scope)          || self
+      default_outvar  = options.delete(:default_outvar) != false
       options.delete(:layout)
 
       # set some defaults
-      options[:outvar]           ||= '@_out_buf'
+      options[:outvar] ||= '@_out_buf' if default_outvar
       options[:default_encoding] ||= settings.default_encoding
 
       # compile and render template


### PR DESCRIPTION
Here I try to fix an another warning from tests.
```
cannot load such file -- pandoc-ruby: skipping markdown tests with
Tilt::PandocTemplate
```

`pandoc-ruby` is not defined in Gemfile, so I add it there. This gem has a prerequisite dependency `pandoc` (a CLI application) that can be installed via apt. That's why I update travis.yml to make it available during a test run.

The final step to make it work is to exclude `outvar` from the option's list provided to the template. When `pandoc` application is called with unsupported parameters it stops the execution and returns an error.
```
Unknown option --outvar.
Try pandoc --help for more information.
```

I'm not really sure why `outvar` parameter is defined by default and what it supposed to do. It seems that it was used before by several templates engines, but looks like it is not supported by all of them. I managed to find a old commit that introduces it https://github.com/sinatra/sinatra/pull/56/commits/f8e0a34a4448e58fdfe46bfe7631bb7cb316b7a6. 

I've added a setting to exclude and disable it for markdown engines, but I have doubts if it is a safe option. What do you think?
