### PR TITLE
[sinatra-contrib][namespace] Do not raise when key is an enumerable

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -284,8 +284,8 @@ module Sinatra
       end
 
       def set(key, value = self, &block)
+        return key.each { |k,v| set(k, v) } if key.respond_to?(:each) and block.nil? and value == self
         raise ArgumentError, "may not set #{key}" unless ([:views] + ALLOWED_ENGINES).include?(key)
-        return key.each { |k,v| set(k, v) } if block.nil? and value == self
         block ||= proc { value }
         singleton_class.send(:define_method, key, &block)
       end

--- a/sinatra-contrib/spec/namespace_spec.rb
+++ b/sinatra-contrib/spec/namespace_spec.rb
@@ -770,6 +770,20 @@ describe Sinatra::Namespace do
       expect(last_response.body).to eq('ok')
     end
 
+    it 'sets hashes correctly' do
+      mock_app do
+        namespace '/foo' do
+          set erb: 'o', sass: 'k'
+          get '/bar' do
+            settings.erb + settings.sass
+          end
+        end
+      end
+
+      expect(get('/foo/bar').status).to eq(200)
+      expect(last_response.body).to eq('ok')
+    end
+
     it 'uses some repro' do
       mock_app do
         set :foo, 42


### PR DESCRIPTION
Hi, and thanks for the great projet.


I made this first contribution because it feels like the order is wrong here: If a hash or array is given, the `set(k,v)` line would never be taken into account...

In fact I came accross this issue because using both `sinatra/namespace` and `sinatra-cross_origin` doesn't work for local cross origin. Reproduction be like:

```ruby
namespace "/foo" do
  get  "/bar" do
    cross_origin allow_origin: "example.com"
    send_file "bar"
  end
end
```

However, I do think that by design you want to block any global keys to be set from a namespace and do not have enough understanding of how this may work. Hence I'm thinking about fixing this issue directly in the `sinatra-cross_origin` gem. Any input on this one would be much appreciated of course :)