### PR TITLE
Add escaping to the static 404 page.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1168,7 +1168,7 @@ module Sinatra
 
       if not_found? || bad_request?
         if boom.message && boom.message != boom.class.name
-          body boom.message
+          body Rack::Utils.escape_html(boom.message)
         else
           content_type 'text/html'
           body '<h1>' + (not_found? ? 'Not Found' : 'Bad Request') + '</h1>'

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -81,6 +81,12 @@ class StaticTest < Minitest::Test
     assert not_found?
   end
 
+  it 'path is escaped in 404 error pages' do
+    env = Rack::MockRequest.env_for("/dummy").tap { |env| env["PATH_INFO"] = "/<script>" }
+    _, _, body = @app.call(env)
+    assert_equal(["GET &#x2F;&lt;script&gt;"], body, "Unexpected response content.") 
+  end
+
   it 'serves files when .. path traverses within public directory' do
     get "/data/../#{File.basename(__FILE__)}"
     assert ok?


### PR DESCRIPTION
This change escapes exception messages on error pages for "not found" and "bad request" errors when serving static content. In particular the message for 404 errors contains the request method and path which are user controlled and should probably be escaped.

This isn't really that exploitable because the path will be URL encoded when being requested by any sane browser, but it seems better to be safe and escape it anyway.

Example error page before the change:
```console
$ curl "https://sinatra.example.com/a<script>"       
GET /a<script>
```

Example after:
```console
$ curl "https://sinatra.example.com/a<script>"       
GET &#x2F;a&lt;script&gt;
```