### PR TITLE
Add Zeitwerk to CALLERS_TO_IGNORE

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1210,7 +1210,7 @@ module Sinatra
         /active_support/,                                   # active_support require hacks
         %r{bundler(/(?:runtime|inline))?\.rb},              # bundler require hacks
         /<internal:/,                                       # internal in ruby >= 1.9.2
-        %r{zeitwerk/kernel\.rb}                             # Zeitwerk kernal#require decorator
+        %r{zeitwerk/kernel\.rb}                             # Zeitwerk kernel#require decorator
       ].freeze
 
       attr_reader :routes, :filters, :templates, :errors

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1209,7 +1209,8 @@ module Sinatra
         %r{rubygems/(custom|core_ext/kernel)_require\.rb$}, # rubygems require hacks
         /active_support/,                                   # active_support require hacks
         %r{bundler(/(?:runtime|inline))?\.rb},              # bundler require hacks
-        /<internal:/                                        # internal in ruby >= 1.9.2
+        /<internal:/,                                       # internal in ruby >= 1.9.2
+        %r{zeitwerk/kernel\.rb}                             # Zeitwerk kernal#require decorator
       ].freeze
 
       attr_reader :routes, :filters, :templates, :errors


### PR DESCRIPTION
Without this the app file will be set to zeitwerk/kernel.rb instead of the actual app file since that's what caller_files.first will return.

Fixes https://github.com/sinatra/sinatra/issues/1826