### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ rvm:
   - 2.6.5
   - ruby-head
   - rbx-3
-  - jruby-9.2.8.0
+  - jruby-9.2.9.0
   - jruby-head
 
 script: ./.travis.sh
@@ -35,7 +35,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
     - rvm: rbx-3
 
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,10 @@ if RUBY_ENGINE == 'jruby'
   gem 'trinidad'
 end
 
+if RUBY_ENGINE == 'jruby' || RUBY_ENGINE == 'ruby'
+  gem "activesupport", "~> 5.1.6"
+end
+
 if RUBY_ENGINE == "ruby"
   gem 'less', '~> 2.0'
   gem 'therubyracer'
@@ -34,7 +38,6 @@ if RUBY_ENGINE == "ruby"
   gem 'bluecloth'
   gem 'rdiscount'
   gem 'RedCloth'
-  gem "activesupport", "~> 5.1.6"
   gem 'puma'
   gem 'yajl-ruby'
   gem 'nokogiri'


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.9.0**.

[JRuby 9.2.9.0 release blog post](https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html)

In order to make the tests run, JRuby must also pull in the ActiveSupport gem, which this PR also does.