### PR TITLE
CI: add jobs testing with Puma 5 and Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }})
+    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}) ${{ matrix.gemfile }}
     permissions:
       contents: read #  to fetch code (actions/checkout)
       actions: read #  to list jobs for workflow run (8398a7/action-slack)
@@ -25,8 +25,10 @@ jobs:
         rack:
           - '~> 2'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 'jruby-9.3', truffleruby, truffleruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby, truffleruby-head]
         include:
+          - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
+          - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.1, rack: stable, puma: stable, gemfile: gems/rack-v3.rb, allow-failure: true }
           - { ruby: 3.1, rack: latest, puma: latest, gemfile: gems/rack-v3.rb, allow-failure: true }
           - { ruby: jruby-head, rack: stable, puma: stable, gemfile: gems/rack-v3.rb, allow-failure: true }

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -21,9 +21,9 @@ group :development, :test do
   end
 
   platform :ruby do
-    gem 'execjs', '2.0.0'
-    gem 'nokogiri', '1.13.6'
-    gem 'redcarpet', '3.5.1'
+    gem 'execjs', '>= 2.0.0'
+    gem 'nokogiri', '>= 1.13.6'
+    gem 'redcarpet', '>= 3.5.1'
     gem 'yajl-ruby'
   end
 


### PR DESCRIPTION
 - Include gemfile in job name
   To be able to tell the difference without opening each job.

 - Avoid exact versions in sinatra-contrib/Gemfile
   Introduced in a1722ca
   Nokogiri 1.13.6 can't be installed on Ruby 3.2:
   https://github.com/sinatra/sinatra/actions/runs/3793184348/jobs/6450054080#step:6:14
