### PR TITLE
Install `libyaml-dev` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,19 +28,30 @@ jobs:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}
     steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get install --yes \
+          pandoc \
+          nodejs \
+          pkg-config \
+          libxml2-dev \
+          libxslt-dev \
+          libyaml-dev
+
     - uses: actions/checkout@v3
+
     - uses: ruby/setup-ruby@v1
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: setup-ruby
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Install dependencies
-      run: sudo apt-get install -y pandoc nodejs pkg-config libxml2-dev libxslt-dev
+
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: tests
       run: bundle exec rake
+
     - name: Run sinatra-contrib tests
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: contrib-tests
@@ -48,6 +59,7 @@ jobs:
       run: |
         bundle install --jobs=3 --retry=3
         bundle exec rake
+
     - name: Run rack-protection tests
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: protection-tests
@@ -55,6 +67,7 @@ jobs:
       run: |
         bundle install --jobs=3 --retry=3
         bundle exec rake
+
     - uses: 8398a7/action-slack@v3
       with:
         status: ${{ job.status }}


### PR DESCRIPTION
Needed to be able to install psych >=5.
Need to do it before setup-ruby runs as that runs `bundle install`.

Related to:
- https://github.com/ruby/psych/pull/541
- https://github.com/ruby/setup-ruby/issues/409
- https://github.com/actions/runner-images/issues/6725

Yes, libyaml-dev will be added to GitHub runner images (this week they say) but opening this PR just in case anyone encounters failing builds. I don't think it hurts having this in the repo even after libyaml-dev have been added to the images.

Added some blank lines to make the workflow easier to read.