### PR TITLE
Make "none" a keyword in content security policy

### DIFF
--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -36,7 +36,7 @@ module Rack
     #          to be used in a policy.
     #
     class ContentSecurityPolicy < Base
-      default_options default_src: :none, script_src: "'self'",
+      default_options default_src: "'none'", script_src: "'self'",
                       img_src: "'self'", style_src: "'self'",
                       connect_src: "'self'", report_only: false
 

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -4,7 +4,7 @@ describe Rack::Protection::ContentSecurityPolicy do
   it 'should set the Content Security Policy' do
     expect(
       get('/', {}, 'wants' => 'text/html').headers["Content-Security-Policy"]
-    ).to eq("connect-src 'self'; default-src none; img-src 'self'; script-src 'self'; style-src 'self'")
+    ).to eq("connect-src 'self'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'")
   end
 
   it 'should not set the Content Security Policy for other content types' do
@@ -33,7 +33,7 @@ describe Rack::Protection::ContentSecurityPolicy do
     end
 
     headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers["Content-Security-Policy"]).to eq("block-all_mixed_content; connect-src 'self'; default-src none; disown-opener; img-src 'self'; script-src 'self'; style-src 'self'; upgrade-insecure_requests")
+    expect(headers["Content-Security-Policy"]).to eq("block-all_mixed_content; connect-src 'self'; default-src 'none'; disown-opener; img-src 'self'; script-src 'self'; style-src 'self'; upgrade-insecure_requests")
   end
 
   it 'should ignore CSP3 no arg directives unless they are set to true' do
@@ -44,7 +44,7 @@ describe Rack::Protection::ContentSecurityPolicy do
     end
 
     headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers["Content-Security-Policy"]).to eq("connect-src 'self'; default-src none; img-src 'self'; script-src 'self'; style-src 'self'")
+    expect(headers["Content-Security-Policy"]).to eq("connect-src 'self'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'")
   end
 
   it 'should allow changing report only' do
@@ -56,7 +56,7 @@ describe Rack::Protection::ContentSecurityPolicy do
 
     headers = get('/', {}, 'wants' => 'text/html').headers
     expect(headers["Content-Security-Policy"]).to be_nil
-    expect(headers["Content-Security-Policy-Report-Only"]).to eq("connect-src 'self'; default-src none; img-src 'self'; report-uri /my_amazing_csp_report_parser; script-src 'self'; style-src 'self'")
+    expect(headers["Content-Security-Policy-Report-Only"]).to eq("connect-src 'self'; default-src 'none'; img-src 'self'; report-uri /my_amazing_csp_report_parser; script-src 'self'; style-src 'self'")
   end
 
   it 'should not override the header if already set' do


### PR DESCRIPTION
As-is the default 'none' gets interpreted as a hostname not a keyword.
To make it a keyword it needs to be wrapped in single quotes.