### PR TITLE
Deprecate Sinatra Reloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * New: Add AES GCM encryption support for session cookies. [#1324] (https://github.com/sinatra/sinatra/pull/1324) by Michael Coyne
 
+* Deprecated: Sinatra Reloader will be removed in the next major release.
+
 * Fix: Internal Sinatra errors now extend `Sinatra::Error`. This fixes [#1204](https://github.com/sinatra/sinatra/issues/1204) and [#1518](https://github.com/sinatra/sinatra/issues/1518). [bda8c29d](https://github.com/sinatra/sinatra/commit/bda8c29d70619d53f5b1c181140638d340695514) by Jordan Owens
 
 * Fix: Preserve query param value if named route param nil. [#1676](https://github.com/sinatra/sinatra/pull/1676) by Jordan Owens

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ ruby myapp.rb
 View at: [http://localhost:4567](http://localhost:4567)
 
 The code you changed will not take effect until you restart the server.
-Please restart the server every time you change or use
-[sinatra/reloader](http://www.sinatrarb.com/contrib/reloader).
+Please restart the server every time you change or use a code reloader
+like [rerun](https://github.com/alexch/rerun) or
+[rack-unreloader](https://github.com/jeremyevans/rack-unreloader).
 
 It is recommended to also run `gem install puma`, which Sinatra will
 pick up if available.

--- a/sinatra-contrib/README.md
+++ b/sinatra-contrib/README.md
@@ -58,7 +58,9 @@ existing APIs.
 
 Currently included:
 
-* [`sinatra/reloader`][sinatra-reloader]: Automatically reloads Ruby files on code changes.
+* [`sinatra/reloader`][sinatra-reloader]: Automatically reloads Ruby files on code changes. **DEPRECATED**: Please consider
+consider using an alternative like [rerun](https://github.com/alexch/rerun) or
+[rack-unreloader](https://github.com/jeremyevans/rack-unreloader) instead.
 
 ### Other Tools
 

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -5,6 +5,9 @@ require 'sinatra/base'
 module Sinatra
   # = Sinatra::Reloader
   #
+  # <b>DEPRECATED:<b> Please consider using an alternative like
+  # <tt>rerun</tt> or <tt>rack-unreloader</tt> instead.
+  #
   # Extension to reload modified files.  Useful during development,
   # since it will automatically require files defining routes, filters,
   # error handlers and inline templates, with every incoming request,


### PR DESCRIPTION
Document the deprecation of Sinatra Reloader and suggest alternatives.

Closes #1534 and #1381.