### PR TITLE
Remove unnecessary `test_files` from the gemspec

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new 'sinatra', version do |s|
     "SECURITY.md",
     "sinatra.gemspec",
     "VERSION"]
-  s.test_files        = s.files.select { |p| p =~ /^test\/.*_test.rb/ }
   s.extra_rdoc_files  = %w[README.md LICENSE]
   s.rdoc_options      = %w[--line-numbers --title Sinatra --main README.rdoc --encoding=UTF-8]
 


### PR DESCRIPTION
This PR removes `test_files` from the gemspec because it is unnecessary.


Sinatra sets an empty array to `test_files` since 987197054525aa5a7f56bfd74895cbbff20dfa4a. The commit omits `test/` directory from published package.
So currently the `test_files` option does nothing.


We have two choices, removing the `test_files`, or adding files under `test/` to `test_files`.
I think the first approach, removing `test_files`, is better. Because `tset_files` is no longer recommended. ref: https://github.com/rubygems/guides/issues/90 https://github.com/rubygems/bundler/pull/3207 
And I guess Sinatra users don't need `test_files` because they had no trouble with empty `test_files`.