### PR TITLE
Issue #1660 - Custom error handler not called if exception raised in before-filter

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1305,7 +1305,10 @@ module Sinatra
       def error(*codes, &block)
         args  = compile! "ERROR", /.*/, block
         codes = codes.flat_map(&method(:Array))
-        codes << Exception if codes.empty?
+        if codes.empty?
+          codes << Exception
+          codes << 500
+        end
         codes << Sinatra::NotFound if codes.include?(404)
         codes.each { |c| (@errors[c] ||= []) << args }
       end

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -516,4 +516,37 @@ class AfterFilterTest < Minitest::Test
     assert_equal 'Error handled after', body
     assert_equal 'Been now and after', doodle
   end
+
+  it 'handles after-filter exceptions in an error block with no status code or exception class specified' do
+    mock_app do
+      after do
+        raise RuntimeError, "after"
+      end
+      get "/" do
+      end
+      error do
+        "Unspecified error handled #{env['sinatra.error'].message}"
+      end
+    end
+
+    get '/'
+    assert_equal 'Unspecified error handled after', body
+  end
+
+  it 'handles before-filter exceptions in an error block with no status code or exception class specified' do
+    mock_app do
+      before do
+        raise RuntimeError, "before"
+      end
+      get "/" do
+      end
+      error do
+        "Unspecified error handled #{env['sinatra.error'].message}"
+      end
+    end
+
+    get '/'
+    assert_equal 'Unspecified error handled before', body
+  end
+
 end


### PR DESCRIPTION
This was the smallest change I could make to fix this issue.  I had trouble fully understanding `error_block!`, so steered clear of it.  It does seem that `error_block!` could be made more readable, as it uses both a while-loop and recursion to cover different inheritance chains.

It seems reasonable to match both subclasses of Exception as well as status 500 if a custom error block is defined without any specific targets.

Any suggestions welcome!