### PR TITLE
feat(sinatra): support ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         # TODO: Add jruby if something like allow_failures will be implemented on Actions.
-        ruby: [2.6, 2.7, '3.0']
+        ruby: [2.6, 2.7, '3.0', 3.1]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/sinatra-contrib/lib/sinatra/config_file.rb
+++ b/sinatra-contrib/lib/sinatra/config_file.rb
@@ -124,7 +124,7 @@ module Sinatra
             raise UnsupportedConfigType unless ['.yml', '.yaml', '.erb'].include?(File.extname(file))
             logger.info "loading config file '#{file}'" if logging? && respond_to?(:logger)
             document = ERB.new(IO.read(file)).result
-            yaml = YAML.load(document)
+            yaml = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(document) : YAML.load(document)
             config = config_for_env(yaml)
             config.each_pair { |key, value| set(key, value) }
           end


### PR DESCRIPTION
Ruby 3.1 ships with Psych 4.0, which is not evaluating aliases etc. [by default](https://github.com/ruby/psych/pull/487) https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

This change breaks http://sinatrarb.com/contrib/config_file, where `unsafe_load` introduced in https://github.com/ruby/psych/pull/488 is used now to keep the old behaviour, which is fine as the config file is not user defined.