### PR TITLE
Update haml and slim dependencies in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'yajl-ruby', platforms: [ :ruby ]
 gem 'nokogiri', '> 1.5.0'
 gem 'rainbows', platforms: [ :ruby ]
 gem 'eventmachine'
-gem 'slim', '~> 2.0'
+gem 'slim', '~> 4'
 gem 'coffee-script', '>= 2.0'
 gem 'rdoc'
 gem 'kramdown'
@@ -47,7 +47,7 @@ gem 'liquid'
 gem 'rabl'
 gem 'builder'
 gem 'erubi'
-gem 'haml', '>= 3.0'
+gem 'haml', '~> 5'
 gem 'sass'
 gem 'celluloid', '~> 0.16.0'
 gem 'commonmarker', '~> 0.20.0', platforms: [ :ruby ]

--- a/test/haml_test.rb
+++ b/test/haml_test.rb
@@ -31,13 +31,13 @@ class HAMLTest < Minitest::Test
     end
     get '/'
     assert ok?
-    assert_equal "<h1>THIS. IS. <EM>SPARTA</EM></h1>\n", body
+    assert_equal "<h1>THIS. IS. <EM>SPARTA</EM>\n</h1>\n", body
   end
 
   it "renders with file layouts" do
     haml_app { haml 'Hello World', :layout => :layout2 }
     assert ok?
-    assert_equal "<h1>HAML Layout!</h1>\n<p>Hello World</p>\n", body
+    assert_equal "<h1>HAML Layout!</h1>\n<p>Hello World\n</p>\n", body
   end
 
   it "raises error if template not found" do


### PR DESCRIPTION
We have lots of warnings for `haml` in our test suite <details>
  <summary>Like this</summary>

```
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
/home/runner/work/sinatra/sinatra/vendor/bundle/jruby/2.6.0/gems/tilt-2.0.10/lib/tilt/haml.rb:77: warning: Haml::Engine#precompiled_method_return_value at /home/runner/.rubies/jruby-9.3.3.0/lib/ruby/stdlib/forwardable.rb:158 forwarding to private method Haml::Compiler#precompiled_method_return_value
```
</details>

Those warnings have been long fixed upstream but we had pinned and old version of `slim` which has a shared dependency with `haml` so the latter couln't have an installed versions greater than `4.0.7`. Now both gems installed their latest versions when running tests.
