### PR TITLE
Add `#select`, `#reject` and `#compact` methods to `Sinatra::IndifferentHash`

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -180,6 +180,20 @@ module Sinatra
       end
     end
 
+    def select(*args, &block)
+      return to_enum(:select) unless block_given?
+      dup.tap { |hash| hash.select!(*args, &block) }
+    end
+
+    def reject(*args, &block)
+      return to_enum(:reject) unless block_given?
+      dup.tap { |hash| hash.reject!(*args, &block) }
+    end
+
+    def compact
+      dup.tap(&:compact!)
+    end if method_defined?(:compact) # Added in Ruby 2.4
+
     private
 
     def convert_key(key)

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -262,4 +262,57 @@ class TestIndifferentHash < Minitest::Test
     assert_equal :a, hash2[:A]
     assert_equal :a, hash2[?A]
   end
+
+  def test_select
+    hash = @hash.select { |k, v| v == :a }
+    assert_equal Sinatra::IndifferentHash[a: :a], hash
+    assert_instance_of Sinatra::IndifferentHash, hash
+
+    hash2 = @hash.select { |k, v| true }
+    assert_equal @hash, hash2
+    assert_instance_of Sinatra::IndifferentHash, hash2
+
+    enum = @hash.select
+    assert_instance_of Enumerator, enum
+  end
+
+  def test_select!
+    @hash.select! { |k, v| v == :a }
+    assert_equal Sinatra::IndifferentHash[a: :a], @hash
+  end
+
+  def test_reject
+    hash = @hash.reject { |k, v| v != :a }
+    assert_equal Sinatra::IndifferentHash[a: :a], hash
+    assert_instance_of Sinatra::IndifferentHash, hash
+
+    hash2 = @hash.reject { |k, v| false }
+    assert_equal @hash, hash2
+    assert_instance_of Sinatra::IndifferentHash, hash2
+
+    enum = @hash.reject
+    assert_instance_of Enumerator, enum
+  end
+
+  def test_reject!
+    @hash.reject! { |k, v| v != :a }
+    assert_equal Sinatra::IndifferentHash[a: :a], @hash
+  end
+
+  def test_compact
+    skip_if_lacking :compact
+
+    hash_with_nil_values = @hash.merge({?z => nil})
+    compacted_hash = hash_with_nil_values.compact
+    assert_equal @hash, compacted_hash
+    assert_instance_of Sinatra::IndifferentHash, compacted_hash
+
+    empty_hash = Sinatra::IndifferentHash.new
+    compacted_hash = empty_hash.compact
+    assert_equal empty_hash, compacted_hash
+
+    non_empty_hash = Sinatra::IndifferentHash[a: :a]
+    compacted_hash = non_empty_hash.compact
+    assert_equal non_empty_hash, compacted_hash
+  end
 end


### PR DESCRIPTION
This PR adds `#select`, `#reject` and `#compact` methods to `Sinatra::IndifferentHash`.

This allows the following code to work:

```ruby
foo_strings = params[:foo].select {|_, v| v.is_a?(String)}

if foo_strings[:bar]
  ...
```

Without this PR, the code above would fail because `select` returns a regular `Hash` with string keys.
