### PR TITLE
Don't run integration tests on Falcon against TruffleRuby

### DIFF
--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -122,7 +122,15 @@ module IntegrationHelper
     super
 
     base_port = 5000 + Process.pid % 100
-    Sinatra::Base.server.each_with_index do |server, index|
+    servers = Sinatra::Base.server.dup
+
+    # TruffleRuby doesn't support `Fiber.set_scheduler` yet
+    unless Fiber.respond_to?(:set_scheduler)
+      warn "skip falcon server"
+      servers.delete('falcon')
+    end
+
+    servers.each_with_index do |server, index|
       Server.run(server, base_port+index)
     end
   end


### PR DESCRIPTION
Hello.

TruffleRuby doesn't support `Fiber.set_scheduler` method so it will be great not to run tests (temporary) that involve this method call on TruffleRuby.

Right now only integration tests with Falcon rely on this method so here in this PR Falcon server is skipped in tests if `Fiber.set_scheduler` is not implemented.

Does it make sense?