### PR TITLE
Handle null byte when serving static files

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1057,16 +1057,16 @@ module Sinatra
     # Attempt to serve static files from public directory. Throws :halt when
     # a matching file is found, returns nil otherwise.
     def static!(options = {})
-      public_dir = settings.public_folder
-      return if public_dir.nil?
+      return if (public_dir = settings.public_folder).nil?      
       path = "#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}"
       return unless valid_path?(path)
-      expanded_path = File.expand_path(path)
-      return unless File.file?(expanded_path)
+      
+      path = File.expand_path(path)
+      return unless File.file?(path)
 
-      env['sinatra.static_file'] = expanded_path
+      env['sinatra.static_file'] = path
       cache_control(*settings.static_cache_control) if settings.static_cache_control?
-      send_file expanded_path, options.merge(:disposition => nil)
+      send_file path, options.merge(:disposition => nil)
     end
 
     # Run the block with 'throw :halt' support and apply result to the response.

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1057,13 +1057,16 @@ module Sinatra
     # Attempt to serve static files from public directory. Throws :halt when
     # a matching file is found, returns nil otherwise.
     def static!(options = {})
-      return if (public_dir = settings.public_folder).nil?
-      path = File.expand_path("#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}" )
-      return unless File.file?(path)
+      public_dir = settings.public_folder
+      return if public_dir.nil?
+      path = "#{public_dir}#{URI_INSTANCE.unescape(request.path_info)}"
+      return unless valid_path?(path)
+      expanded_path = File.expand_path(path)
+      return unless File.file?(expanded_path)
 
-      env['sinatra.static_file'] = path
+      env['sinatra.static_file'] = expanded_path
       cache_control(*settings.static_cache_control) if settings.static_cache_control?
-      send_file path, options.merge(:disposition => nil)
+      send_file expanded_path, options.merge(:disposition => nil)
     end
 
     # Run the block with 'throw :halt' support and apply result to the response.

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -59,6 +59,11 @@ class StaticTest < Minitest::Test
     assert not_found?
   end
 
+  it 'passes to the next handler when the path contains null bytes' do
+    get "/foo%00"
+    assert not_found?
+  end
+
   it 'passes to the next handler when the static option is disabled' do
     @app.set :static, false
     get "/#{File.basename(__FILE__)}"


### PR DESCRIPTION
This is raising an exception on a production application I am running. This should be fine since `nil` is an acceptable return type of the method.