### PR TITLE
Do not let NotFound exception leak path info.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1061,7 +1061,7 @@ module Sinatra
       if @app
         forward
       else
-        raise NotFound, "#{request.request_method} #{request.path_info}"
+        raise NotFound
       end
     end
 

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -81,10 +81,10 @@ class StaticTest < Minitest::Test
     assert not_found?
   end
 
-  it 'path is escaped in 404 error pages' do
+  it 'there is no path is 404 error pages' do
     env = Rack::MockRequest.env_for("/dummy").tap { |env| env["PATH_INFO"] = "/<script>" }
     _, _, body = @app.call(env)
-    assert_equal(["GET &#x2F;&lt;script&gt;"], body, "Unexpected response content.") 
+    assert_equal(["<h1>Not Found</h1>"], body, "Unexpected response content.")
   end
 
   it 'serves files when .. path traverses within public directory' do


### PR DESCRIPTION
This is the fix for issues created by #1566. See there for more details. 