### PR TITLE
Validate expanded path matches public_dir when serving static files

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1090,6 +1090,7 @@ module Sinatra
       return unless valid_path?(path)
 
       path = File.expand_path(path)
+      return unless path.start_with?(File.expand_path(public_dir) + '/')
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -97,6 +97,7 @@ class StaticTest < Minitest::Test
     mock_app do
       set :static, true
       set :public_folder, __dir__ + '/data'
+      disable :protection
     end
     get "/../#{File.basename(__FILE__)}"
     assert not_found?


### PR DESCRIPTION
This change adds additional validation to the requested static file.

cc @namusyaka 