### PR TITLE
Lookup Tilt class for template engine without loading files

### DIFF
--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -169,15 +169,14 @@ module Sinatra
         settings.template_engines[:all].each do |engine|
           exts.each { |ext| possible << [engine, "#{name}.#{ext}"] }
         end
+
         exts.each do |ext|
           settings.template_engines[ext].each { |e| possible << [e, name] }
         end
+
         possible.each do |engine, template|
-          begin
-            klass = Tilt[engine]
-          rescue LoadError
-            next
-          end
+          klass = Tilt.default_mapping.template_map[engine.to_s] ||
+            Tilt.lazy_map[engine.to_s].fetch(0, [])[0]
 
           find_template(settings.views, template, klass) do |file|
             next unless File.exist? file


### PR DESCRIPTION
Resolves #1172. This fetches only the string name of the template class instead of loading the template class (if it hasn't already been loaded).