### PR TITLE
Revert "Remove outdated code for Tilt 1.x versions "

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ if RUBY_ENGINE == "ruby"
   gem 'sass'
   gem 'reel-rack'
   gem 'celluloid', '~> 0.16.0'
-  gem 'commonmarker', '~> 0.20.0'
   gem 'simplecov', require: false
 end
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -786,8 +786,15 @@ module Sinatra
     def find_template(views, name, engine)
       yield ::File.join(views, "#{name}.#{@preferred_extension}")
 
-      Tilt.default_mapping.extensions_for(engine).each do |ext|
-        yield ::File.join(views, "#{name}.#{ext}") unless ext == @preferred_extension
+      if Tilt.respond_to?(:mappings)
+        Tilt.mappings.each do |ext, engines|
+          next unless ext != @preferred_extension and engines.include? engine
+          yield ::File.join(views, "#{name}.#{ext}")
+        end
+      else
+        Tilt.default_mapping.extensions_for(engine).each do |ext|
+          yield ::File.join(views, "#{name}.#{ext}") unless ext == @preferred_extension
+        end
       end
     end
 

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -173,12 +173,16 @@ module Sinatra
           settings.template_engines[ext].each { |e| possible << [e, name] }
         end
         possible.each do |engine, template|
-          begin
-            klass = Tilt[engine]
-          rescue LoadError
-            next
+          # not exactly like Tilt[engine], but does not trigger a require
+          if Tilt.respond_to?(:mappings)
+            klass = Tilt.mappings[Tilt.normalize(engine)].first
+          else
+            begin
+              klass = Tilt[engine]
+            rescue LoadError
+              next
+            end
           end
-
           find_template(settings.views, template, klass) do |file|
             next unless File.exist? file
             return settings.rendering_method(engine) << template.to_sym

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -39,7 +39,7 @@ EOF
   s.add_dependency "sinatra", version
   s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", ">= 2.8.2"
-  s.add_dependency "tilt", "~> 2.0"
+  s.add_dependency "tilt",      ">= 1.3", "< 3"
   s.add_dependency "rack-protection", version
   s.add_dependency "multi_json"
 

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -198,7 +198,7 @@ class StaticTest < Minitest::Test
   it 'sets cache control headers on static files if set' do
     @app.set :static_cache_control, :public
     env = Rack::MockRequest.env_for("/#{File.basename(__FILE__)}")
-    _, headers, _ = @app.call(env)
+    status, headers, body = @app.call(env)
     assert headers.has_key?('Cache-Control')
     assert_equal headers['Cache-Control'], 'public'
 
@@ -207,7 +207,7 @@ class StaticTest < Minitest::Test
       [:public, :must_revalidate, {:max_age => 300}]
     )
     env = Rack::MockRequest.env_for("/#{File.basename(__FILE__)}")
-    _, headers, _ = @app.call(env)
+    status, headers, body = @app.call(env)
     assert headers.has_key?('Cache-Control')
     assert_equal(
       headers['Cache-Control'],


### PR DESCRIPTION
Reverts sinatra/sinatra#1532От 1d19193653b0c2c0bde044ca2279b30b64bf7316 пн сеп 17 00:00:00 2001
От: Василий Яклюшин <vyaklushin@gmail.com>
Дата: неделя, 28 април 2019 г. 18:02:09 +0200
Тема: [PATCH 1/4] Премахване на остарял код за поддръжка на Tilt 1.x версии

Открих, че кодовата база на Синатра все още съдържа код за обработка
двете версии на Tilt (1.x и 2.x), но започвайки от Sinatra 2.0
минимално необходимата версия на Tilt също е 2.0.

Този ангажимент премахва стария код и изчиства малко как тестовете
генерират се различни маркиращи двигатели.
---
 lib / sinatra / base.rb | 11 ++ ---------
 test / markdown_test.rb | 15 ++++++++ -------
 2 променени файла, 10 вмъквания (+), 16 изтривания (-)

diff - затвори a / lib / sinatra / base.rb b / lib / sinatra / base.rb
индекс d9c3164a1..9e41e940a 100644
--- a / lib / sinatra / base.rb
+++ b / lib / sinatra / base.rb
@@ -786,15 +786,8 @@ def rabl (шаблон, опции = {}, локали = {})
     def find_template (изгледи, име, двигател)
       yield :: File.join (изгледи, "#{name}.#{@preferred_extension}")
 
- ако Tilt.respond_to? (: mappings)
- Tilt.mappings.each do | ext, двигатели |
- следващата, освен ако не е ext! = @preferred_extension и engines.include? двигател
- yield :: File.join (изгледи, "# {name}. # {ext}")
- край
- друго
- Tilt.default_mapping.extensions_for (engine) .each do | ext |
- yield :: File.join (изгледи, "# {name}. # {ext}"), освен ако ext == @preferred_extension
- край
+ Tilt.default_mapping.extensions_for (engine) .each do | ext |
+ yield :: File.join (изгледи, "# {name}. # {ext}"), освен ако ext == @preferred_extension
       край
     край
 
diff - затвори a / test / markdown_test.rb b / test / markdown_test.rb
индекс 7c7deecf3..b363d4061 100644
--- a / test / markdown_test.rb
+++ b / test / markdown_test.rb
@@ -69,17 +69,18 @@ def setup
 край
 
 # Ще генерира RDiscountTest, KramdownTest и др.
-map = Tilt.respond_to? (: lazy_map)? Tilt.lazy_map ['md'] .map (&: first): Tilt.mappings ['md']
+ markdown_templates = Tilt.lazy_map ['md'] .map {| klass, _require_path | klass}
 
-map.each |
+ markdown_templates.each do | template_name |
   започвам
- t = eval (t), ако t.is_a? низ
- t.new {""}
- klass = Class.new (Minitest :: Test) {define_method (: engine) {t}}
+ template = Object.const_get (име на шаблон)
+
+ klass = Class.new (Minitest :: Test) {define_method (: engine) {шаблон}}
     klass.class_eval (& MarkdownTest)
- име = t.name [/ [^:] + $ /]. sub (/ Template $ /, '') << "Тест"
+
+ name = template_name.split ('::'). last.sub (/ Шаблон $ /, 'Тест')
     Име на Object.const_set, klass
   rescue LoadError, NameError
- warn "# {$!}: прескачане на тестовете за намаление с # {t}"
+ warn "# {$!}: прескача тестове за намаляване с # {template_name}"
   край
 край

От c0dd32ec196bf103229f615a3cea915bd68e2547 пн сеп 17 00:00:00 2001
От: Василий Яклюшин <vyaklushin@gmail.com>
Дата: неделя, 28 април 2019 г. 18:02:45 +0200
Тема: [PATCH 2/4] Добавяне на скъпоценен камък

Той разрешава следните предупреждения при тестовете:
`` `
не може да зареди такъв файл - commonmarker: пропуска тестовете за намаление с Tilt :: CommonMarkerTemplate
`` `
---
 Gemfile | 1 +
 1 файл е променен, 1 е поставен (+)

diff - git a / Gemfile b / Gemfile
индекс 13bee90de..6df880fd4 100644
--- a / Gemfile
+++ b / Gemfile
@@ -59,6 +59,7 @@ ако RUBY_ENGINE == "рубин"
   скъпоценен камък
   скъпоценност
   скъпоценен камък „целулоид“, „~> 0.16.0“
+ gem „общ маркер“, „~> 0.20.0“
   gem "simplecov", изискват: false
 край
 

От 9f6c2625913db9001867e1cc376444533db94b20 Пон Сеп 17 00:00:00 2001
От: Василий Яклюшин <vyaklushin@gmail.com>
Дата: неделя, 28 април 2019 г. 16:38:36 +0200
Тема: [PATCH 3/4] Поправка на предупреждение: присвоена, но неизползвана променлива

---
 test / static_test.rb | 4 ++ -
 1 променен файл, 2 вмъквания (+), 2 изтривания (-)

diff - git a / test / static_test.rb b / тест / static_test.rb
индекс d0cbbb03c..e8408b14e 100644
--- a / test / static_test.rb
+++ b / test / static_test.rb
@@ -198,7 +198,7 @@ def assert_valid_range (http_range, обхват, път, файл)
   той "задава кеш контролни заглавия на статични файлове, ако е настроен"
     @ app.set: static_cache_control,: public
     env = Rack :: MockRequest.env_for ("/ # {File.basename (__ FILE__)}")
- състояние, заглавия, body = @ app.call (env)
+ _, заглавки, _ = @ app.call (env)
     да потвърди headers.has_key? („Управление на кеша“)
     assert_equal заглавия ['Cache-Control'], 'public'
 
@@ -207,7 +207,7 @@ def assert_valid_range (http_range, обхват, път, файл)
       [: public,: must_revalidate, {: max_age => 300}]
     )
     env = Rack :: MockRequest.env_for ("/ # {File.basename (__ FILE__)}")
- състояние, заглавия, body = @ app.call (env)
+ _, заглавки, _ = @ app.call (env)
     да потвърди headers.has_key? („Управление на кеша“)
     assert_equal (
       заглавията [ "Кеш-контрол"],

От c4ec8837cb6d97a778843247c23fe64939e0d4e8 Пет Сеп 17 00:00:00 2001
От: Василий Яклюшин <vyaklushin@gmail.com>
Дата: Сря, 1 май 2019 г. 12:19:44 +0200
Тема: [PATCH 4/4] Пренебрегва поддръжката на tilt 1.x за sinatra-contrib

---
 sinatra-contrib / lib / sinatra / reply_with.rb | 14 +++++ ---------
 sinatra-contrib / sinatra-contrib.gemspec | 2 + -
 2 променени файла, 6 вмъквания (+), 10 заличавания (-)

diff - git a / sinatra-contrib / lib / синатра / respond_with.rb b / sinatra-contrib / lib / sinatra
индекс 8521ca984..ed788c4b4 100644
--- a / sinatra-contrib / lib / синатра / respond_with.rb
+++ b / sinatra-contrib / lib / sinatra / reply_with.rb
@@ -173,16 +173,12 @@ def template_for (име, exts)
           settings.template_engines [ext] .each {| e | възможно << [e, име]}
         край
         възможно, всеки | двигател, шаблон |
- # не е точно като Tilt [engine], но не задейства изискване
- ако Tilt.respond_to? (: mappings)
- klass = Tilt.mappings [Tilt.normalize (engine)]
- друго
- започнете
- klass = Tilt [двигател]
спасяване LoadError. \ t
- следващия
- край
+ започва
+ klass = Tilt [двигател]
+ спасяване на LoadError
+ следващ
           край
+
           | find_template (settings.views, template, klass) do | file |
             следващата, освен ако не съществува File.exist? досие
             return settings.rendering_method (engine) << template.to_sym
diff - git a / sinatra-contrib / sinatra-contrib.gemspec b / sinatra-contrib / sinatra-contrib.gemspec
индекс 7d0d78526..6f683f051 100644
--- a / sinatra-contrib / sinatra-contrib.gemspec
+++ b / sinatra-contrib / sinatra-contrib.gemspec
@@-39,7 + 39,7 @@ EOF
   s.add_dependency "sinatra", версия
   s.add_dependency "mustermann", "~> 1.0"
   s.add_dependency "backports", "> = 2.8.2"
- s.add_dependency "tilt", "> = 1.3", "<3"
+ s.add_dependency "tilt", "~> 2.0"
   s.add_dependency "защита на рак", версия
   s.add_dependency "multi_json" @defunkt 