### PR TITLE
Improve `after_reload` issues

### DIFF
--- a/sinatra-contrib/lib/sinatra/contrib/version.rb
+++ b/sinatra-contrib/lib/sinatra/contrib/version.rb
@@ -1,6 +1,6 @@
 module Sinatra
   module Contrib
-    VERSION = '2.1.1'
+    VERSION = '2.1.0'
   end
 end
 

--- a/sinatra-contrib/lib/sinatra/contrib/version.rb
+++ b/sinatra-contrib/lib/sinatra/contrib/version.rb
@@ -1,6 +1,6 @@
 module Sinatra
   module Contrib
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end
 

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -251,7 +251,11 @@ module Sinatra
         watcher.update
         reloaded_paths << watcher.path
       end
-      @@after_reload.each { |block| block.call(reloaded_paths) } if reloaded_paths.any?
+      return if reloaded_paths.empty?
+      @@after_reload.each do |block|
+        args = (block.lambda? && block.arity != 1) ? [] : [reloaded_paths]
+        block.call(*args)
+      end
     end
 
     # Contains the methods defined in Sinatra::Base that are overridden.

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -242,14 +242,16 @@ module Sinatra
     # Reloads the modified files, adding, updating and removing the
     # needed elements.
     def self.perform(klass)
+      reloaded_paths = []
       Watcher::List.for(klass).updated.each do |watcher|
         klass.set(:inline_templates, watcher.path) if watcher.inline_templates?
         watcher.elements.each { |element| klass.deactivate(element) }
         $LOADED_FEATURES.delete(watcher.path)
         require watcher.path
         watcher.update
+        reloaded_paths << watcher.path
       end
-      @@after_reload.each(&:call)
+      @@after_reload.each { |block| block.call(reloaded_paths) } if reloaded_paths.any?
     end
 
     # Contains the methods defined in Sinatra::Base that are overridden.

--- a/sinatra-contrib/spec/reloader_spec.rb
+++ b/sinatra-contrib/spec/reloader_spec.rb
@@ -429,15 +429,17 @@ describe Sinatra::Reloader do
     end
 
     it "allows block execution after reloading files" do
-      app_const.after_reload do
-        $reloaded = true
+      app_const.after_reload do |files|
+        $reloaded = files
       end
       expect($reloaded).to eq(nil)
       expect(get('/foo').body.strip).to eq('foo')
       update_file(@foo_path) do |f|
         f.write 'class Foo; def self.foo() "bar" end end'
       end
-      expect($reloaded).to eq(true)
+      expect(get("/foo").body.strip).to eq("bar") # Makes the reload happen
+      expect($reloaded.size).to eq(1)
+      expect(File.basename($reloaded[0])).to eq("foo.rb")
     end
   end
 

--- a/sinatra-contrib/spec/reloader_spec.rb
+++ b/sinatra-contrib/spec/reloader_spec.rb
@@ -434,12 +434,13 @@ describe Sinatra::Reloader do
       end
       expect($reloaded).to eq(nil)
       expect(get('/foo').body.strip).to eq('foo')
+      expect($reloaded).to eq(nil) # after_reload was not called
       update_file(@foo_path) do |f|
         f.write 'class Foo; def self.foo() "bar" end end'
       end
       expect(get("/foo").body.strip).to eq("bar") # Makes the reload happen
       expect($reloaded.size).to eq(1)
-      expect(File.basename($reloaded[0])).to eq("foo.rb")
+      expect(File.basename($reloaded[0])).to eq(File.basename(@foo_path))
     end
   end
 


### PR DESCRIPTION
* Make `after_reload` run only if paths were updated.
* Pass the actual reloaded paths to the `after_reload` blocks.

Hi Sinatra folks. I've used Sinatra for many years, and it's the best. But this is the first time I've tried `after_reload` under the `Sinatra::Reloader` module.

I found that it was running my `after_reload` block _every_ time my modular app ran, even when no files changed. This seems to have fixed it.

For your reference, here's the actual code in my app that uses it:
```ruby
    configure :development do
      register Sinatra::Reloader # http://sinatrarb.com/contrib/reloader

      ApiConfig.extra_watch_files.each { |file| also_reload file }
      puts "+ Reloader: Watching #{ApiConfig.extra_watch_files.size} extra files."

      after_reload do |paths|
        puts "+ Reloader: Reloaded paths: #{paths}"
      end
    end
```