### PR TITLE
Sinatra::Base.caller_locations can accept arguments

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1558,8 +1558,8 @@ module Sinatra
 
       # Like caller_files, but containing Arrays rather than strings with the
       # first element being the file, and the second being the line.
-      def caller_locations
-        cleaned_caller 2
+      def caller_locations(start_or_range = 1, length = nil)
+        cleaned_caller 2, start_or_range, length
       end
 
       private
@@ -1773,10 +1773,13 @@ module Sinatra
       end
 
       # Like Kernel#caller but excluding certain magic entries
-      def cleaned_caller(keep = 3)
-        caller(1).
-          map!    { |line| line.split(/:(?=\d|in )/, 3)[0,keep] }.
-          reject { |file, *_| CALLERS_TO_IGNORE.any? { |pattern| file =~ pattern } }
+      def cleaned_caller(keep = 3, start_or_range = 1, length = nil)
+        Array(
+          caller(1)
+            .map! { |line| line.split(/:(?=\d|in )/, 3)[0,keep] }
+            .reject! { |file, *_| CALLERS_TO_IGNORE.any? { |pattern| file =~ pattern } }
+            .slice(*[start_or_range, length].compact)
+        )
       end
     end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -182,4 +182,27 @@ class BaseTest < Minitest::Test
       assert_equal '28', response['Content-Length']
     end
   end
+
+  describe "#caller_locations" do
+    class TestApp < Sinatra::Base
+      get('/') { 'Hello World' }
+    end
+
+    it "can call caller_locations" do
+      assert_operator TestApp.caller_locations.size, :>, 1
+    end
+
+    it "can call caller_locations with start and length" do
+      assert_equal 1, TestApp.caller_locations(1, 1).size
+      assert_equal 2, TestApp.caller_locations(1, 2).size
+      assert_equal 3, TestApp.caller_locations(2, 3).size
+    end
+
+    it "can call caller_locations with range" do
+      assert_equal 1, TestApp.caller_locations(1..1).size
+      assert_equal 2, TestApp.caller_locations(1..2).size
+      assert_equal 3, TestApp.caller_locations(2..4).size
+      assert_equal 3, TestApp.caller_locations(2...5).size
+    end
+  end
 end


### PR DESCRIPTION
makes class_attribute from active support work

otherwise calling `class_attribute :customer_id` on Sinatra::Base
would result in:

```
wrong number of arguments (given 2, expected 0)
```