### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     name: Test with Ruby-${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         # TODO: Add jruby if something like allow_failures will be implemented on Actions.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ name: Testing
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
* Disable `fast-fail` so that we can feedback for all versions in the matrix, even if a specific version fails
* Run the test workflow for all branches, this is useful when you want test feedback without having to open a PR