### PR TITLE
eliminate warnings of keyword parameter for ruby 2.7.0

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1601,7 +1601,7 @@ module Sinatra
 
       def route(verb, path, options = {}, &block)
         enable :empty_path_info if path == "" and empty_path_info.nil?
-        signature = compile!(verb, path, block, options)
+        signature = compile!(verb, path, block, **options)
         (@routes[verb] ||= []) << signature
         invoke_hook(:route_added, verb, path, block)
         signature
@@ -1638,7 +1638,7 @@ module Sinatra
       end
 
       def compile(path, route_mustermann_opts = {})
-        Mustermann.new(path, mustermann_opts.merge(route_mustermann_opts))
+        Mustermann.new(path, **mustermann_opts.merge(route_mustermann_opts))
       end
 
       def setup_default_middleware(builder)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1345,19 +1345,19 @@ module Sinatra
       # context as route handlers and may access/modify the request and
       # response.
       def before(path = /.*/, **options, &block)
-        add_filter(:before, path, options, &block)
+        add_filter(:before, path, **options, &block)
       end
 
       # Define an after filter; runs after all requests within the same
       # context as route handlers and may access/modify the request and
       # response.
       def after(path = /.*/, **options, &block)
-        add_filter(:after, path, options, &block)
+        add_filter(:after, path, **options, &block)
       end
 
       # add a filter
       def add_filter(type, path = /.*/, **options, &block)
-        filters[type] << compile!(type, path, block, options)
+        filters[type] << compile!(type, path, block, **options)
       end
 
       # Add a route condition. The route is considered non-matching when the


### PR DESCRIPTION
### Problem

A keyword argument must be passed with `**` annotation in Ruby 3.0.
https://bugs.ruby-lang.org/issues/14183

In Ruby 2.7.0, passing a keyword argument without `**` occurs some warnings like `warning: The last argument is used as the keyword parameter`.

### Solution

To avoid this warnings, I added `**` annotations for keyword arguments.

### Environment
ruby2.7.0-preview3