### PR TITLE
CI: Use jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ rvm:
   - 2.6.3
   - ruby-head
   - rbx-3
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
   - jruby-head
 
 script: ./.travis.sh
@@ -35,7 +35,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.8.0
     - rvm: rbx-3
 
 notifications:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)