### PR TITLE
Use `ruby2_keywords` for delegation

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1529,10 +1529,11 @@ module Sinatra
       # Create a new instance of the class fronted by its middleware
       # pipeline. The object is guaranteed to respond to #call but may not be
       # an instance of the class new was called on.
-      def new(*args, **kwargs, &bk)
-        instance = new!(*args, **kwargs, &bk)
+      def new(*args, &bk)
+        instance = new!(*args, &bk)
         Wrapper.new(build(instance).to_app, instance)
       end
+      ruby2_keywords :new if respond_to?(:ruby2_keywords, true)
 
       # Creates a Rack::Builder instance with all the middleware set up and
       # the given +app+ as end point.


### PR DESCRIPTION
Follows "The Only Correct Way" from https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html

Related to https://github.com/sinatra/sinatra/pull/1670
Fixes https://github.com/sinatra/sinatra/issues/1749