### PR TITLE
Fix additional Ruby 2.7 keyword warnings

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -332,7 +332,7 @@ module Sinatra
       def prefixed(method, pattern = nil, conditions = {}, &block)
         default = %r{(?:/.*)?} if method == :before or method == :after
         pattern, conditions = compile pattern, conditions, default
-        result = base.send(method, pattern, conditions, &block)
+        result = base.send(method, pattern, **conditions, &block)
         invoke_hook :route_added, method.to_s.upcase, pattern, block
         result
       end

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -269,7 +269,7 @@ module Sinatra
       #
       # Note: We are using #compile! so we don't interfere with extensions
       # changing #route.
-      def compile!(verb, path, block, options = {})
+      def compile!(verb, path, block, **options)
         source_location = block.respond_to?(:source_location) ?
           block.source_location.first : caller_files[1]
         signature = super
@@ -302,7 +302,7 @@ module Sinatra
       # Does everything Sinatra::Base#add_filter does, but it also tells
       # the +Watcher::List+ for the Sinatra application to watch the defined
       # filter.
-      def add_filter(type, path = nil, options = {}, &block)
+      def add_filter(type, path = nil, **options, &block)
         source_location = block.respond_to?(:source_location) ?
           block.source_location.first : caller_files[1]
         result = super

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -221,7 +221,7 @@ module Sinatra
 
     private
 
-    def compile!(verb, path, block, options = {})
+    def compile!(verb, path, block, **options)
       options[:provides] ||= respond_to if respond_to
       super
     end


### PR DESCRIPTION
These were missed in https://github.com/sinatra/sinatra/pull/1581.
