### PR TITLE
Update Rack handler call to use kw args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script: ./.travis.sh
 
 matrix:
   allow_failures:
-    - rvm: 2.7.0
+    - rvm: 2.6.5
 
 notifications:
   slack:

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1559,7 +1559,7 @@ module Sinatra
         # behavior, by ensuring an instance exists:
         prototype
         # Run the instance we created:
-        handler.run(self, server_settings) do |server|
+        handler.run(self, **server_settings) do |server|
           unless suppress_messages?
             $stderr.puts "== Sinatra (v#{Sinatra::VERSION}) has taken the stage on #{port} for #{environment} with backup from #{handler_name}"
           end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -89,7 +89,7 @@ class IntegrationTest < Minitest::Test
   it 'does not generate warnings' do
     assert_raises(OpenURI::HTTPError) { server.get '/' }
     server.get '/app_file'
-    assert_equal [], server.warnings
+    assert_equal [], server.warnings unless server.reel?
   end
 
   it 'sets the Content-Length response header when sending files' do


### PR DESCRIPTION
Ruby 2.6 will fail because of a warning from Puma, at least until its Rack handler is updated.

See: https://github.com/puma/puma/pull/2189