### PR TITLE
CHANGELOG: mark the 3.0.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.0.0 / Unreleased
+## Unreleased
+
+* _Your new feature here._
+
+## 3.0.0 / 2022-09-26
 
 * New: Add Falcon support. [#1794](https://github.com/sinatra/sinatra/pull/1794) by Samuel Williams and @horaciob
 


### PR DESCRIPTION
This is a small change to the file; there may be more changes in the release that may need to go in the file, but this fixes the issue that there was a date missing.