### PR TITLE
Actually remove thin from server selection

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1850,7 +1850,6 @@ module Sinatra
     server.unshift 'puma'
     server.unshift 'falcon'   if ruby_engine != 'jruby'
     server.unshift 'mongrel'  if ruby_engine.nil?
-    server.unshift 'thin'     if ruby_engine != 'jruby'
     server.unshift 'trinidad' if ruby_engine == 'jruby'
 
     set :absolute_redirects, true


### PR DESCRIPTION
After https://github.com/sinatra/sinatra/issues/1624 `thin` is still left in this block, which keeps it the most preferred server in regular Ruby. Let's remove it for real this time.