### PR TITLE
Skip the Slack action if `secrets.SLACK_WEBHOOK` is not set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
         MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
-      if: failure()
+      if: failure() && env.SLACK_WEBHOOK_URL


### PR DESCRIPTION
Since forks do not have access to the `SLACK_WEBHOOK` secret, this step would always fail.

---

I tried this by temporarily setting the `SLACK_WEBHOOK` secret om my fork, just to ensure it tries to send upon failures still.