### PR TITLE
Update documentation for Rack::Protection::EscapedParams

### DIFF
--- a/rack-protection/lib/rack/protection/escaped_params.rb
+++ b/rack-protection/lib/rack/protection/escaped_params.rb
@@ -17,8 +17,7 @@ module Rack
     # More infos::         http://en.wikipedia.org/wiki/Cross-site_scripting
     #
     # Automatically escapes Rack::Request#params so they can be embedded in HTML
-    # or JavaScript without any further issues. Calls +html_safe+ on the escaped
-    # strings if defined, to avoid double-escaping in Rails.
+    # or JavaScript without any further issues.
     #
     # Options:
     # escape:: What escaping modes to use, should be Symbol or Array of Symbols.


### PR DESCRIPTION
The documentation for [Rack::Protection::EscapedParams](https://github.com/sinatra/sinatra/blob/bc8d0c8f1ae92717ec553e3f9469952719cdc38c/rack-protection/lib/rack/protection/escaped_params.rb) currently states:

>  Calls html_safe on the escaped strings if defined, to avoid double-escaping in Rails.

However, a quick search shows no mentions of `html_safe` in the Sinatra code repository nor in https://github.com/rack/rack (which is where [`Rack::Utils.escape_html`](https://github.com/rack/rack/blob/856934f8252d414378e9c17a56573db50c5784a5/lib/rack/utils.rb#L186-L189), the default escaping method, is defined).

Testing this with Rails, the behavior also confirms `html_safe` is not set on escaped strings:

```ruby
Loading development environment (Rails 7.0.1)                     
3.1.0 :001 > require 'rack/protection'
 => false 
3.1.0 :002 > ''.html_safe?
 => false 
3.1.0 :003 > Rack::Utils.escape_html('<script>')
 => "&lt;script&gt;" 
3.1.0 :004 > Rack::Utils.escape_html('<script>').html_safe?
 => false 
3.1.0 :005 > Rack::Utils.escape_html(Rack::Utils.escape_html('<script>'))
 => "&amp;lt;script&amp;gt;"
```

This pull request just removes the quoted sentence from the documentation.