### PR TITLE
feat: default bind to 0.0.0.0 in .dockerenv

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1797,7 +1797,7 @@ module Sinatra
     set :handler_name, nil
     set :traps, true
     set :server, %w[HTTP webrick]
-    set :bind, Proc.new { development? ? 'localhost' : '0.0.0.0' }
+    set :bind, Proc.new { development? && !File.exist?('/.dockerenv') ? 'localhost' : '0.0.0.0' }
     set :port, Integer(ENV['PORT'] && !ENV['PORT'].empty? ? ENV['PORT'] : 4567)
     set :quiet, false
 


### PR DESCRIPTION
closes: #1369

IMHO it's good to give a nice convention over configuration feeling when running sinatra in development on the local machine or within docker without sacrificing security best practices in regard to exposing development applications to the local network. 

I intentionally didn't change the default hint for the OptionParser, as i consider this a convenience feature for development (one thing less to get wrong), where the best practice should be to declare it.