### PR TITLE
Revert "Allow running with Rack 3. (#1811)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}) ${{ matrix.gemfile }}
+    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }})
     permissions:
       contents: read #  to fetch code (actions/checkout)
       actions: read #  to list jobs for workflow run (8398a7/action-slack)
@@ -29,14 +29,11 @@ jobs:
         include:
           - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
-          - { ruby: 3.1, rack: stable, puma: stable, gemfile: gems/rack-v3.rb, allow-failure: true }
-          - { ruby: 3.1, rack: latest, puma: latest, gemfile: gems/rack-v3.rb, allow-failure: true }
-          - { ruby: jruby-head, rack: stable, puma: stable, gemfile: gems/rack-v3.rb, allow-failure: true }
+          - { ruby: 3.2, rack: '~> 2', puma: latest }
+          - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-
     steps:
     - name: Install dependencies
       run: |

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ puma_version = { github: 'puma/puma' } if puma_version == 'latest'
 gem 'puma', puma_version
 
 gem 'minitest', '~> 5.0'
+gem 'rack-test', github: 'rack/rack-test'
 gem 'rubocop', '~> 1.32.0', require: false
 gem 'yard'
 

--- a/gems/rack-v3.rb
+++ b/gems/rack-v3.rb
@@ -1,4 +1,0 @@
-eval_gemfile("../Gemfile")
-
-gem "rackup"
-gem "rack-session"

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -13,3 +13,5 @@ gem 'rack', rack_version
 gem 'sinatra', path: '..'
 
 gemspec
+
+gem 'rack-test', github: 'rack/rack-test'

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -6,6 +6,8 @@ gemspec
 gem 'rack-protection', path: '../rack-protection'
 gem 'sinatra', path: '..'
 
+gem 'rack-test', github: 'rack/rack-test'
+
 group :development, :test do
   platform :jruby do
     gem 'json'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -46,7 +46,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'mustermann', '~> 3.0'
-  s.add_dependency 'rack', '>= 2.2.4', '< 4'
+  s.add_dependency 'rack', '~> 2.2', '>= 2.2.4'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -24,7 +24,7 @@ module Rack::Handler
     end
   end
 
-  register :mock, Mock
+  register 'mock', 'Rack::Handler::Mock'
 end
 
 class ServerTest < Minitest::Test


### PR DESCRIPTION
This reverts commit 2ccd0dc29dc699c40a71ef6c1c8702668cc73d1b.

It doesn't make sense to have this in master when it is not working. CI will install Rack 3 and fail jobs. We don't know if we break something for Rack 2 now.

@jkowens please consider this