### PR TITLE
Fix compatibility with Psych >= 4

### DIFF
--- a/sinatra-contrib/lib/sinatra/config_file.rb
+++ b/sinatra-contrib/lib/sinatra/config_file.rb
@@ -124,7 +124,7 @@ module Sinatra
             raise UnsupportedConfigType unless ['.yml', '.yaml', '.erb'].include?(File.extname(file))
             logger.info "loading config file '#{file}'" if logging? && respond_to?(:logger)
             document = ERB.new(IO.read(file)).result
-            yaml = YAML.load(document)
+            yaml = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(document) : YAML.load(document)
             config = config_for_env(yaml)
             config.each_pair { |key, value| set(key, value) }
           end


### PR DESCRIPTION
Starting In Psych 4.0.0 (bundled in Ruby 3.1) `YAML.load` behaves like `YAML.safe_load`.
To preserve compatibility `Sinatra::ConfigFile` now uses `YAML.unsafe_load` if available.
This should be fine because config_file is in-repo, and therefore trusted. 

https://github.com/ruby/psych/pull/487

* `YAML` is used only here in sinatra repo
* sinatra-contrib test allways fails with Ruby 3.1
* CI Test for Ruby 3.1 has been dropped here d6ba201b840a96fabf2748fbad71c165beaf141c