### PR TITLE
Gemfile: Use :ruby to denote platform-with-C-exts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,17 +21,17 @@ gem "sinatra-contrib", path: "sinatra-contrib"
 gem "twitter-text", "1.14.7"
 
 
-gem "activesupport", "~> 5.1.6", platforms: [ :jruby, :mri ]
+gem "activesupport", "~> 5.1.6"
 
-gem 'redcarpet', platforms: [ :mri ]
+gem 'redcarpet', platforms: [ :ruby ]
 gem 'wlang', '>= 3.0.1'
-gem 'bluecloth', platforms: [ :mri ]
-gem 'rdiscount', platforms: [ :mri ]
-gem 'RedCloth', platforms: [ :mri ]
-gem 'puma', platforms: [ :jruby, :mri ]
-gem 'yajl-ruby', platforms: [ :mri ]
-gem 'nokogiri', '> 1.5.0', platforms: [ :jruby, :mri ]
-gem 'rainbows', platforms: [ :mri ]
+gem 'bluecloth', platforms: [ :ruby ]
+gem 'rdiscount', platforms: [ :ruby ]
+gem 'RedCloth', platforms: [ :ruby ]
+gem 'puma'
+gem 'yajl-ruby', platforms: [ :ruby ]
+gem 'nokogiri', '> 1.5.0'
+gem 'rainbows', platforms: [ :ruby ]
 gem 'eventmachine'
 gem 'slim', '~> 2.0'
 gem 'coffee-script', '>= 2.0'
@@ -51,7 +51,7 @@ gem 'erubis'
 gem 'haml', '>= 3.0'
 gem 'sass'
 gem 'celluloid', '~> 0.16.0'
-gem 'commonmarker', '~> 0.20.0', platforms: [ :mri ]
+gem 'commonmarker', '~> 0.20.0', platforms: [ :ruby ]
 gem 'pandoc-ruby', '~> 2.0.2'
 gem 'simplecov', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "sinatra-contrib", path: "sinatra-contrib"
 gem "twitter-text", "1.14.7"
 
 
-gem "activesupport", "~> 5.1.6"
+gem "activesupport", "~> 6.1"
 
 gem 'redcarpet', platforms: [ :ruby ]
 gem 'wlang', '>= 3.0.1'

--- a/test/rabl_test.rb
+++ b/test/rabl_test.rb
@@ -4,6 +4,7 @@ begin
 require 'rabl'
 require 'ostruct'
 require 'json'
+require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/hash/conversions'
 
 class RablTest < Minitest::Test


### PR DESCRIPTION
This change is a follow-up to e168cb5d49d76bbfb9d719c610bccef69747b62b

Thanks to eregon for noting that :mri is distinct from :ruby.

With this change, Truffleruby stands a better chance of installing the right gems in the Gemfile.

- We use `:ruby` as a `platforms:` argument. That allows Truffleruby to also install these gems, along with their C extensions.
- In addition, this PR upgrades ActiveSupport to `~> 6.1`, to get to a version of the `tzinfo` gem compatible with concurrent-ruby. This avoids a runtime exception thrown in Truffleruby in the test suite.

**Update**: I ran into "RablTest needs more core_ext stuff loaded!" so I found https://api.rubyonrails.org/classes/Array.html#method-i-extract_options-21 and loaded that for that test.