### PR TITLE
fix ReDoS

### DIFF
--- a/rack-protection/lib/rack/protection/ip_spoofing.rb
+++ b/rack-protection/lib/rack/protection/ip_spoofing.rb
@@ -16,7 +16,7 @@ module Rack
       def accepts?(env)
         return true unless env.include? 'HTTP_X_FORWARDED_FOR'
 
-        ips = env['HTTP_X_FORWARDED_FOR'].split(/\s*,\s*/)
+        ips = env['HTTP_X_FORWARDED_FOR'].split(',').map(&:strip)
         return false if env.include?('HTTP_CLIENT_IP') && (!ips.include? env['HTTP_CLIENT_IP'])
         return false if env.include?('HTTP_X_REAL_IP') && (!ips.include? env['HTTP_X_REAL_IP'])
 


### PR DESCRIPTION
I fixed ReDoS for Rack::Protection::IPSpoofing.
ReDOS occurs when a specially crafted header is received while using it.

### PoC

ip_spoofing_benchmark.rb

```ruby
require 'benchmark'

def attack_text(length)
 ("\t" * length +"\ta,a\t").split(/\s*,\s*/)
end

Benchmark.bm do |x|
  x.report { attack_text(10) }
  x.report { attack_text(100) }
  x.report { attack_text(1000) }
  x.report { attack_text(10000) }
  x.report { attack_text(100000) }
end
```

```
❯ bundle exec ruby ip_spoofing_benchmark.rb
       user     system      total        real
   0.000006   0.000001   0.000007 (  0.000005)
   0.000028   0.000000   0.000028 (  0.000027)
   0.002259   0.000012   0.002271 (  0.002272)
   0.223570   0.000703   0.224273 (  0.224464)
  22.489373   0.102019  22.591392 ( 22.658066)
``` 