### PR TITLE
Stop setting LANG=C and not removing LC_TYPE ENV vars; that disrupt Truffleruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,11 +23,6 @@ end
 
 # SPECS ===============================================================
 
-task :test do
-  ENV['LANG'] = 'C'
-  ENV.delete 'LC_CTYPE'
-end
-
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
   t.ruby_opts = ['-r rubygems'] if defined? Gem


### PR DESCRIPTION
This is related to work happening for https://github.com/sinatra/sinatra/pull/1751#issuecomment-1050947044

Removing these two settings deals with this Truffleruby warning:

> [To redirect Truffle log output to a file use one of the following options:
> * '--log.file=<path>' if the option is passed using a guest language launcher.
> * '-Dpolyglot.log.file=<path>' if the option is passed using the host Java launcher.
> * Configure logging using the polyglot embedding API.]
> [ruby] WARNING: Encoding.find('locale') is US-ASCII, this often indicates that the system locale is not set properly. Set LANG=C and LC_ALL=C to suppress this warning (but some things might break).
> 