### PR TITLE
Support Haml 6

### DIFF
--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -87,7 +87,7 @@ module Sinatra
     def capture(*args, &block)
       return block[*args] if ruby?
 
-      if haml? && Tilt[:haml] == Tilt::HamlTemplate
+      if haml? && Tilt[:haml] == Tilt::HamlTemplate && defined?(Haml::Buffer)
         buffer = Haml::Buffer.new(nil, Haml::Options.new.for_buffer)
         with_haml_buffer(buffer) { capture_haml(*args, &block) }
       else

--- a/sinatra-contrib/lib/sinatra/content_for.rb
+++ b/sinatra-contrib/lib/sinatra/content_for.rb
@@ -175,7 +175,7 @@ module Sinatra
     # for <tt>:head</tt>.
     def yield_content(key, *args, &block)
       if block_given? && !content_for?(key)
-        haml? && Tilt[:haml] == Tilt::HamlTemplate ? capture_haml(*args, &block) : yield(*args)
+        haml? && Tilt[:haml] == Tilt::HamlTemplate && respond_to?(:capture_haml) ? capture_haml(*args, &block) : yield(*args)
       else
         content = content_blocks[key.to_sym].map { |b| capture(*args, &b) }
         content.join.tap do |c|

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -46,7 +46,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.add_development_dependency 'asciidoctor'
   s.add_development_dependency 'builder'
   s.add_development_dependency 'erubi'
-  s.add_development_dependency 'haml', '~> 5'
+  s.add_development_dependency 'haml'
   s.add_development_dependency 'liquid'
   s.add_development_dependency 'markaby'
   s.add_development_dependency 'nokogiri'

--- a/sinatra-contrib/spec/content_for/passes_values.haml
+++ b/sinatra-contrib/spec/content_for/passes_values.haml
@@ -1,1 +1,1 @@
-= yield_content :foo, 1, 2
+!= yield_content :foo, 1, 2


### PR DESCRIPTION
Use Haml::Buffer only if it is defined. Resolves #1816.