### PR TITLE
fix: add back a rack-protection.rb file

### DIFF
--- a/rack-protection/lib/rack-protection.rb
+++ b/rack-protection/lib/rack-protection.rb
@@ -1,1 +1,1 @@
-require_relative 'rack_protection'
+require 'rack/protection'

--- a/rack-protection/lib/rack-protection.rb
+++ b/rack-protection/lib/rack-protection.rb
@@ -1,0 +1,1 @@
+require_relative 'rack_protection'


### PR DESCRIPTION
In order to keep compat with earlier files, this wrapper file is needed.

See https://github.com/omniauth/omniauth/issues/1089

This is a reaction to https://github.com/sinatra/sinatra/pull/1537#issuecomment-1257647560 - thanks @mvz !