### PR TITLE
Support capture and content_for with Hamlit

### DIFF
--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -16,8 +16,10 @@ group :development, :test do
   end
 
   platform :jruby, :ruby do
-    gem 'slim', '2.1.0'
+    gem 'hamlit'
+    gem 'hamlit-block', '>= 0.7.1'
     gem 'liquid', '~> 2.6.x'
+    gem 'slim'
   end
 
   platform :ruby do

--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -86,7 +86,7 @@ module Sinatra
 
     def capture(*args, &block)
       return block[*args] if ruby?
-      if haml?
+      if haml? && Tilt[:haml] == Tilt::HamlTemplate
         buffer = Haml::Buffer.new(nil, Haml::Options.new.for_buffer)
         with_haml_buffer(buffer) { capture_haml(*args, &block) }
       else

--- a/sinatra-contrib/lib/sinatra/content_for.rb
+++ b/sinatra-contrib/lib/sinatra/content_for.rb
@@ -174,7 +174,7 @@ module Sinatra
     # for <tt>:head</tt>.
     def yield_content(key, *args, &block)
       if block_given? && !content_for?(key)
-        haml? ? capture_haml(*args, &block) : yield(*args)
+        (haml? && Tilt[:haml] == Tilt::HamlTemplate) ? capture_haml(*args, &block) : yield(*args)
       else
         content = content_blocks[key.to_sym].map { |b| capture(*args, &b) }
         content.join.tap do |c|

--- a/sinatra-contrib/lib/sinatra/engine_tracking.rb
+++ b/sinatra-contrib/lib/sinatra/engine_tracking.rb
@@ -29,10 +29,9 @@ module Sinatra
       erb? && Tilt[:erb] == Tilt::ErubisTemplate
     end
 
-    # @return [Boolean] Returns true if current engine is `:haml` and
-    # `Tilt[:haml]` is set to `Tilt::HamlTemplate`.
+    # @return [Boolean] Returns true if current engine is `:haml`.
     def haml?
-      @current_engine == :haml && Tilt[:haml] == Tilt::HamlTemplate
+      @current_engine == :haml
     end
 
     # @return [Boolean] Returns true if current engine is `:sass`.

--- a/sinatra-contrib/lib/sinatra/engine_tracking.rb
+++ b/sinatra-contrib/lib/sinatra/engine_tracking.rb
@@ -29,9 +29,10 @@ module Sinatra
       erb? && Tilt[:erb] == Tilt::ErubisTemplate
     end
 
-    # @return [Boolean] Returns true if current engine is `:haml`.
+    # @return [Boolean] Returns true if current engine is `:haml` and
+    # `Tilt[:haml]` is set to `Tilt::HamlTemplate`.
     def haml?
-      @current_engine == :haml
+      @current_engine == :haml && Tilt[:haml] == Tilt::HamlTemplate
     end
 
     # @return [Boolean] Returns true if current engine is `:sass`.

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -240,8 +240,8 @@ module Sinatra
         :css  => [:less,  :sass, :scss],
         :xml  => [:builder, :nokogiri],
         :js   => [:coffee],
-        :html => [:erb, :erubi, :erubis, :haml, :slim, :liquid, :radius, :mab,
-          :markdown, :textile, :rdoc],
+        :html => [:erb, :erubi, :erubis, :haml, :halmit, :slim, :liquid, :radius,
+          :mab, :markdown, :textile, :rdoc],
         :all =>  (Sinatra::Templates.instance_methods.map(&:to_sym) +
           [:mab] - [:find_template, :markaby]),
         :json => [:yajl],

--- a/sinatra-contrib/spec/capture_spec.rb
+++ b/sinatra-contrib/spec/capture_spec.rb
@@ -23,6 +23,9 @@ describe Sinatra::Capture do
     if engine == :erubi || engine == :erubis
       lang = :erb
     end
+    if engine == :hamlit
+      lang = :haml
+    end
     require "#{engine}"
 
     it "captures content" do
@@ -35,6 +38,7 @@ describe Sinatra::Capture do
   end
 
   describe('haml')   { it_behaves_like "a template language", :haml   }
+  describe('hamlit') { it_behaves_like "a template language", :hamlit }
   describe('slim')   { it_behaves_like "a template language", :slim   }
   describe('erubi')  { it_behaves_like "a template language", :erubi  }
   describe('erubis') { it_behaves_like "a template language", :erubis }

--- a/sinatra-contrib/spec/content_for/different_key.hamlit
+++ b/sinatra-contrib/spec/content_for/different_key.hamlit
@@ -1,0 +1,2 @@
+- content_for :bar do
+  bar

--- a/sinatra-contrib/spec/content_for/footer.hamlit
+++ b/sinatra-contrib/spec/content_for/footer.hamlit
@@ -1,0 +1,2 @@
+- if content_for? :foo
+  != yield_content :foo

--- a/sinatra-contrib/spec/content_for/layout.hamlit
+++ b/sinatra-contrib/spec/content_for/layout.hamlit
@@ -1,0 +1,1 @@
+= yield_content :foo

--- a/sinatra-contrib/spec/content_for/multiple_blocks.hamlit
+++ b/sinatra-contrib/spec/content_for/multiple_blocks.hamlit
@@ -1,0 +1,8 @@
+- content_for :foo do
+  foo
+- content_for :foo do
+  bar
+- content_for :baz do
+  WON'T RENDER ME
+- content_for :foo do
+  baz

--- a/sinatra-contrib/spec/content_for/multiple_yields.hamlit
+++ b/sinatra-contrib/spec/content_for/multiple_yields.hamlit
@@ -1,0 +1,3 @@
+= yield_content :foo
+= yield_content :foo
+= yield_content :foo

--- a/sinatra-contrib/spec/content_for/parameter_value.hamlit
+++ b/sinatra-contrib/spec/content_for/parameter_value.hamlit
@@ -1,0 +1,1 @@
+- content_for :foo, 'foo'

--- a/sinatra-contrib/spec/content_for/passes_values.hamlit
+++ b/sinatra-contrib/spec/content_for/passes_values.hamlit
@@ -1,0 +1,1 @@
+!= yield_content :foo, 1, 2

--- a/sinatra-contrib/spec/content_for/same_key.hamlit
+++ b/sinatra-contrib/spec/content_for/same_key.hamlit
@@ -1,0 +1,2 @@
+- content_for :foo do
+  foo

--- a/sinatra-contrib/spec/content_for/takes_values.hamlit
+++ b/sinatra-contrib/spec/content_for/takes_values.hamlit
@@ -1,0 +1,3 @@
+- content_for :foo do |a, b|
+  %i= a
+  =b

--- a/sinatra-contrib/spec/content_for/yield_block.hamlit
+++ b/sinatra-contrib/spec/content_for/yield_block.hamlit
@@ -1,0 +1,2 @@
+!= yield_content :foo  do
+  baz

--- a/sinatra-contrib/spec/content_for_spec.rb
+++ b/sinatra-contrib/spec/content_for_spec.rb
@@ -9,6 +9,8 @@ describe Sinatra::ContentFor do
   end
 
   Tilt.prefer Tilt::ERBTemplate
+  require 'hamlit/block'
+  Tilt.register Tilt::HamlTemplate, :haml
 
   extend Forwardable
   def_delegators :subject, :content_for, :clear_content_for, :yield_content
@@ -89,7 +91,7 @@ describe Sinatra::ContentFor do
   end
 
   # TODO: liquid radius markaby builder nokogiri
-  engines = %w[erb erubi erubis haml slim]
+  engines = %w[erb erubi erubis haml hamlit slim]
 
   engines.each do |inner|
     describe inner.capitalize do


### PR DESCRIPTION
## Problem
As explained in https://github.com/k0kubun/hamlit/issues/150, sinatra-contrib's `capture` and `yield_content` don't work with hamlit.gem (another implementation of Haml) because they use helpers specific to haml.gem.

## Solution
Let them stop using haml.gem-specific helpers if :haml engine is not `Tilt::HamlTemplate` (but `Hamlit::Block::Template`). 
Note that hamlit-block plugin is necessary to make sinatra-contrib's `capture` work with Hamlit.