### PR TITLE
Use latest version of rack-test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ rack_version = nil if rack_version.empty? or rack_version == 'stable'
 rack_version = {:github => 'rack/rack'} if rack_version == 'master'
 gem 'rack', rack_version
 
-gem 'rack-test', '>= 0.6.2', '< 2'
+gem 'rack-test', github: 'rack/rack-test'
 gem "minitest", "~> 5.0"
 gem 'yard'
 

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -11,3 +11,5 @@ gem 'rack', rack_version
 gem 'sinatra', path: '..'
 
 gemspec
+
+gem 'rack-test', github: 'rack/rack-test'

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -35,6 +35,6 @@ EOF
 
   # dependencies
   s.add_dependency "rack"
-  s.add_development_dependency "rack-test", "< 2"
+  s.add_development_dependency "rack-test", "~> 2"
   s.add_development_dependency "rspec", "~> 3"
 end

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -4,6 +4,8 @@ gemspec
 gem 'sinatra', path: '..'
 gem 'rack-protection', path: '../rack-protection'
 
+gem 'rack-test', github: 'rack/rack-test'
+
 group :development, :test do
   platform :jruby do
     gem 'json'

--- a/sinatra-contrib/lib/sinatra/test_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/test_helpers.rb
@@ -13,19 +13,6 @@ module Sinatra
   # Helper methods to ease testing your Sinatra application. Partly extracted
   # from Sinatra. Testing framework agnostic.
   module TestHelpers
-    # Test variant of session, which exposes a `global_env`.
-    class Session < Rack::Test::Session
-      def global_env
-        @global_env ||= {}
-      end
-
-      private
-
-      def default_env
-        super.merge global_env
-      end
-    end
-
     include Rack::Test::Methods
     extend Forwardable
     attr_accessor :settings
@@ -207,10 +194,6 @@ module Sinatra
     # @return The env of the last request
     def last_env
       last_request.env
-    end
-
-    def build_rack_test_session(name) # :nodoc:
-      Session.new rack_mock_session(name)
     end
   end
 end

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -53,5 +53,5 @@ EOF
   s.add_development_dependency "nokogiri"
   s.add_development_dependency "markaby"
   s.add_development_dependency "rake", "< 11"
-  s.add_development_dependency "rack-test", "< 2"
+  s.add_development_dependency "rack-test", "~> 2"
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -46,4 +46,6 @@ EOF
   s.add_dependency 'tilt', '~> 2.0'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'mustermann', '~> 3.0'
+
+  s.add_development_dependency 'rack-test', '~> 2'
 end


### PR DESCRIPTION
Allow versions greater (and equals) than 2.0 for the `rack-test` gem. The only change needed was to remove the `build_rack_test_session` in test_helper because it uses the deprecated `rack_mock_session` which calls `build_rack_test_session` again creating an infinite loop