### PR TITLE
CI: Update to jruby-9.2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ rvm:
   - 2.6.5
   - ruby-head
   - rbx-3
-  - jruby-9.2.9.0
+  - jruby-9.2.11.0
   - jruby-head
 
 script: ./.travis.sh
@@ -30,7 +30,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.9.0
+    - rvm: jruby-9.2.11.0
     - rvm: rbx-3
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.11.0
     - rvm: rbx-3
 
 notifications:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)

Question for reviewer: Perhaps it's time to let JRuby out of the allow_failures jail?