### PR TITLE
CI: Refer to rack/rack default branch as 'main'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 'jruby-9.3', truffleruby, truffleruby-head]
         include:
-          - { ruby: 3.1, rack: master, allow-failure: true }
+          - { ruby: 3.1, rack: main, allow-failure: true }
           - { ruby: jruby-head, rack: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'rake'
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'master'
+rack_version = { github: 'rack/rack' } if rack_version == 'main'
 gem 'rack', rack_version
 
 gem 'minitest', '~> 5.0'

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -7,7 +7,7 @@ gem 'rake'
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'master'
+rack_version = { github: 'rack/rack' } if rack_version == 'main'
 gem 'rack', rack_version
 
 gem 'sinatra', path: '..'


### PR DESCRIPTION
This PR changes the configured branch name for a GitHub Actions matrix element that runs our test suite with the latest development code of Rack.

Rack has changed the name of the default branch, to `main`. This PR now reflects the current default branch of that repository.

Issue manifests in CI as:

> Revision master does not exist in the repository
> https://github.com/rack/rack.git. Maybe you misspelled it?

After this change, we get this, which is more of what we want from a CI job like this (which is exploring the next major version):

> 
> Fetching https://github.com/rack/rack.git
> Fetching https://github.com/rack/rack-test.git
> Fetching gem metadata from https://rubygems.org/.......
> Resolving dependencies...
> Bundler could not find compatible versions for gem "rack":
>   In Gemfile:
>     rack-protection was resolved to 3.0.0, which depends on
>       rack
> 
>     sinatra was resolved to 3.0.0, which depends on
>       rack (~> 2.2, >= 2.2.4)
> 
> Could not find gem 'rack (~> 2.2, >= 2.2.4)', which is required by gem
> 'rack-protection', in https://github.com/rack/rack.git (at main@ab9cd74).
> 
> The source contains the following gems matching 'rack':
>   * rack-3.0.0

Mildly related to #1797 