### PR TITLE
Fix `use` with keyword arguments for Ruby 3.0

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1471,6 +1471,7 @@ module Sinatra
         @prototype = nil
         @middleware << [middleware, args, block]
       end
+      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
       # Stop the self-hosted server if running.
       def quit!

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -97,4 +97,14 @@ class MiddlewareTest < Minitest::Test
     get '/'
   end
 
+  class KeywordArgumentIntializationMiddleware < MockMiddleware
+    def initialize(app, **)
+      super app
+    end
+  end
+
+  it "handles keyword arguments" do
+    @app.use KeywordArgumentIntializationMiddleware, argument: "argument"
+    get '/'
+  end
 end


### PR DESCRIPTION
The added test case would, prior to the fix, fail under Ruby 3.0, with the following error:

```
MiddlewareTest#test_handles_keyword_arguments_0:
ArgumentError: wrong number of arguments (given 2, expected 1)
```

The change itself was inspired by https://github.com/rack/rack/pull/1505