### PR TITLE
Add default_content_type setting in Japanese readme

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2003,6 +2003,15 @@ set :protection, :session => true
   <dt>bind</dt>
   <dd>バインドするIPアドレス(デフォルト: `environment`がdevelopmentにセットされているときは、<tt>0.0.0.0</tt> <em>または</em> <tt>localhost</tt>)。ビルトインサーバでのみ使われる。</dd>
 
+  <dt>default_content_type</dt>
+  <dd>
+    不明なときに仮定される Content-Type (デフォルトは<tt>"text/html"</tt>)。
+    <tt>nil</tt> を設定するとすべてのレスポンスでデフォルトの Content-Type が設定されなくなる。
+    このように設定した場合、コンテンツを出力するときに Content-Type を手動で設定する必要がある。
+    そうしないと、user-agenet はコンテンツを盗み見る必要がある。
+    (または、もし Rack::Protection::XSSHeader の <tt>nosniff</tt> が有効な場合、<tt>application/octet-stream</tt> と仮定される。)
+  </dd>
+
   <dt>default_encoding</dt>
   <dd>不明なときに仮定されるエンコーディング(デフォルトは<tt>"utf-8"</tt>)。</dd>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2005,11 +2005,11 @@ set :protection, :session => true
 
   <dt>default_content_type</dt>
   <dd>
-    不明なときに仮定される Content-Type (デフォルトは<tt>"text/html"</tt>)。
-    <tt>nil</tt> を設定するとすべてのレスポンスでデフォルトの Content-Type が設定されなくなる。
+    Content-Type がセットされていない場合に適用される (デフォルトは<tt>"text/html"</tt>)。
+    <tt>default_content_type</tt> に <tt>nil</tt> を設定すると、すべてのレスポンスにデフォルトの Content-Type が設定されなくなる。
     このように設定した場合、コンテンツを出力するときに Content-Type を手動で設定する必要がある。
-    そうしないと、user-agenet はコンテンツを盗み見る必要がある。
-    (または、もし Rack::Protection::XSSHeader の <tt>nosniff</tt> が有効な場合、<tt>application/octet-stream</tt> と仮定される。)
+    そうしなければ、user-agent がそれを推測しなければならなくなります。
+    (または、もし Rack::Protection::XSSHeader の <tt>nosniff</tt> が有効な場合、<tt>application/octet-stream</tt> と仮定します。)
   </dd>
 
   <dt>default_encoding</dt>


### PR DESCRIPTION
I translated this  commit. https://github.com/sinatra/sinatra/commit/2128dcfb31f0e067bfc8e28afd54b94021caee68#diff-04c6e90faac2675aa89e2176d2eec7d8