### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rvm:
   - 2.5.7
   - 2.6.5
   - 2.7.0
-  - jruby-9.2.11.0
+  - jruby-9.2.11.1
 
 script: ./.travis.sh
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)