### PR TITLE
Add option to configure token session key

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -24,6 +24,13 @@ module Rack
     #                                the token on a request. Default value:
     #                                <tt>"authenticity_token"</tt>
     #
+    # [<tt>:key</tt>] the name of the param that should contain
+    #                                the token in the session. Default value:
+    #                                <tt>:csrf</tt>
+    #
+    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Default value:
+    #                                <tt>nil</tt>
+    #
     # == Example: Forms application
     #
     # To show what the AuthenticityToken does, this section includes a sample
@@ -85,6 +92,7 @@ module Rack
       TOKEN_LENGTH = 32
 
       default_options :authenticity_param => 'authenticity_token',
+                      :key => :csrf,
                       :allow_if => nil
 
       def self.token(session)
@@ -113,7 +121,7 @@ module Rack
       private
 
       def set_token(session)
-        session[:csrf] ||= self.class.random_token
+        session[options[:key]] ||= self.class.random_token
       end
 
       # Checks the client's masked token to see if it matches the
@@ -177,7 +185,7 @@ module Rack
       end
 
       def real_token(session)
-        decode_token(session[:csrf])
+        decode_token(session[options[:key]])
       end
 
       def encode_token(token)

--- a/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
@@ -59,6 +59,17 @@ describe Rack::Protection::AuthenticityToken do
     expect(env['rack.session'][:csrf]).not_to be_nil
   end
 
+  it "allows for a custom token session key" do
+    mock_app do
+      use Rack::Session::Cookie, :key => 'rack.session'
+      use Rack::Protection::AuthenticityToken, :key => :_csrf
+      run DummyApp
+    end
+
+    get '/'
+    expect(env['rack.session'][:_csrf]).not_to be_nil
+  end
+
   describe ".token" do
     it "returns a unique masked version of the authenticity token" do
       expect(Rack::Protection::AuthenticityToken.token(session)).not_to eq(masked_token)


### PR DESCRIPTION
Allow the session key for authenticity tokens to be configurable. Instead of`:csrf` it can be configured to match other Rack frameworks like Rails `:_csrf_token`, etc.