### PR TITLE
Rack 3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,12 +115,12 @@ jobs:
         rubygems: ${{ matrix.ruby == '3.0' && 'latest' || 'default' }}
 
     - name: Run sinatra tests
-      continue-on-error: ${{ matrix.allow-failure || false }}
+      continue-on-error: true
       id: tests
       run: bundle exec rake
 
     - name: Run sinatra-contrib tests
-      continue-on-error: ${{ matrix.allow-failure || false }}
+      continue-on-error: true
       id: contrib-tests
       working-directory: sinatra-contrib
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}
       tilt: ${{ matrix.tilt }}
+
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, truffleruby]
         include:
           # Puma
-          - { ruby: 3.1, rack: stable, puma: '~> 5',   tilt: stable }
           - { ruby: 3.2, rack: stable, puma: head,     tilt: stable, allow-failure: true }
           # Tilt
           - { ruby: 3.2, rack: stable, puma: stable,   tilt: head, allow-failure: true }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, truffleruby]
         include:
+          # Rack
+          - { ruby: 3.2, rack: head,   puma: stable,   tilt: stable, allow-failure: true }
           # Puma
           - { ruby: 3.2, rack: stable, puma: head,     tilt: stable, allow-failure: true }
           # Tilt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,25 +67,25 @@ jobs:
         puma:
           - stable
         rack:
-          - '~> 2'
+          - stable
         tilt:
           - stable
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, truffleruby]
         include:
           # Puma
-          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: stable }
-          - { ruby: 3.2, rack: '~> 2', puma: head,     tilt: stable, allow-failure: true }
+          - { ruby: 3.1, rack: stable, puma: '~> 5',   tilt: stable }
+          - { ruby: 3.2, rack: stable, puma: head,     tilt: stable, allow-failure: true }
           # Tilt
-          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: head, allow-failure: true }
+          - { ruby: 3.2, rack: stable, puma: stable,   tilt: head, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
-          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-9.3, rack: stable, puma: stable, tilt: stable, allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
-          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-9.4, rack: stable, puma: stable, tilt: stable, allow-failure: true }
           # Never fail our build due to problems with head
-          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
-          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
-          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: ruby-head,        rack: stable, puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-head,       rack: stable, puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: stable, puma: stable, tilt: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,12 +115,12 @@ jobs:
         rubygems: ${{ matrix.ruby == '3.0' && 'latest' || 'default' }}
 
     - name: Run sinatra tests
-      continue-on-error: true
+      continue-on-error: ${{ matrix.allow-failure || false }}
       id: tests
       run: bundle exec rake
 
     - name: Run sinatra-contrib tests
-      continue-on-error: true
+      continue-on-error: ${{ matrix.allow-failure || false }}
       id: contrib-tests
       working-directory: sinatra-contrib
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rack:
-          - "~> 2"
+          - stable
         ruby:
           - "2.6"
           - "2.7"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.swp
 *.rbc
 /pkg
-/Gemfile.lock
+*.lock
 /coverage
 .yardoc
 /doc

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
 rack_version = { github: 'rack/rack' } if rack_version == 'head'
 gem 'rack', rack_version
+gem 'rackup'
 
 puma_version = ENV['puma'].to_s
 puma_version = nil if puma_version.empty? || (puma_version == 'stable')

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -2,7 +2,10 @@
 
 # external dependencies
 require 'rack'
-require 'rackup'
+begin
+  require 'rackup'
+rescue LoadError
+end
 require 'tilt'
 require 'rack/protection'
 require 'mustermann'
@@ -1597,6 +1600,23 @@ module Sinatra
       # Puma, Falcon, or WEBrick (in that order). If given a block, will call
       # with the constructed handler once we have taken the stage.
       def run!(options = {}, &block)
+        unless defined?(Rackup::Handler)
+          rackup_warning = <<~MISSING_RACKUP
+            Sinatra could not start, the "rackup" gem was not found!
+
+            Add it to your bundle with:
+
+                bundle add rackup
+
+            or install it with:
+
+                gem install rackup
+
+          MISSING_RACKUP
+          warn rackup_warning
+          exit 1
+        end
+
         return if running?
 
         set options

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -302,7 +302,10 @@ module Sinatra
 
     # Halt processing and redirect to the URI provided.
     def redirect(uri, *args)
-      if (env['HTTP_VERSION'] == 'HTTP/1.1') && (env['REQUEST_METHOD'] != 'GET')
+      # SERVER_PROTOCOL is required in Rack 3, fall back to HTTP_VERSION
+      # for servers not updated for Rack 3 (like Puma 5)
+      http_version = env['SERVER_PROTOCOL'] || env['HTTP_VERSION']
+      if (http_version == 'HTTP/1.1') && (env['REQUEST_METHOD'] != 'GET')
         status 303
       else
         status 302

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -289,9 +289,7 @@ module Sinatra
         def block.each; yield(call) end
         response.body = block
       elsif value
-        # Rack 2.0 returns a Rack::File::Iterator here instead of
-        # Rack::File as it was in the previous API.
-        unless request.head? || value.is_a?(Rack::File::Iterator) || value.is_a?(Stream)
+        unless request.head? || value.is_a?(Rack::Files::Iterator) || value.is_a?(Stream)
           headers.delete 'content-length'
         end
         response.body = value

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1461,7 +1461,13 @@ module Sinatra
       #   mime_types :js   # => ['application/javascript', 'text/javascript']
       def mime_types(type)
         type = mime_type type
-        type =~ %r{^application/(xml|javascript)$} ? [type, "text/#{$1}"] : [type]
+        if type =~ %r{^application/(xml|javascript)$}
+          [type, "text/#{$1}"]
+        elsif type =~ %r{^text/(xml|javascript)$}
+          [type, "application/#{$1}"]
+        else
+          [type]
+        end
       end
 
       # Define a before filter; runs before all requests within the same

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -2,6 +2,7 @@
 
 # external dependencies
 require 'rack'
+require 'rackup'
 require 'tilt'
 require 'rack/protection'
 require 'mustermann'
@@ -1599,7 +1600,7 @@ module Sinatra
         return if running?
 
         set options
-        handler         = Rack::Handler.pick(server)
+        handler         = Rackup::Handler.pick(server)
         handler_name    = handler.name.gsub(/.*::/, '')
         server_settings = settings.respond_to?(:server_settings) ? settings.server_settings : {}
         server_settings.merge!(Port: port, Host: bind)

--- a/lib/sinatra/show_exceptions.rb
+++ b/lib/sinatra/show_exceptions.rb
@@ -38,8 +38,8 @@ module Sinatra
       [
         500,
         {
-          'Content-Type' => content_type,
-          'Content-Length' => body.bytesize.to_s
+          'content-type' => content_type,
+          'content-length' => body.bytesize.to_s
         },
         [body]
       ]

--- a/rack-protection/lib/rack/protection.rb
+++ b/rack-protection/lib/rack/protection.rb
@@ -2,6 +2,7 @@
 
 require 'rack/protection/version'
 require 'rack'
+require 'rack/session'
 
 module Rack
   module Protection

--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -74,7 +74,7 @@ module Rack
 
       def deny(env)
         warn env, "attack prevented by #{self.class}"
-        [options[:status], { 'Content-Type' => 'text/plain' }, [options[:message]]]
+        [options[:status], { 'content-type' => 'text/plain' }, [options[:message]]]
       end
 
       def report(env)

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -26,7 +26,7 @@ module Rack
     #               https://scotthelme.co.uk/csp-cheat-sheet/
     #               http://www.html5rocks.com/en/tutorials/security/content-security-policy/
     #
-    # Sets the 'Content-Security-Policy[-Report-Only]' header.
+    # Sets the 'content-security-policy[-report-only]' header.
     #
     # Options: ContentSecurityPolicy configuration is a complex topic with
     #          several levels of support that has evolved over time.
@@ -71,7 +71,7 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        header = options[:report_only] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy'
+        header = options[:report_only] ? 'content-security-policy-report-only' : 'content-security-policy'
         headers[header] ||= csp_policy if html? headers
         [status, headers, body]
       end

--- a/rack-protection/lib/rack/protection/cookie_tossing.rb
+++ b/rack-protection/lib/rack/protection/cookie_tossing.rb
@@ -51,7 +51,7 @@ module Rack
       def redirect(env)
         request = Request.new(env)
         warn env, "attack prevented by #{self.class}"
-        [302, { 'Content-Type' => 'text/html', 'Location' => request.path }, []]
+        [302, { 'content-type' => 'text/html', 'location' => request.path }, []]
       end
 
       def bad_cookies

--- a/rack-protection/lib/rack/protection/encrypted_cookie.rb
+++ b/rack-protection/lib/rack/protection/encrypted_cookie.rb
@@ -202,7 +202,7 @@ module Rack
       end
 
       def unpacked_cookie_data(request)
-        request.fetch_header(RACK_SESSION_UNPACKED_COOKIE_DATA) do |k|
+        request.fetch_header(Session::RACK_SESSION_UNPACKED_COOKIE_DATA) do |k|
           session_data = cookie_data = request.cookies[@key]
 
           # Try to decrypt with the first secret, if that returns nil, try

--- a/rack-protection/lib/rack/protection/frame_options.rb
+++ b/rack-protection/lib/rack/protection/frame_options.rb
@@ -31,7 +31,7 @@ module Rack
 
       def call(env)
         status, headers, body        = @app.call(env)
-        headers['X-Frame-Options'] ||= frame_options if html? headers
+        headers['x-frame-options'] ||= frame_options if html? headers
         [status, headers, body]
       end
     end

--- a/rack-protection/lib/rack/protection/json_csrf.rb
+++ b/rack-protection/lib/rack/protection/json_csrf.rb
@@ -39,7 +39,7 @@ module Rack
       def has_vector?(request, headers)
         return false if request.xhr?
         return false if options[:allow_if]&.call(request.env)
-        return false unless headers['Content-Type'].to_s.split(';', 2).first =~ %r{^\s*application/json\s*$}
+        return false unless headers['content-type'].to_s.split(';', 2).first =~ %r{^\s*application/json\s*$}
 
         origin(request.env).nil? and referrer(request.env) != request.host
       end

--- a/rack-protection/lib/rack/protection/referrer_policy.rb
+++ b/rack-protection/lib/rack/protection/referrer_policy.rb
@@ -19,7 +19,7 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        headers['Referrer-Policy'] ||= options[:referrer_policy]
+        headers['referrer-policy'] ||= options[:referrer_policy]
         [status, headers, body]
       end
     end

--- a/rack-protection/lib/rack/protection/strict_transport.rb
+++ b/rack-protection/lib/rack/protection/strict_transport.rb
@@ -33,7 +33,7 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        headers['Strict-Transport-Security'] ||= strict_transport
+        headers['strict-transport-security'] ||= strict_transport
         [status, headers, body]
       end
     end

--- a/rack-protection/lib/rack/protection/xss_header.rb
+++ b/rack-protection/lib/rack/protection/xss_header.rb
@@ -18,8 +18,8 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        headers['X-XSS-Protection']       ||= "1; mode=#{options[:xss_mode]}" if html? headers
-        headers['X-Content-Type-Options'] ||= 'nosniff'                       if options[:nosniff]
+        headers['x-xss-protection']       ||= "1; mode=#{options[:xss_mode]}" if html? headers
+        headers['x-content-type-options'] ||= 'nosniff'                       if options[:nosniff]
         [status, headers, body]
       end
     end

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -40,5 +40,5 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'
-  s.add_dependency 'rack', '>= 3.0.0.beta1', '< 4'
+  s.add_dependency 'rack', '>= 3.0.0', '< 4'
 end

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -40,5 +40,5 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'
-  s.add_dependency 'rack', '~> 2.2', '>= 2.2.4'
+  s.add_dependency 'rack', '>= 3.0.0.beta1', '< 4'
 end

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -41,4 +41,5 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
+  s.add_dependency 'rack-session', '>= 2.0.0', '< 3'
 end

--- a/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/authenticity_token_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Rack::Protection::AuthenticityToken do
   it 'allows for a custom authenticity token param' do
     mock_app do
       use Rack::Protection::AuthenticityToken, authenticity_param: 'csrf_param'
-      run proc { |_e| [200, { 'Content-Type' => 'text/plain' }, ['hi']] }
+      run proc { |_e| [200, { 'content-type' => 'text/plain' }, ['hi']] }
     end
 
     post('/', { 'csrf_param' => token }, 'rack.session' => { csrf: token })

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Rack::Protection::ContentSecurityPolicy do
   end
 
   it 'should not override the header if already set' do
-    mock_app with_headers('Content-Security-Policy' => 'default-src: none')
+    mock_app with_headers('content-security-policy' => 'default-src: none')
     expect(get('/', {}, 'wants' => 'text/html').headers['Content-Security-Policy']).to eq('default-src: none')
   end
 end

--- a/rack-protection/spec/lib/rack/protection/cookie_tossing_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/cookie_tossing_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Rack::Protection::CookieTossing do
     it 'adds the correct Set-Cookie header' do
       get '/some/path', {}, 'HTTP_COOKIE' => 'rack.%73ession=EVIL_SESSION_TOKEN; rack.session=EVIL_SESSION_TOKEN; rack.session=SESSION_TOKEN'
 
-      expected_header = <<-END.chomp
+      expected_header = <<-END.chomp.split("\n")
 rack.%2573ession=; domain=example.org; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT
 rack.%2573ession=; domain=example.org; path=/some; expires=Thu, 01 Jan 1970 00:00:00 GMT
 rack.%2573ession=; domain=example.org; path=/some/path; expires=Thu, 01 Jan 1970 00:00:00 GMT

--- a/rack-protection/spec/lib/rack/protection/escaped_params_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/escaped_params_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rack::Protection::EscapedParams do
     it 'escapes html entities' do
       mock_app do |env|
         request = Rack::Request.new(env)
-        [200, { 'Content-Type' => 'text/plain' }, [request.params['foo']]]
+        [200, { 'content-type' => 'text/plain' }, [request.params['foo']]]
       end
       get '/', foo: '<bar>'
       expect(body).to eq('&lt;bar&gt;')
@@ -16,7 +16,7 @@ RSpec.describe Rack::Protection::EscapedParams do
     it 'leaves normal params untouched' do
       mock_app do |env|
         request = Rack::Request.new(env)
-        [200, { 'Content-Type' => 'text/plain' }, [request.params['foo']]]
+        [200, { 'content-type' => 'text/plain' }, [request.params['foo']]]
       end
       get '/', foo: 'bar'
       expect(body).to eq('bar')
@@ -25,7 +25,7 @@ RSpec.describe Rack::Protection::EscapedParams do
     it 'copes with nested arrays' do
       mock_app do |env|
         request = Rack::Request.new(env)
-        [200, { 'Content-Type' => 'text/plain' }, [request.params['foo']['bar']]]
+        [200, { 'content-type' => 'text/plain' }, [request.params['foo']['bar']]]
       end
       get '/', foo: { bar: '<bar>' }
       expect(body).to eq('&lt;bar&gt;')
@@ -33,7 +33,7 @@ RSpec.describe Rack::Protection::EscapedParams do
 
     it 'leaves cache-breaker params untouched' do
       mock_app do |_env|
-        [200, { 'Content-Type' => 'text/plain' }, ['hi']]
+        [200, { 'content-type' => 'text/plain' }, ['hi']]
       end
 
       get '/?95df8d9bf5237ad08df3115ee74dcb10'
@@ -43,7 +43,7 @@ RSpec.describe Rack::Protection::EscapedParams do
     it 'leaves TempFiles untouched' do
       mock_app do |env|
         request = Rack::Request.new(env)
-        [200, { 'Content-Type' => 'text/plain' }, ["#{request.params['file'][:filename]}\n#{request.params['file'][:tempfile].read}\n#{request.params['other']}"]]
+        [200, { 'content-type' => 'text/plain' }, ["#{request.params['file'][:filename]}\n#{request.params['file'][:tempfile].read}\n#{request.params['other']}"]]
       end
 
       temp_file = File.open('_escaped_params_tmp_file', 'w')

--- a/rack-protection/spec/lib/rack/protection/frame_options_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/frame_options_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Rack::Protection::FrameOptions do
   end
 
   it 'should not override the header if already set' do
-    mock_app with_headers('X-Frame-Options' => 'allow')
+    mock_app with_headers('x-frame-options' => 'allow')
     expect(get('/', {}, 'wants' => 'text/html').headers['X-Frame-Options']).to eq('allow')
   end
 end

--- a/rack-protection/spec/lib/rack/protection/json_csrf_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/json_csrf_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Rack::Protection::JsonCsrf do
 
     def self.call(env)
       Thread.current[:last_env] = env
-      [200, { 'Content-Type' => 'application/json' }, body]
+      [200, { 'content-type' => 'application/json' }, body]
     end
   end
 
   describe 'json response' do
     before do
-      mock_app { |_e| [200, { 'Content-Type' => 'application/json' }, []] }
+      mock_app { |_e| [200, { 'content-type' => 'application/json' }, []] }
     end
 
     it 'denies get requests with json responses with a remote referrer' do
@@ -39,7 +39,7 @@ RSpec.describe Rack::Protection::JsonCsrf do
 
     it 'closes the body returned by the app if it denies the get request' do
       mock_app DummyAppWithBody do |_e|
-        [200, { 'Content-Type' => 'application/json' }, []]
+        [200, { 'content-type' => 'application/json' }, []]
       end
 
       get('/', {}, 'HTTP_REFERER' => 'http://evil.com')
@@ -50,7 +50,7 @@ RSpec.describe Rack::Protection::JsonCsrf do
     it 'accepts requests with json responses with a remote referrer when allow_if is true' do
       mock_app do
         use Rack::Protection::JsonCsrf, allow_if: ->(env) { env['HTTP_REFERER'] == 'http://good.com' }
-        run proc { |_e| [200, { 'Content-Type' => 'application/json' }, []] }
+        run proc { |_e| [200, { 'content-type' => 'application/json' }, []] }
       end
 
       expect(get('/', {}, 'HTTP_REFERER' => 'http://good.com')).to be_ok
@@ -88,7 +88,7 @@ RSpec.describe Rack::Protection::JsonCsrf do
     it 'still denies' do
       mock_app do
         use Rack::Protection, reaction: :drop_session
-        run proc { |_e| [200, { 'Content-Type' => 'application/json' }, []] }
+        run proc { |_e| [200, { 'content-type' => 'application/json' }, []] }
       end
 
       session = { foo: :bar }

--- a/rack-protection/spec/lib/rack/protection/path_traversal_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/path_traversal_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Rack::Protection::PathTraversal do
 
   context 'escaping' do
     before do
-      mock_app { |e| [200, { 'Content-Type' => 'text/plain' }, [e['PATH_INFO']]] }
+      mock_app { |e| [200, { 'content-type' => 'text/plain' }, [e['PATH_INFO']]] }
     end
 
     %w[/foo/bar /foo/bar/ / /.f /a.x].each do |path|
@@ -28,7 +28,7 @@ RSpec.describe Rack::Protection::PathTraversal do
 
   context "PATH_INFO's encoding" do
     before do
-      @app = Rack::Protection::PathTraversal.new(proc { |e| [200, { 'Content-Type' => 'text/plain' }, [e['PATH_INFO'].encoding.to_s]] })
+      @app = Rack::Protection::PathTraversal.new(proc { |e| [200, { 'content-type' => 'text/plain' }, [e['PATH_INFO'].encoding.to_s]] })
     end
 
     it 'should remain unchanged as ASCII-8BIT' do

--- a/rack-protection/spec/lib/rack/protection/protection_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/protection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Rack::Protection do
   it 'passes on options' do
     mock_app do
       use Rack::Protection, track: ['HTTP_FOO']
-      run proc { |_e| [200, { 'Content-Type' => 'text/plain' }, ['hi']] }
+      run proc { |_e| [200, { 'content-type' => 'text/plain' }, ['hi']] }
     end
 
     session = { foo: :bar }
@@ -21,7 +21,7 @@ RSpec.describe Rack::Protection do
   it 'passes errors through if :reaction => :report is used' do
     mock_app do
       use Rack::Protection, reaction: :report
-      run proc { |e| [200, { 'Content-Type' => 'text/plain' }, [e['protection.failed'].to_s]] }
+      run proc { |e| [200, { 'content-type' => 'text/plain' }, [e['protection.failed'].to_s]] }
     end
 
     session = { foo: :bar }

--- a/rack-protection/spec/lib/rack/protection/session_hijacking_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/session_hijacking_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Rack::Protection::SessionHijacking do
 
   it 'accepts requests with a changing Version header' do
     session = { foo: :bar }
-    get '/', {}, 'rack.session' => session, 'HTTP_VERSION' => '1.0'
-    get '/', {}, 'rack.session' => session, 'HTTP_VERSION' => '1.1'
+    get '/', {}, 'rack.session' => session, 'SERVER_PROTOCOL' => 'HTTP/1.0'
+    get '/', {}, 'rack.session' => session, 'SERVER_PROTOCOL' => 'HTTP/1.1'
     expect(session[:foo]).to eq(:bar)
   end
 end

--- a/rack-protection/spec/lib/rack/protection/xss_header_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/xss_header_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Rack::Protection::XSSHeader do
   end
 
   it 'should not override the header if already set' do
-    mock_app with_headers('X-XSS-Protection' => '0')
+    mock_app with_headers('x-xss-protection' => '0')
     expect(get('/', {}, 'wants' => 'text/html').headers['X-XSS-Protection']).to eq('0')
   end
 
@@ -48,7 +48,7 @@ RSpec.describe Rack::Protection::XSSHeader do
   end
 
   it 'should not override the header if already set X-Content-Type-Options' do
-    mock_app with_headers('X-Content-Type-Options' => 'sniff')
+    mock_app with_headers('x-content-type-options' => 'sniff')
     expect(get('/', {}, 'wants' => 'text/html').headers['X-Content-Type-Options']).to eq('sniff')
   end
 end

--- a/rack-protection/spec/support/dummy_app.rb
+++ b/rack-protection/spec/support/dummy_app.rb
@@ -4,6 +4,6 @@ module DummyApp
   def self.call(env)
     Thread.current[:last_env] = env
     body = (env['REQUEST_METHOD'] == 'HEAD' ? '' : 'ok')
-    [200, { 'Content-Type' => env['wants'] || 'text/plain' }, [body]]
+    [200, { 'content-type' => env['wants'] || 'text/plain' }, [body]]
   end
 end

--- a/rack-protection/spec/support/spec_helpers.rb
+++ b/rack-protection/spec/support/spec_helpers.rb
@@ -29,7 +29,7 @@ module SpecHelpers
   end
 
   def with_headers(headers)
-    proc { [200, { 'Content-Type' => 'text/plain' }.merge(headers), ['ok']] }
+    proc { [200, { 'content-type' => 'text/plain' }.merge(headers), ['ok']] }
   end
 
   def env

--- a/sinatra-contrib/lib/sinatra/cookies.rb
+++ b/sinatra-contrib/lib/sinatra/cookies.rb
@@ -60,7 +60,7 @@ module Sinatra
       attr_reader :options
 
       def initialize(app)
-        @response_string = nil
+        @response_array  = nil
         @response_hash   = {}
         @response        = app.response
         @request         = app.request
@@ -309,12 +309,12 @@ module Sinatra
       end
 
       def parse_response
-        string = @response['Set-Cookie']
-        return if @response_string == string
+        cookies_from_response = Array(@response['Set-Cookie'])
+        return if @response_array == cookies_from_response
 
         hash = {}
 
-        string.each_line do |line|
+        cookies_from_response.each do |line|
           key, value = line.split(';', 2).first.to_s.split('=', 2)
           next if key.nil?
 
@@ -328,7 +328,7 @@ module Sinatra
         end
 
         @response_hash.replace hash
-        @response_string = string
+        @response_array = cookies_from_response
       end
 
       def request_cookies

--- a/sinatra-contrib/lib/sinatra/link_header.rb
+++ b/sinatra-contrib/lib/sinatra/link_header.rb
@@ -89,10 +89,10 @@ module Sinatra
       link          = (response['Link'] ||= '')
 
       urls.map do |url|
-        link << ",\n" unless link.empty?
+        link << "," unless link.empty?
         link << (http_pattern % url)
         html_pattern % url
-      end.join "\n"
+      end.join
     end
 
     ##
@@ -117,10 +117,10 @@ module Sinatra
       yield if block_given?
       return '' unless response.include? 'Link'
 
-      response['Link'].split(",\n").map do |line|
+      response['Link'].split(",").map do |line|
         url, *opts = line.split(';').map(&:strip)
         "<link href=\"#{url[1..-2]}\" #{opts.join ' '} />"
-      end.join "\n"
+      end.join
     end
 
     def self.registered(_base)

--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -153,12 +153,12 @@ RSpec.describe Sinatra::Cookies do
       expect(jar['foo']).to be_nil
     end
 
-    it 'removes response cookies from cookies hash' do
+    it 'does not remove response cookies from cookies hash' do
       expect(cookie_route do
         cookies['foo'] = 'bar'
         cookies.clear
         cookies['foo']
-      end).to be_nil
+      end).to eq('bar')
     end
 
     it 'expires existing cookies' do
@@ -189,12 +189,12 @@ RSpec.describe Sinatra::Cookies do
       expect(jar['foo']).to be_nil
     end
 
-    it 'removes response cookies from cookies hash' do
+    it 'does not remove response cookies from cookies hash' do
       expect(cookie_route do
         cookies['foo'] = 'bar'
         cookies.delete 'foo'
         cookies['foo']
-      end).to be_nil
+      end).to eq('bar')
     end
 
     it 'expires existing cookies' do
@@ -246,13 +246,16 @@ RSpec.describe Sinatra::Cookies do
   end
 
   describe :delete_if do
-    it 'deletes cookies that match the block' do
+    it 'expires cookies that match the block' do
       expect(cookie_route('foo=bar') do
         cookies['bar'] = 'baz'
         cookies['baz'] = 'foo'
         cookies.delete_if { |*a| a.include? 'bar' }
-        cookies.values_at 'foo', 'bar', 'baz'
-      end).to eq([nil, nil, 'foo'])
+        response['Set-Cookie']
+      end).to eq(["bar=baz; domain=example.org; path=/; httponly",
+                  "baz=foo; domain=example.org; path=/; httponly",
+                  "foo=; domain=example.org; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly",
+                  "bar=; domain=example.org; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly"])
     end
   end
 
@@ -454,12 +457,12 @@ RSpec.describe Sinatra::Cookies do
       end).to be false
     end
 
-    it 'becomes true if response cookies are removed' do
+    it 'deos not become true if response cookies are removed' do
       expect(cookie_route do
         cookies['foo'] = 'bar'
         cookies.delete :foo
         cookies.empty?
-      end).to be true
+      end).to be false
     end
 
     it 'becomes true if request cookies are removed' do
@@ -469,12 +472,12 @@ RSpec.describe Sinatra::Cookies do
       end).to be_truthy
     end
 
-    it 'becomes true after clear' do
+    it 'does not become true after clear' do
       expect(cookie_route('foo=bar', 'bar=baz') do
         cookies['foo'] = 'bar'
         cookies.clear
         cookies.empty?
-      end).to be_truthy
+      end).to be false
     end
   end
 

--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Sinatra::Cookies do
       expect(cookie_route do
         cookies['foo'] = 'bar'
         response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
-      end).to include('HttpOnly')
+      end).to include('httponly')
     end
 
     it 'sets domain to nil if localhost' do
@@ -217,7 +217,7 @@ RSpec.describe Sinatra::Cookies do
         cookies.delete 'foo'
         response['Set-Cookie']
       end
-      expect(cookie_header).to include("path=/foo;", "domain=bar.com;", "secure;", "HttpOnly")
+      expect(cookie_header).to include("path=/foo;", "domain=bar.com;", "secure;", "httponly")
     end
 
     it 'does not touch other cookies' do
@@ -724,20 +724,20 @@ RSpec.describe Sinatra::Cookies do
       expect(cookie_jar['foo']).to eq('bar')
     end
 
-    it 'sets a cookie with HttpOnly' do
+    it 'sets a cookie with httponly' do
       expect(cookie_route do
         request.script_name = '/foo'
         cookies.set('foo', value: 'bar', httponly: true)
         response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
-      end).to include('HttpOnly')
+      end).to include('httponly')
     end
 
-    it 'sets a cookie without HttpOnly' do
+    it 'sets a cookie without httponly' do
       expect(cookie_route do
         request.script_name = '/foo'
         cookies.set('foo', value: 'bar', httponly: false)
         response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
-      end).not_to include('HttpOnly')
+      end).not_to include('httponly')
     end
   end
 

--- a/sinatra-contrib/spec/cookies_spec.rb
+++ b/sinatra-contrib/spec/cookies_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe Sinatra::Cookies do
       end).to be false
     end
 
-    it 'deos not become true if response cookies are removed' do
+    it 'does not become true if response cookies are removed' do
       expect(cookie_route do
         cookies['foo'] = 'bar'
         cookies.delete :foo

--- a/sinatra-contrib/spec/json_spec.rb
+++ b/sinatra-contrib/spec/json_spec.rb
@@ -57,7 +57,10 @@ RSpec.describe Sinatra::JSON do
 
   it "accepts shorthands for :content_type" do
     mock_app { get('/') { json({}, :content_type => :js) } }
-    expect(get('/')["Content-Type"]).to eq("application/javascript;charset=utf-8")
+    # Changed to "text/javascript" in Rack >3.0
+    # https://github.com/sinatra/sinatra/pull/1857#issuecomment-1445062212
+    expect(get('/')["Content-Type"])
+      .to eq("application/javascript;charset=utf-8").or eq("text/javascript;charset=utf-8")
   end
 
   it 'calls generate on :encoder if available' do

--- a/sinatra-contrib/spec/link_header_spec.rb
+++ b/sinatra-contrib/spec/link_header_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Sinatra::LinkHeader do
     it "takes an options hash" do
       get '/'
       elements = ["<something>", "foo=\"bar\"", "rel=\"from-filter\""]
-      expect(headers['Link'].split(",\n").first.strip.split('; ').sort).to eq(elements)
+      expect(headers['Link'].split(",").first.strip.split('; ').sort).to eq(elements)
     end
   end
 

--- a/sinatra-contrib/spec/link_header_spec.rb
+++ b/sinatra-contrib/spec/link_header_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Sinatra::LinkHeader do
   describe :link do
     it "sets link headers" do
       get '/'
-      expect(headers['Link'].lines).to include('<booyah>; rel="something"')
+      expect(headers['Link']).to include('<booyah>; rel="something"')
     end
 
     it "returns link html tags" do

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -46,7 +46,9 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'mustermann', '~> 3.0'
-  s.add_dependency 'rack', '~> 2.2', '>= 2.2.4'
+  s.add_dependency 'rack', '>= 2.2.4', '< 4'
+  s.add_dependency 'rackup', '>= 0.2.3', '< 1'
+  s.add_dependency 'rack-session', '>= 0.3.0', '< 1'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -46,7 +46,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'mustermann', '~> 3.0'
-  s.add_dependency 'rack', '>= 3.0.0.beta1', '< 4'
+  s.add_dependency 'rack', '>= 3.0.0', '< 4'
   s.add_dependency 'rackup', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-session', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-protection', version

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -47,8 +47,8 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
 
   s.add_dependency 'mustermann', '~> 3.0'
   s.add_dependency 'rack', '>= 3.0.0.beta1', '< 4'
-  s.add_dependency 'rackup', '>= 0.2.3', '< 1'
-  s.add_dependency 'rack-session', '>= 0.3.0', '< 1'
+  s.add_dependency 'rackup', '>= 2.0.0', '< 3'
+  s.add_dependency 'rack-session', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -46,7 +46,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'mustermann', '~> 3.0'
-  s.add_dependency 'rack', '>= 2.2.4', '< 4'
+  s.add_dependency 'rack', '>= 3.0.0.beta1', '< 4'
   s.add_dependency 'rackup', '>= 0.2.3', '< 1'
   s.add_dependency 'rack-session', '>= 0.3.0', '< 1'
   s.add_dependency 'rack-protection', version

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -47,7 +47,6 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
 
   s.add_dependency 'mustermann', '~> 3.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
-  s.add_dependency 'rackup', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
 end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -48,7 +48,6 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.add_dependency 'mustermann', '~> 3.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
   s.add_dependency 'rackup', '>= 2.0.0', '< 3'
-  s.add_dependency 'rack-session', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
 end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -681,11 +681,13 @@ class HelpersTest < Minitest::Test
           assert_equal content_type(:foo),    'text/foo;charset=utf-8'
           assert_equal content_type(:xml),    'application/xml;charset=utf-8'
           assert_equal content_type(:xhtml),  'application/xhtml+xml;charset=utf-8'
-          assert_equal content_type(:js),     'application/javascript;charset=utf-8'
           assert_equal content_type(:json),   'application/json'
           assert_equal content_type(:bar),    'application/bar'
           assert_equal content_type(:png),    'image/png'
           assert_equal content_type(:baz),    'application/baz;charset=utf-8'
+          # Changed to "text/javascript" in Rack >3.0
+          # https://github.com/sinatra/sinatra/pull/1857#issuecomment-1445062212
+          assert_match %r{^application|text/javascript;charset=utf-8$}, content_type(:js)
           tests_ran = true
           "done"
         end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -236,7 +236,7 @@ class HelpersTest < Minitest::Test
 
     it 'uses 303 for post requests if request is HTTP 1.1' do
       mock_app { post('/') { redirect '/'} }
-      post('/', {}, 'HTTP_VERSION' => 'HTTP/1.1')
+      post('/', {}, 'SERVER_PROTOCOL' => 'HTTP/1.1')
       assert_equal 303, status
       assert_equal '', body
       assert_equal 'http://example.org/', response['Location']
@@ -244,7 +244,7 @@ class HelpersTest < Minitest::Test
 
     it 'uses 302 for post requests if request is HTTP 1.0' do
       mock_app { post('/') { redirect '/'} }
-      post('/', {}, 'HTTP_VERSION' => 'HTTP/1.0')
+      post('/', {}, 'SERVER_PROTOCOL' => 'HTTP/1.0')
       assert_equal 302, status
       assert_equal '', body
       assert_equal 'http://example.org/', response['Location']

--- a/test/integration/gemfile_without_rackup.rb
+++ b/test/integration/gemfile_without_rackup.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: File.join('..', '..')

--- a/test/integration_start_helper.rb
+++ b/test/integration_start_helper.rb
@@ -14,9 +14,10 @@ module IntegrationStartHelper
     ]
   end
 
-  def with_process(command)
+  def with_process(command:, env: {}, debug: false)
     process = ChildProcess.build(*command)
     process.leader = true # ensure entire process tree dies
+    process.environment.merge!(env)
     read_io, write_io = IO.pipe
     process.io.stdout = write_io
     process.io.stderr = write_io
@@ -26,6 +27,8 @@ module IntegrationStartHelper
     # attempting to read from it. If the parent leaves its write end open, it
     # will not detect EOF.
     write_io.close
+
+    echo_output(read_io) if debug || debug_all?
 
     yield process, read_io
   ensure
@@ -42,7 +45,7 @@ module IntegrationStartHelper
     end
   end
 
-  def debug?
+  def debug_all?
     ENV.key?("DEBUG_START_PROCESS")
   end
 

--- a/test/integration_start_test.rb
+++ b/test/integration_start_test.rb
@@ -4,6 +4,8 @@ class IntegrationStartTest < Minitest::Test
   include IntegrationStartHelper
 
   def test_app_start_without_rackup
+    skip "So much work to run with rack head branch" if ENV['rack'] == 'head'
+
     app_file = File.join(__dir__, "integration", "simple_app.rb")
     gem_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb")
     command = command_for(app_file)

--- a/test/integration_start_test.rb
+++ b/test/integration_start_test.rb
@@ -3,11 +3,21 @@ require_relative "integration_start_helper"
 class IntegrationStartTest < Minitest::Test
   include IntegrationStartHelper
 
+  def test_app_start_without_rackup
+    app_file = File.join(__dir__, "integration", "simple_app.rb")
+    gem_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb")
+    command = command_for(app_file)
+    env = { BUNDLE_GEMFILE: gem_file }
+
+    with_process(command: command, env: env) do |process, read_io|
+      assert wait_for_output(read_io, /Sinatra could not start, the "rackup" gem was not found/)
+    end
+  end
+
   def test_classic_app_start
     app_file = File.join(__dir__, "integration", "simple_app.rb")
     command = command_for(app_file)
-    with_process(command) do |process, read_io|
-      echo_output(read_io) if debug? # will block
+    with_process(command: command) do |process, read_io|
       assert wait_for_output(read_io, /Sinatra \(v.+\) has taken the stage/)
     end
   end
@@ -15,8 +25,7 @@ class IntegrationStartTest < Minitest::Test
   def test_classic_app_with_zeitwerk
     app_file = File.join(__dir__, "integration", "zeitwerk_app.rb")
     command = command_for(app_file)
-    with_process(command) do |process, read_io|
-      echo_output(read_io) if debug? # will block
+    with_process(command: command) do |process, read_io|
       assert wait_for_output(read_io, /Sinatra \(v.+\) has taken the stage/)
     end
   end

--- a/test/integration_start_test.rb
+++ b/test/integration_start_test.rb
@@ -9,7 +9,7 @@ class IntegrationStartTest < Minitest::Test
     app_file = File.join(__dir__, "integration", "simple_app.rb")
     gem_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb")
     command = command_for(app_file)
-    env = { BUNDLE_GEMFILE: gem_file }
+    env = { "BUNDLE_GEMFILE" => gem_file }
 
     with_process(command: command, env: env) do |process, read_io|
       assert wait_for_output(read_io, /Sinatra could not start, the "rackup" gem was not found/)

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -40,7 +40,7 @@ class ResponseTest < Minitest::Test
       @response.body   = ['Hello World']
       assert_equal [
         status_code,
-        { 'Content-Type' => 'text/html', 'Content-Length' => '11' },
+        { 'content-type' => 'text/html', 'content-length' => '11' },
         ['Hello World']
       ], @response.finish
     end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -313,7 +313,7 @@ class RoutingTest < Minitest::Test
   it "handles params without a value" do
     mock_app {
       get '/' do
-        assert_nil params.fetch('foo')
+        assert_empty params.fetch('foo')
         "Given: #{params.keys.sort.join(',')}"
       end
     }

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -313,7 +313,7 @@ class RoutingTest < Minitest::Test
   it "handles params without a value" do
     mock_app {
       get '/' do
-        assert_empty params.fetch('foo')
+        assert_nil params.fetch('foo')
         "Given: #{params.keys.sort.join(',')}"
       end
     }

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -24,7 +24,7 @@ module Rack::Handler
     end
   end
 
-  register 'mock', 'Rack::Handler::Mock'
+  register :mock, Mock
 end
 
 class ServerTest < Minitest::Test

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 require 'stringio'
 
-module Rack::Handler
+module Rackup::Handler
   class Mock
     extend Minitest::Assertions
     # Allow assertions in request context


### PR DESCRIPTION
Adds support for Rack 3, drops support for Rack 2.

Close #1797

- [x] make sinatra test `handles params without a value` pass
- [x] address various rack deprecations
- [x] address `Rack::Handler is deprecated and replaced by Rackup::Handler`
- [x] make [rack `latest` job work](https://github.com/sinatra/sinatra/actions/runs/3808067712/jobs/6478335024#step:7:10)
- [x] restore `continue-on-error` in test workflow
- [x] use rackup 2.x https://rubygems.org/gems/rackup
- [x] use rack-session 2.x https://rubygems.org/gems/rack-session

See the individual commits for various details.

<Details><Summary>Old comment from Dec, 2022</Summary>

There's one failing test left to address (besides async tests that I have disabled for now, that area is being discussed a bit in #1853): EDIT: behaviour changed in Rack 3: https://github.com/rack/rack/pull/1989

https://github.com/sinatra/sinatra/blob/9b6ba81089244826395577113ac7bac622fdc327/test/routing_test.rb#L314-L323

Opening as draft until we have addressed that – and also until I've taken this for a spin with a real app – something for next year! Happy New Year Sinatra users 🥳 

</Details>

---

This work was sponsored by [84codes](https://84.codes/) ([CloudAMQP](https://www.cloudamqp.com/), [CloudKarafka](https://www.cloudkarafka.com/), [ElephantSQL](https://www.cloudmqtt.com/), [CloudMQTT](https://www.elephantsql.com/))