### PR TITLE
Skip falcon only for TruffleRuby

### DIFF
--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -125,7 +125,7 @@ module IntegrationHelper
     servers = Sinatra::Base.server.dup
 
     # TruffleRuby doesn't support `Fiber.set_scheduler` yet
-    unless Fiber.respond_to?(:set_scheduler)
+    if RUBY_ENGINE == "truffleruby" && !Fiber.respond_to?(:set_scheduler)
       warn "skip falcon server"
       servers.delete('falcon')
     end


### PR DESCRIPTION
Fix skipping integration tests with falcon on TruffleRuby.

Skip tests with falcon only for TruffleRuby. Ruby versions < 3.0 don't support `Fiber.set_scheduler` but are still supported by falcon. So we need to run specs with falcon on Ruby versions < 3.0 but skip it for TruffleRuby.

Related PR - https://github.com/sinatra/sinatra/pull/1839