### PR TITLE
Fix Delegator to pass keyword arguments for Ruby 3.0

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1943,10 +1943,12 @@ module Sinatra
   module Delegator #:nodoc:
     def self.delegate(*methods)
       methods.each do |method_name|
-        define_method(method_name) do |*args, **options, &block|
-          return super(*args, **options, &block) if respond_to? method_name
-          Delegator.target.send(method_name, *args, **options, &block)
+        define_method(method_name) do |*args, &block|
+          return super(*args, &block) if respond_to? method_name
+          Delegator.target.send(method_name, *args, &block)
         end
+        # ensure keyword argument passing is compatible with ruby >= 2.7
+        ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
         private method_name
       end
     end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1943,9 +1943,9 @@ module Sinatra
   module Delegator #:nodoc:
     def self.delegate(*methods)
       methods.each do |method_name|
-        define_method(method_name) do |*args, &block|
-          return super(*args, &block) if respond_to? method_name
-          Delegator.target.send(method_name, *args, &block)
+        define_method(method_name) do |*args, **options, &block|
+          return super(*args, **options, &block) if respond_to? method_name
+          Delegator.target.send(method_name, *args, **options, &block)
         end
         private method_name
       end

--- a/test/delegator_test.rb
+++ b/test/delegator_test.rb
@@ -88,6 +88,17 @@ class DelegatorTest < Minitest::Test
     assert_equal '', response.body
   end
 
+  it "delegates before with keyword arguments correctly" do
+    delegation_app do
+      set(:foo) do |something|
+        something
+      end
+      before(foo: 'bar') do
+        :nothing
+      end
+    end
+  end
+
   it "registers extensions with the delegation target" do
     app, mixin = mirror, Module.new
     Sinatra.register mixin


### PR DESCRIPTION
When Ruby is upgraded to 3.0, errors result from keyword arguments not being passed correctly through the Delegator `delegate` method. This PR fixes the issue.