### PR TITLE
Fix capture support for Hamlit

### DIFF
--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -16,8 +16,9 @@ group :development, :test do
   end
 
   platform :jruby, :ruby do
-    gem 'slim', '2.1.0'
+    gem 'hamlit', '>= 2.10.1'
     gem 'liquid', '~> 2.6.x'
+    gem 'slim'
   end
 
   platform :ruby do

--- a/sinatra-contrib/lib/sinatra/engine_tracking.rb
+++ b/sinatra-contrib/lib/sinatra/engine_tracking.rb
@@ -29,9 +29,10 @@ module Sinatra
       erb? && Tilt[:erb] == Tilt::ErubisTemplate
     end
 
-    # @return [Boolean] Returns true if current engine is `:haml`.
+    # @return [Boolean] Returns true if current engine is `:haml` and
+    # `Tilt[:haml]` is set to `Tilt::HamlTemplate`, not `Hamlit::Template`.
     def haml?
-      @current_engine == :haml
+      @current_engine == :haml && Tilt[:tilt] == Tilt::HamlTemplate
     end
 
     # @return [Boolean] Returns true if current engine is `:sass`.

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -240,8 +240,8 @@ module Sinatra
         :css  => [:less,  :sass, :scss],
         :xml  => [:builder, :nokogiri],
         :js   => [:coffee],
-        :html => [:erb, :erubi, :erubis, :haml, :slim, :liquid, :radius, :mab,
-          :markdown, :textile, :rdoc],
+        :html => [:erb, :erubi, :erubis, :haml, :halmit, :slim, :liquid, :radius,
+          :mab, :markdown, :textile, :rdoc],
         :all =>  (Sinatra::Templates.instance_methods.map(&:to_sym) +
           [:mab] - [:find_template, :markaby]),
         :json => [:yajl],

--- a/sinatra-contrib/spec/capture_spec.rb
+++ b/sinatra-contrib/spec/capture_spec.rb
@@ -23,6 +23,9 @@ describe Sinatra::Capture do
     if engine == :erubi || engine == :erubis
       lang = :erb
     end
+    if engine == :hamlit
+      lang = :haml
+    end
     require "#{engine}"
 
     it "captures content" do
@@ -35,6 +38,7 @@ describe Sinatra::Capture do
   end
 
   describe('haml')   { it_behaves_like "a template language", :haml   }
+  describe('hamlit') { it_behaves_like "a template language", :hamlit }
   describe('slim')   { it_behaves_like "a template language", :slim   }
   describe('erubi')  { it_behaves_like "a template language", :erubi  }
   describe('erubis') { it_behaves_like "a template language", :erubis }


### PR DESCRIPTION
## Problem
As explained in https://github.com/k0kubun/hamlit/issues/150, sinatra-contrib's `capture` and `yield_content` don't work with hamlit.gem (another implementation of Haml) because they use helpers specific to haml.gem.

## Solution
Let them stop using haml.gem-specific helpers if :haml engine is not `Tilt::HamlTemplate` (but `Hamlit::Template`).
Because hamlit is implemented just like slim, these features should work in the same way.