### PR TITLE
Fix content security policy no-arg directives

### DIFF
--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -62,7 +62,7 @@ module Rack
         # Set these key values to boolean 'true' to include in policy
         NO_ARG_DIRECTIVES.each do |d|
           if options.key?(d) && options[d].is_a?(TrueClass)
-            directives << d.to_s.gsub(/_/, '-')
+            directives << d.to_s.tr('_', '-')
           end
         end
 

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -62,7 +62,7 @@ module Rack
         # Set these key values to boolean 'true' to include in policy
         NO_ARG_DIRECTIVES.each do |d|
           if options.key?(d) && options[d].is_a?(TrueClass)
-            directives << d.to_s.sub(/_/, '-')
+            directives << d.to_s.gsub(/_/, '-')
           end
         end
 

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -33,7 +33,7 @@ describe Rack::Protection::ContentSecurityPolicy do
     end
 
     headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers["Content-Security-Policy"]).to eq("block-all_mixed_content; connect-src 'self'; default-src none; disown-opener; img-src 'self'; script-src 'self'; style-src 'self'; upgrade-insecure_requests")
+    expect(headers["Content-Security-Policy"]).to eq("block-all-mixed-content; connect-src 'self'; default-src none; disown-opener; img-src 'self'; script-src 'self'; style-src 'self'; upgrade-insecure-requests")
   end
 
   it 'should ignore CSP3 no arg directives unless they are set to true' do


### PR DESCRIPTION
Many of the CSP3 no-arg directives are multiple words so calling `sub`
only transforms the first "_" to a "-" when we need to transform all of
them to have a valid directive.