### PR TITLE
[unstable] fix: Drop reel integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ if RUBY_ENGINE == "ruby"
   gem 'erubis'
   gem 'haml', '>= 3.0'
   gem 'sass'
-  gem 'reel-rack'
   gem 'celluloid', '~> 0.16.0'
   gem 'commonmarker', '~> 0.20.0'
   gem 'pandoc-ruby', '~> 2.0.2'

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1830,7 +1830,6 @@ module Sinatra
 
     ruby_engine = defined?(RUBY_ENGINE) && RUBY_ENGINE
 
-    server.unshift 'reel'
     server.unshift 'puma'
     server.unshift 'mongrel'  if ruby_engine.nil?
     server.unshift 'thin'     if ruby_engine != 'jruby'

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -81,10 +81,6 @@ module IntegrationHelper
       name.to_s == "puma"
     end
 
-    def reel?
-      name.to_s == "reel"
-    end
-
     def trinidad?
       name.to_s == "trinidad"
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -17,7 +17,7 @@ class IntegrationTest < Minitest::Test
     random = "%064x" % Kernel.rand(2**256-1)
     server.get "/ping?x=#{random}"
     count = server.log.scan("GET /ping?x=#{random}").count
-    if server.net_http_server? || server.reel?
+    if server.net_http_server?
       assert_equal 0, count
     elsif server.webrick?
       assert(count > 0)
@@ -47,13 +47,13 @@ class IntegrationTest < Minitest::Test
     }ix
 
     # because Net HTTP Server logs to $stderr by default
-    assert_match exp, server.log unless server.net_http_server? || server.reel? || server.rainbows?
+    assert_match exp, server.log unless server.net_http_server? || server.rainbows?
   end
 
   it 'does not generate warnings' do
     assert_raises(OpenURI::HTTPError) { server.get '/' }
     server.get '/app_file'
-    assert_equal [], server.warnings unless server.reel?
+    assert_equal [], server.warnings
   end
 
   it 'sets the Content-Length response header when sending files' do


### PR DESCRIPTION
This PR removes the integration support for Reel.

Reel has been unmaintained since 2016, and we can stop supporting it in the upcoming version of Sinatra.

This PR wants to thank Reel for its service, and let it go.

Fixes #1726