### PR TITLE
Add support to keep open streaming connections with Puma

### DIFF
--- a/test/integration/app.rb
+++ b/test/integration/app.rb
@@ -37,7 +37,7 @@ end
 
 set :out, nil
 get '/async' do
-  stream(:keep_open) { |o| (settings.out = o) << "hi!" }
+  stream(:keep_open) { |o| (settings.out = o) << "hi!"; sleep 1 }
 end
 
 get '/send' do
@@ -66,7 +66,7 @@ end
 class Subclass < Sinatra::Base
   set :out, nil
   get '/subclass/async' do
-    stream(:keep_open) { |o| (settings.out = o) << "hi!" }
+    stream(:keep_open) { |o| (settings.out = o) << "hi!"; sleep 1 }
   end
 
   get '/subclass/send' do

--- a/test/integration_async_helper.rb
+++ b/test/integration_async_helper.rb
@@ -4,7 +4,7 @@ module IntegrationAsyncHelper
   def it(message, &block)
     base_port = 5100 + Process.pid % 100
 
-    %w(rainbows).each_with_index do |server_name, index|
+    %w(rainbows puma).each_with_index do |server_name, index|
       server = IntegrationHelper::BaseServer.new(server_name, base_port + index)
       next unless server.installed?
 

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -44,7 +44,14 @@ module IntegrationHelper
 
     def installed?
       return @installed unless @installed.nil?
-      s = server == 'HTTP' ? 'net/http/server' : server
+      s = case server
+      when 'HTTP'
+        'net/http/server'
+      when 'puma'
+        'puma/rack/handler'
+      else
+        server
+      end
       require s
       @installed = true
     rescue LoadError

--- a/test/streaming_test.rb
+++ b/test/streaming_test.rb
@@ -133,6 +133,7 @@ class StreamingTest < Minitest::Test
         env['async.close'] = close
         stream(:keep_open) do |out|
           out.callback { ran = true }
+          out.close
         end
       end
     end


### PR DESCRIPTION
@ioquatix I also tried to test this with Falcon as well, but it didn't seem to work. Does Falcon buffer the response?

This is somewhat modeled after streaming in Roda: https://github.com/jeremyevans/roda/blob/c919ac9c7e88f159f8c6185b0bdb5a9311e24d93/lib/roda/plugins/streaming.rb#L143