### PR TITLE
Support ruby 2.6 Hash#merge with multiple arguments

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -132,13 +132,17 @@ module Sinatra
       super(*keys)
     end
 
-    def merge!(other_hash)
-      return super if other_hash.is_a?(self.class)
-
-      other_hash.each_pair do |key, value|
-        key = convert_key(key)
-        value = yield(key, self[key], value) if block_given? && key?(key)
-        self[key] = convert_value(value)
+    def merge!(*other_hashes)
+      other_hashes.each do |other_hash|
+        if other_hash.is_a?(self.class)
+          super
+        else
+          other_hash.each_pair do |key, value|
+            key = convert_key(key)
+            value = yield(key, self[key], value) if block_given? && key?(key)
+            self[key] = convert_value(value)
+          end
+        end
       end
 
       self
@@ -146,8 +150,8 @@ module Sinatra
 
     alias_method :update, :merge!
 
-    def merge(other_hash, &block)
-      dup.merge!(other_hash, &block)
+    def merge(*other_hashes, &block)
+      dup.merge!(*other_hashes, &block)
     end
 
     def replace(other_hash)

--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -135,7 +135,7 @@ module Sinatra
     def merge!(*other_hashes)
       other_hashes.each do |other_hash|
         if other_hash.is_a?(self.class)
-          super
+          super(other_hash)
         else
           other_hash.each_pair do |key, value|
             key = convert_key(key)

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -210,6 +210,13 @@ class TestIndifferentHash < Minitest::Test
     assert_equal 1, hash[?a]
     assert_equal 2, hash[?b]
     assert_equal 3, hash[?c]
+
+    hash2 = Sinatra::IndifferentHash[d: 4]
+    hash3 = {e: 5}
+    hash.merge!(hash2, hash3)
+
+    assert_equal 4, hash[?d]
+    assert_equal 5, hash[?e]
   end
 
   def test_replace

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -205,6 +205,13 @@ class TestIndifferentHash < Minitest::Test
     assert_equal 2, hash2[?q]
   end
 
+  def test_merge_with_multiple_argument
+    hash = Sinatra::IndifferentHash.new.merge({a: 1}, {b: 2}, {c: 3})
+    assert_equal 1, hash[?a]
+    assert_equal 2, hash[?b]
+    assert_equal 3, hash[?c]
+  end
+
   def test_replace
     @hash.replace(?a=>1, :q=>2)
     assert_equal({ ?a=>1, ?q=>2 }, @hash)


### PR DESCRIPTION
close https://github.com/sinatra/sinatra/issues/1571

I tested locally:
```
➜  sinatra bundle exec ruby test/indifferent_hash_test.rb
Run options: --seed 9474

# Running:

...........................

Finished in 0.004303s, 6274.6921 runs/s, 23471.9963 assertions/s.

27 runs, 101 assertions, 0 failures, 0 errors, 0 skips
```