### PR TITLE
Fix hamlit version

### DIFF
--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   end
 
   platform :jruby, :ruby do
-    gem 'hamlit', '~> 3'
+    gem 'hamlit', '>= 3'
     gem 'liquid', '~> 2.6.x'
     gem 'slim'
   end

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -16,8 +16,7 @@ group :development, :test do
   end
 
   platform :jruby, :ruby do
-    gem 'hamlit'
-    gem 'hamlit-block', '>= 0.7.1'
+    gem 'hamlit', '~> 3'
     gem 'liquid', '~> 2.6.x'
     gem 'slim'
   end

--- a/sinatra-contrib/spec/content_for_spec.rb
+++ b/sinatra-contrib/spec/content_for_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sinatra::ContentFor do
   end
 
   Tilt.prefer Tilt::ERBTemplate
-  require 'hamlit/block'
+  require 'hamlit'
   Tilt.register Tilt::HamlTemplate, :haml
 
   extend Forwardable


### PR DESCRIPTION
In recent version [2.16.1](https://github.com/k0kubun/hamlit/compare/v2.16.0...v2.16.1#diff-420695a198614966ed3845b1d3ab3165415f651c30ca6e271339cf0f850952f1R9) of Hamlit, the class `Hamlit::Compiler::ScriptCompiler` was modified to receive a second parameter in its constructor, however the gem `hamlit-block` which uses aforementioned gem wasn't updated so it still tries to instantiate a new `ScriptCompiler` class with only [one parameter](https://github.com/hamlit/hamlit-block/blob/master/lib/hamlit/block/compiler.rb#L15)

We should move to support hamlit version 3 so here I've fixed the version to be the last one that was working, 2.15.2