### PR TITLE
Add message to NotFound exception

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1050,7 +1050,7 @@ module Sinatra
       if @app
         forward
       else
-        raise NotFound
+        raise NotFound, "#{request.request_method} #{request.path_info}"
       end
     end
 


### PR DESCRIPTION
Hi. I am currently monkey-patching this in my own project, but I think it would be useful for everyone, so I'm submitting this PR.

Add request method and path to the NotFound exception message. This is useful for exception reporting tools.

As an example, this is what Airbrake looks before this change. I can still get the URL but I have to click in to each report. It is very hard to get a nice overview.

<img width="481" alt="before" src="https://user-images.githubusercontent.com/1991151/64058778-f939e580-cb64-11e9-8c92-365266153505.png">

And this is what it looks like after:

<img width="552" alt="after" src="https://user-images.githubusercontent.com/1991151/64058779-01922080-cb65-11e9-83a3-e279be974f75.png">

Let me know what you think!