### PR TITLE
Replace origin_whitelist with permitted_origins

### DIFF
--- a/rack-protection/lib/rack/protection/http_origin.rb
+++ b/rack-protection/lib/rack/protection/http_origin.rb
@@ -35,7 +35,7 @@ module Rack
 
         if options.key? :origin_whitelist
           warn "Rack::Protection origin_whitelist option is deprecated and will be removed, " \
-            "use origin_whitelist instead.\n"
+            "use permitted_origins instead.\n"
         end
 
         permitted_origins = options[:permitted_origins] || options[:origin_whitelist]

--- a/rack-protection/lib/rack/protection/http_origin.rb
+++ b/rack-protection/lib/rack/protection/http_origin.rb
@@ -9,11 +9,11 @@ module Rack
     #                      http://tools.ietf.org/html/draft-abarth-origin
     #
     # Does not accept unsafe HTTP requests when value of Origin HTTP request header
-    # does not match default or whitelisted URIs.
+    # does not match default or permitted URIs.
     #
-    # If you want to whitelist a specific domain, you can pass in as the `:origin_whitelist` option:
+    # If you want to permit a specific domain, you can pass in as the `:origin_permitted` option:
     #
-    #     use Rack::Protection, origin_whitelist: ["http://localhost:3000", "http://127.0.01:3000"]
+    #     use Rack::Protection, origin_permitted: ["http://localhost:3000", "http://127.0.01:3000"]
     #
     # The `:allow_if` option can also be set to a proc to use custom allow/deny logic.
     class HttpOrigin < Base
@@ -32,7 +32,14 @@ module Rack
         return true unless origin = env['HTTP_ORIGIN']
         return true if base_url(env) == origin
         return true if options[:allow_if] && options[:allow_if].call(env)
-        Array(options[:origin_whitelist]).include? origin
+
+        if options.key? :origin_whitelist
+          warn "Rack::Protection origin_whitelist option is deprecated and will be removed, " \
+            "use origin_whitelist instead.\n"
+        end
+
+        permitted_origins = options[:origin_permitted] || options[:origin_whitelist]
+        Array(permitted_origins).include? origin
       end
 
     end

--- a/rack-protection/lib/rack/protection/http_origin.rb
+++ b/rack-protection/lib/rack/protection/http_origin.rb
@@ -11,9 +11,9 @@ module Rack
     # Does not accept unsafe HTTP requests when value of Origin HTTP request header
     # does not match default or permitted URIs.
     #
-    # If you want to permit a specific domain, you can pass in as the `:origin_permitted` option:
+    # If you want to permit a specific domain, you can pass in as the `:permitted_origins` option:
     #
-    #     use Rack::Protection, origin_permitted: ["http://localhost:3000", "http://127.0.01:3000"]
+    #     use Rack::Protection, permitted_origins: ["http://localhost:3000", "http://127.0.01:3000"]
     #
     # The `:allow_if` option can also be set to a proc to use custom allow/deny logic.
     class HttpOrigin < Base
@@ -38,7 +38,7 @@ module Rack
             "use origin_whitelist instead.\n"
         end
 
-        permitted_origins = options[:origin_permitted] || options[:origin_whitelist]
+        permitted_origins = options[:permitted_origins] || options[:origin_whitelist]
         Array(permitted_origins).include? origin
       end
 

--- a/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
@@ -37,7 +37,7 @@ describe Rack::Protection::HttpOrigin do
 
     it "accepts #{method} requests with whitelisted Origin" do
       mock_app do
-        use Rack::Protection::HttpOrigin, :permitted_origins => ['http://www.friend.com']
+        use Rack::Protection::HttpOrigin, permitted_origins: ['http://www.friend.com']
         run DummyApp
       end
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://www.friend.com')).to be_ok

--- a/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
@@ -15,7 +15,7 @@ describe Rack::Protection::HttpOrigin do
   end
 
   %w(GET HEAD).each do |method|
-    it "accepts #{method} requests with non-whitelisted Origin" do
+    it "accepts #{method} requests with non-permitted Origin" do
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://malicious.com')).to be_ok
     end
   end
@@ -31,13 +31,13 @@ describe Rack::Protection::HttpOrigin do
   end
 
   %w(POST PUT DELETE).each do |method|
-    it "denies #{method} requests with non-whitelisted Origin" do
+    it "denies #{method} requests with non-permitted Origin" do
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://malicious.com')).not_to be_ok
     end
 
     it "accepts #{method} requests with whitelisted Origin" do
       mock_app do
-        use Rack::Protection::HttpOrigin, :origin_whitelist => ['http://www.friend.com']
+        use Rack::Protection::HttpOrigin, :origin_permitted => ['http://www.friend.com']
         run DummyApp
       end
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://www.friend.com')).to be_ok

--- a/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/http_origin_spec.rb
@@ -37,7 +37,7 @@ describe Rack::Protection::HttpOrigin do
 
     it "accepts #{method} requests with whitelisted Origin" do
       mock_app do
-        use Rack::Protection::HttpOrigin, :origin_permitted => ['http://www.friend.com']
+        use Rack::Protection::HttpOrigin, :permitted_origins => ['http://www.friend.com']
         run DummyApp
       end
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://www.friend.com')).to be_ok


### PR DESCRIPTION
- Added `permitted_origin` in lieu of `origin_whitelist`
- Deprecated `origin_whitelist` with a warning

Closes https://github.com/sinatra/sinatra/issues/1620