### PR TITLE
Make sure the authenticity token is a string.

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -143,7 +143,7 @@ module Rack
       # Checks the client's masked token to see if it matches the
       # session token.
       def valid_token?(env, token)
-        return false if token.nil? || token.empty?
+        return false if token.nil? || ! token.is_a?(String) || token.empty? 
 
         session = session(env)
 

--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -143,7 +143,7 @@ module Rack
       # Checks the client's masked token to see if it matches the
       # session token.
       def valid_token?(env, token)
-        return false if token.nil? || ! token.is_a?(String) || token.empty? 
+        return false if token.nil? || !token.is_a?(String) || token.empty?
 
         session = session(env)
 


### PR DESCRIPTION
Currently, the user can send in a hash or array parameter instead of string, which in turn throws a NoMethodError exception in Base64.urlsafe_decode64.
This fix makes sure that only string tokens are accepted and other data are not passed any further.