### PR TITLE
Handle EOFError raised by Rack and raise BadRequest (and lock Rack version to 2.0 to pass tests)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ source 'https://rubygems.org' unless ENV['QUICK']
 gemspec
 
 gem 'rake'
-gem 'rack', git: 'https://github.com/rack/rack.git'
+gem 'rack', '~> 2.0'
 gem 'rack-test', '>= 0.6.2'
 gem "minitest", "~> 5.0"
 gem 'yard'

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -78,6 +78,8 @@ module Sinatra
       super
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise BadRequest, "Invalid query parameters: #{Rack::Utils.escape_html(e.message)}"
+    rescue EOFError => e
+      raise BadRequest, "Invalid multipart/form-data: #{Rack::Utils.escape_html(e.message)}"
     end
 
     class AcceptEntry

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -17,6 +17,15 @@ class RequestTest < Minitest::Test
     assert_equal 'bar', request.params['foo']
   end
 
+  it 'raises Sinatra::BadRequest when multipart/form-data request has no content' do
+    request = Sinatra::Request.new(
+      'REQUEST_METHOD' => 'POST',
+      'CONTENT_TYPE' => 'multipart/form-data; boundary=dummy',
+      'rack.input' => StringIO.new('')
+    )
+    assert_raises(Sinatra::BadRequest) { request.params }
+  end
+
   it 'is secure when the url scheme is https' do
     request = Sinatra::Request.new('rack.url_scheme' => 'https')
     assert request.secure?


### PR DESCRIPTION
This fixes #1739. Now Sinatra returns 400 Bad Request instead of 500.