### PR TITLE
chore: Make therubyracer conditionally installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 
 if RUBY_ENGINE == "ruby"
   gem 'less', '~> 2.0'
-  gem 'therubyracer'
+  gem 'therubyracer' if RUBY_VERSION < '3.1.0'
   gem 'redcarpet'
   gem 'wlang', '>= 3.0.1'
   gem 'bluecloth'

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -28,8 +28,8 @@ group :development, :test do
     gem 'redcarpet', '2.3.0'
     gem 'yajl-ruby'
     # ref is a dependency of therubyracer
-    gem 'ref'
-    gem 'therubyracer'
+    gem 'ref' if RUBY_VERSION < '3.1.0'
+    gem 'therubyracer' if RUBY_VERSION < '3.1.0'
   end
 
   gem 'multi_json'

--- a/test/less_test.rb
+++ b/test/less_test.rb
@@ -1,69 +1,71 @@
 require File.expand_path('../helper', __FILE__)
 
-begin
-require 'less'
+if RUBY_VERSION < '3.1.0'
+  begin
+  require 'less'
 
-class LessTest < Minitest::Test
-  def less_app(options = {}, &block)
-    mock_app do
-      set :views, __dir__ + '/views'
-      set options
-      get('/', &block)
+  class LessTest < Minitest::Test
+    def less_app(options = {}, &block)
+      mock_app do
+        set :views, __dir__ + '/views'
+        set options
+        get('/', &block)
+      end
+      get '/'
     end
-    get '/'
-  end
 
-  it 'renders inline Less strings' do
-    less_app {
-      less "@white_color: #fff; #main { background-color: @white_color }"
-    }
-    assert ok?
-    assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
-  end
-
-  it 'defaults content type to css' do
-    less_app {
-      less "@white_color: #fff; #main { background-color: @white_color }"
-    }
-    assert ok?
-    assert_equal "text/css;charset=utf-8", response['Content-Type']
-  end
-
-  it 'defaults allows setting content type per route' do
-    less_app do
-      content_type :html
-      less "@white_color: #fff; #main { background-color: @white_color }"
+    it 'renders inline Less strings' do
+      less_app {
+        less "@white_color: #fff; #main { background-color: @white_color }"
+      }
+      assert ok?
+      assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
     end
-    assert ok?
-    assert_equal "text/html;charset=utf-8", response['Content-Type']
-  end
 
-  it 'defaults allows setting content type globally' do
-    less_app(:less => { :content_type => 'html' }) do
-      less "@white_color: #fff; #main { background-color: @white_color }"
+    it 'defaults content type to css' do
+      less_app {
+        less "@white_color: #fff; #main { background-color: @white_color }"
+      }
+      assert ok?
+      assert_equal "text/css;charset=utf-8", response['Content-Type']
     end
-    assert ok?
-    assert_equal "text/html;charset=utf-8", response['Content-Type']
+
+    it 'defaults allows setting content type per route' do
+      less_app do
+        content_type :html
+        less "@white_color: #fff; #main { background-color: @white_color }"
+      end
+      assert ok?
+      assert_equal "text/html;charset=utf-8", response['Content-Type']
+    end
+
+    it 'defaults allows setting content type globally' do
+      less_app(:less => { :content_type => 'html' }) do
+        less "@white_color: #fff; #main { background-color: @white_color }"
+      end
+      assert ok?
+      assert_equal "text/html;charset=utf-8", response['Content-Type']
+    end
+
+    it 'renders .less files in views path' do
+      less_app { less :hello }
+      assert ok?
+      assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
+    end
+
+    it 'ignores the layout option' do
+      less_app { less :hello, :layout => :layout2 }
+      assert ok?
+      assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
+    end
+
+    it "raises error if template not found" do
+      mock_app { get('/') { less :no_such_template } }
+      assert_raises(Errno::ENOENT) { get('/') }
+    end
   end
 
-  it 'renders .less files in views path' do
-    less_app { less :hello }
-    assert ok?
-    assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
+  rescue LoadError
+    warn "#{$!}: skipping less tests"
   end
-
-  it 'ignores the layout option' do
-    less_app { less :hello, :layout => :layout2 }
-    assert ok?
-    assert_equal "#main{background-color:#ffffff;}", body.gsub(/\s/, "")
-  end
-
-  it "raises error if template not found" do
-    mock_app { get('/') { less :no_such_template } }
-    assert_raises(Errno::ENOENT) { get('/') }
-  end
-end
-
-rescue LoadError
-  warn "#{$!}: skipping less tests"
 end


### PR DESCRIPTION
This testing tool is used to run tests for Less, the templating library.

In order to get to a green build, this change exempts therubyracer and
the Less tests from the CI build for "3.1.0" or later.

See #1715 