### PR TITLE
Drop Rubinius section from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,13 +64,6 @@ if RUBY_ENGINE == "ruby"
   gem 'simplecov', require: false
 end
 
-if RUBY_ENGINE == "rbx"
-  gem 'json'
-  gem 'rubysl'
-  gem 'rubysl-test-unit'
-  gem 'erubi'
-end
-
 platforms :jruby do
   gem 'json'
 end


### PR DESCRIPTION
This PR drops Rubinius lines from Gemfile.

Future PRs can turn the `RUBY_ENGINE` sections into `platforms:` annotations.
