### PR TITLE
authenticity token: removed reference of compatibility with rack_csrf

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -20,7 +20,7 @@ module Rack
     # It is not OOTB-compatible with the {rack-csrf}[https://rubygems.org/gems/rack_csrf] gem.
     # For that, the following patch needs to be applied:
     # 
-    #   Rack::Protection::AuthenticityTokenProtection.default_options(key: "csrf.token", authenticity_param: "_csrf")
+    #   Rack::Protection::AuthenticityToken.default_options(key: "csrf.token", authenticity_param: "_csrf")
     #
     # == Options
     #

--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -20,7 +20,7 @@ module Rack
     # It is not OOTB-compatible with the {rack-csrf}[https://rubygems.org/gems/rack_csrf] gem.
     # For that, the following patch needs to be applied:
     # 
-    #   OmniAuth::AuthenticityTokenProtection.default_options(key: "csrf.token", authenticity_param: "_csrf")
+    #   Rack::Protection::AuthenticityTokenProtection.default_options(key: "csrf.token", authenticity_param: "_csrf")
     #
     # == Options
     #

--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -17,7 +17,10 @@ module Rack
     # It checks the <tt>X-CSRF-Token</tt> header and the <tt>POST</tt> form
     # data.
     #
-    # Compatible with the {rack-csrf}[https://rubygems.org/gems/rack_csrf] gem.
+    # It is not OOTB-compatible with the {rack-csrf}[https://rubygems.org/gems/rack_csrf] gem.
+    # For that, the following patch needs to be applied:
+    # 
+    #   OmniAuth::AuthenticityTokenProtection.default_options(key: "csrf.token", authenticity_param: "_csrf")
     #
     # == Options
     #


### PR DESCRIPTION
Instead, replaced it with a snippet on how to provide compatibility.

Fixes #1778