### PR TITLE
replace thin with puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ if RUBY_ENGINE == "ruby"
   gem 'puma'
   gem 'yajl-ruby'
   gem 'nokogiri'
-  gem 'thin'
+  gem 'puma'
   gem 'slim', '~> 2.0'
   gem 'coffee-script', '>= 2.0'
   gem 'rdoc'


### PR DESCRIPTION
Because of https://github.com/rack/rack/commit/98d9cf5834d4e27e34bbaa017cdfc68795763b55,
the support for thin was removed from rack.