### PR TITLE
Add test for delegation of keyword arguments in `before` method

### DIFF
--- a/test/delegator_test.rb
+++ b/test/delegator_test.rb
@@ -88,6 +88,17 @@ class DelegatorTest < Minitest::Test
     assert_equal '', response.body
   end
 
+  it "delegates before with keyword arguments correctly" do
+    delegation_app do
+      set(:foo) do |something|
+        something
+      end
+      before(foo: 'bar') do
+        :nothing
+      end
+    end
+  end
+
   it "registers extensions with the delegation target" do
     app, mixin = mirror, Module.new
     Sinatra.register mixin


### PR DESCRIPTION
- passes on Ruby < 2.7
- passes with warning on Ruby >= 2.7, < 3.0
- fails on Ruby 3.0