### PR TITLE
CI: Use latest JRuby 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ rvm:
   - 2.6.6
   - 2.7.1
   - 3.0.0
-  - jruby-9.2.15.0
+  - jruby-9.2.16.0
 
 script: ./.travis.sh
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.2.15.0
+    - rvm: jruby-9.2.16.0
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ rvm:
   - 2.6.6
   - 2.7.1
   - 3.0.0
-  - jruby-9.2.14.0
+  - jruby-9.2.15.0
 
 script: ./.travis.sh
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.2.14.0
+    - rvm: jruby-9.2.15.0
 
 notifications:
   slack:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)