### PR TITLE
Preserve query param value if named route param nil

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1046,7 +1046,7 @@ module Sinatra
 
       params.delete("ignore") # TODO: better params handling, maybe turn it into "smart" object or detect changes
       force_encoding(params)
-      @params = @params.merge(params) if params.any?
+      @params = @params.merge(params) { |k, v1, v2| v2 || v1 } if params.any?
 
       regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? {|subpattern| subpattern.is_a?(Mustermann::Regular)} )
       if regexp_exists

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -358,6 +358,10 @@ class RoutingTest < Minitest::Test
     assert ok?
     assert_equal "foo=hello;bar=", body
 
+    get '/hello?bar=baz'
+    assert ok?
+    assert_equal "foo=hello;bar=baz", body
+
     get '/'
     assert ok?
     assert_equal "foo=;bar=", body


### PR DESCRIPTION
Optional named route params overwrite a query param of the same name with nil if not included. Fixes #1666.