### PR TITLE
Fix issue setting environment from command line option

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1831,58 +1831,6 @@ module Sinatra
       content_type 'text/html'
       '<h1>Internal Server Error</h1>'
     end
-
-    configure :development do
-      get '/__sinatra__/:image.png' do
-        filename = File.dirname(__FILE__) + "/images/#{params[:image].to_i}.png"
-        content_type :png
-        send_file filename
-      end
-
-      error NotFound do
-        content_type 'text/html'
-
-        if self.class == Sinatra::Application
-          code = <<-RUBY.gsub(/^ {12}/, '')
-            #{request.request_method.downcase} '#{request.path_info}' do
-              "Hello World"
-            end
-          RUBY
-        else
-          code = <<-RUBY.gsub(/^ {12}/, '')
-            class #{self.class}
-              #{request.request_method.downcase} '#{request.path_info}' do
-                "Hello World"
-              end
-            end
-          RUBY
-
-          file = settings.app_file.to_s.sub(settings.root.to_s, '').sub(/^\//, '')
-          code = "# in #{file}\n#{code}" unless file.empty?
-        end
-
-        (<<-HTML).gsub(/^ {10}/, '')
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <style type="text/css">
-            body { text-align:center;font-family:helvetica,arial;font-size:22px;
-              color:#888;margin:20px}
-            #c {margin:0 auto;width:500px;text-align:left}
-            </style>
-          </head>
-          <body>
-            <h2>Sinatra doesn’t know this ditty.</h2>
-            <img src='#{uri "/__sinatra__/404.png"}'>
-            <div id="c">
-              Try this:
-              <pre>#{Rack::Utils.escape_html(code)}</pre>
-            </div>
-          </body>
-          </html>
-        HTML
-      end
-    end
   end
 
   # Execution context for classic style (top-level) applications. All

--- a/lib/sinatra/main.rb
+++ b/lib/sinatra/main.rb
@@ -1,16 +1,8 @@
 require 'sinatra/base'
 
 module Sinatra
-  class Application < Base
-
-    # we assume that the first file that requires 'sinatra' is the
-    # app_file. all other path related options are calculated based
-    # on this path by default.
-    set :app_file, caller_files.first || $0
-
-    set :run, Proc.new { File.expand_path($0) == File.expand_path(app_file) }
-
-    if run? && ARGV.any?
+  class Base
+    if ARGV.any?
       require 'optparse'
       OptionParser.new { |op|
         op.on('-p port',   'set the port (default is 4567)')                { |val| set :port, Integer(val) }
@@ -21,6 +13,67 @@ module Sinatra
         op.on('-x',        'turn on the mutex lock (default is off)')       {       set :lock, true }
       }.parse!(ARGV.dup)
     end
+
+    configure :development do
+      get '/__sinatra__/:image.png' do
+        filename = File.dirname(__FILE__) + "/images/#{params[:image].to_i}.png"
+        content_type :png
+        send_file filename
+      end
+
+      error NotFound do
+        content_type 'text/html'
+
+        if self.class == Sinatra::Application
+          code = <<-RUBY.gsub(/^ {12}/, '')
+            #{request.request_method.downcase} '#{request.path_info}' do
+              "Hello World"
+            end
+          RUBY
+        else
+          code = <<-RUBY.gsub(/^ {12}/, '')
+            class #{self.class}
+              #{request.request_method.downcase} '#{request.path_info}' do
+                "Hello World"
+              end
+            end
+          RUBY
+
+          file = settings.app_file.to_s.sub(settings.root.to_s, '').sub(/^\//, '')
+          code = "# in #{file}\n#{code}" unless file.empty?
+        end
+
+        (<<-HTML).gsub(/^ {10}/, '')
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <style type="text/css">
+            body { text-align:center;font-family:helvetica,arial;font-size:22px;
+              color:#888;margin:20px}
+            #c {margin:0 auto;width:500px;text-align:left}
+            </style>
+          </head>
+          <body>
+            <h2>Sinatra doesn’t know this ditty.</h2>
+            <img src='#{uri "/__sinatra__/404.png"}'>
+            <div id="c">
+              Try this:
+              <pre>#{Rack::Utils.escape_html(code)}</pre>
+            </div>
+          </body>
+          </html>
+        HTML
+      end
+    end
+  end
+
+  class Application < Base
+    # we assume that the first file that requires 'sinatra' is the
+    # app_file. all other path related options are calculated based
+    # on this path by default.
+    set :app_file, caller_files.first || $0
+
+    set :run, Proc.new { File.expand_path($0) == File.expand_path(app_file) }
   end
 
   at_exit { Application.run! if $!.nil? && Application.run? }


### PR DESCRIPTION
When setting environment to production from command line, some development configurations were already registered. For instance the development `NotFound` error handler was setup. Command line options are now parsed before environment configurations are run. Resolves #1544.