### PR TITLE
CI: allow JRuby and head versions to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           # Due to https://github.com/jruby/jruby/issues/7647
           - { ruby: jruby-9.4, rack: '~> 2', puma: stable, allow-failure: true }
           # Never fail our build due to problems with head
+          - { ruby: ruby-head, rack: '~> 2', puma: stable, allow-failure: true }
           - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
           - { ruby: truffleruby-head, rack: '~> 2', puma: stable, allow-failure: true }
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,16 @@ jobs:
         rack:
           - '~> 2'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
         include:
           - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: latest }
+          # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
+          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
           - { ruby: jruby-9.4, rack: '~> 2', puma: stable, allow-failure: true }
+          # Never fail our build due to problems with head
           - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
           - { ruby: truffleruby-head, rack: '~> 2', puma: stable, allow-failure: true }
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         rack:
           - '~> 2'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', 'jruby-9.4', truffleruby]
         include:
           - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,13 @@ jobs:
         rack:
           - '~> 2'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby, truffleruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby]
         include:
           - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: latest }
           - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,13 @@ jobs:
         rack:
           - '~> 2'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', 'jruby-9.4', truffleruby]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 'jruby-9.3', truffleruby]
         include:
           - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
           - { ruby: 3.2, rack: '~> 2', puma: latest }
+          # Due to https://github.com/jruby/jruby/issues/7647
+          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, allow-failure: true }
           - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
           - { ruby: truffleruby-head, rack: '~> 2', puma: stable, allow-failure: true }
     env:


### PR DESCRIPTION
See https://github.com/sinatra/sinatra/actions/runs/4138714331/jobs/7155450583#step:5:639

Failure was

      1) Failure:
    IntegrationTest#test_with_webrick_does_not_generate_warnings_0 [/home/runner/work/sinatra/sinatra/test/integration_test.rb:56]: