### PR TITLE
Pin jar-dependencies to 0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,3 +51,5 @@ gem 'slim', '~> 4'
 gem 'yajl-ruby', platforms: [:ruby]
 
 gem 'json', platforms: %i[jruby mri]
+
+gem 'jar-dependencies', '= 0.4.1', platforms: [:jruby] # Gem::LoadError with jar-dependencies 0.4.2

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
     gem 'json'
     gem 'rdoc'
     gem 'therubyrhino'
+    gem 'jar-dependencies', '= 0.4.1' # Gem::LoadError with jar-dependencies 0.4.2
   end
 
   platform :jruby, :ruby do


### PR DESCRIPTION
Fix JRuby CI error. Should be able to remove once JRuby is updated.