### PR TITLE
Reduce RDoc generation time by not including every README

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new 'sinatra', version do |s|
     "VERSION"]
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
-  s.rdoc_options      = %w[--line-numbers --inline-source --title Sinatra --main README.rdoc --encoding=UTF-8]
+  s.rdoc_options      = %w[--line-numbers --title Sinatra --main README.rdoc --encoding=UTF-8]
 
   if s.respond_to?(:metadata)
     s.metadata = {

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new 'sinatra', version do |s|
     "sinatra.gemspec",
     "VERSION"]
   s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
-  s.extra_rdoc_files  = s.files.select { |p| p =~ /^README/ } << 'LICENSE'
+  s.extra_rdoc_files  = %w[README.md LICENSE]
   s.rdoc_options      = %w[--line-numbers --title Sinatra --main README.rdoc --encoding=UTF-8]
 
   if s.respond_to?(:metadata)

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -33,11 +33,6 @@ Gem::Specification.new 'sinatra', version do |s|
       'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
     }
   else
-    msg = "RubyGems 2.0 or newer is required to protect against public "\
-          "gem pushes. You can update your rubygems version by running:\n\n"\
-          "gem install rubygems-update\n"\
-          "update_rubygems\n"\
-          "gem update --system"
     raise <<-EOF
 RubyGems 2.0 or newer is required to protect against public gem pushes. You can update your rubygems version by running:
   gem install rubygems-update


### PR DESCRIPTION
👋 I've recently stumbled across https://github.com/sinatra/sinatra/issues/1578 . Here I've done the changes requested in the issue, that is not including every README file, I've only included the english version in the RDoc documentation.

At my machine time needed to generate documentation decreases drastically:

```bash
❯ gem install sinatra --no-doc
Fetching sinatra-2.1.0.gem
Successfully installed sinatra-2.1.0
1 gem installed

❯ time gem rdoc sinatra
Parsing documentation for sinatra-2.1.0
Installing ri documentation for sinatra-2.1.0
gem rdoc sinatra  262.31s user 1.75s system 97% cpu 4:31.63 total # -----> BEFORE

❯ gem uninstall sinatra
❯ gem specific_install git@github.com:epergo/sinatra.git ep/reduce-rdoc-generation-time
Switched to a new branch 'ep/reduce-rdoc-generation-time'
  Successfully built RubyGem
  Name: sinatra
  Version: 2.1.0
  File: sinatra-2.1.0.gem

❯ time gem rdoc sinatra
Parsing documentation for sinatra-2.1.0
Installing ri documentation for sinatra-2.1.0
gem rdoc sinatra  25.40s user 0.46s system 97% cpu 26.657 total # -----> AFTER
```

I understand if we decide not to merge this as it would mean not including every language in the RDoc result, and it may come handy for some people, but having in mind that the rest of the documentation is in English and Readmes in other languages can be still read in this repository and in http://sinatrarb.com I think it shouldn't cause much negative impact.

WDYT? 