### PR TITLE
CI: handle dependencies the same way, add Tilt to the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}
+      tilt: ${{ matrix.tilt }}
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
           # Puma
           - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0.0' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0.0' }
-          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: 3.2, rack: '~> 2', puma: head,     tilt: '~> 2.0.0', allow-failure: true }
           # Tilt
-          - { ruby: 3.1, rack: '~> 2', puma: stable,   tilt: '~> 2', allow-failure: true }
-          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: latest, allow-failure: true }
+          - { ruby: 3.1, rack: '~> 2', puma: stable,   tilt: '~> 2',     allow-failure: true }
+          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: head,       allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
           - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }})
+    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.puma }})
     permissions:
       contents: read #  to fetch code (actions/checkout)
       actions: read #  to list jobs for workflow run (8398a7/action-slack)
@@ -24,20 +24,26 @@ jobs:
           - stable
         rack:
           - '~> 2'
+        tilt:
+          - stable
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
         include:
-          - { ruby: 2.6, rack: '~> 2', puma: '~> 5' }
-          - { ruby: 3.2, rack: '~> 2', puma: '~> 5' }
-          - { ruby: 3.2, rack: '~> 2', puma: latest }
+          # Puma
+          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: stable }
+          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: stable }
+          # Puma head
+          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: stable }
+          # Tilt head
+          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: latest, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
-          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, allow-failure: true }
+          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
-          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, allow-failure: true }
+          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
           # Never fail our build due to problems with head
-          - { ruby: ruby-head, rack: '~> 2', puma: stable, allow-failure: true }
-          - { ruby: jruby-head, rack: '~> 2', puma: stable, allow-failure: true }
-          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, allow-failure: true }
+          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,26 +25,26 @@ jobs:
         rack:
           - '~> 2'
         tilt:
-          - '~> 2.0'
+          - '~> 2.0.0'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
         include:
           # Puma
-          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0' }
-          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0' }
+          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0.0' }
+          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0.0' }
           # Puma head
-          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0' }
+          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0.0' }
           # Tilt
           - { ruby: 3.1, rack: '~> 2', puma: latest,   tilt: '~> 2', allow-failure: true }
           - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: latest, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
-          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
+          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
-          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
+          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
           # Never fail our build due to problems with head
-          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
-          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
-          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
+          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,25 +25,26 @@ jobs:
         rack:
           - '~> 2'
         tilt:
-          - stable
+          - '~> 2.0'
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
         include:
           # Puma
-          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: stable }
-          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: stable }
+          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0' }
+          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0' }
           # Puma head
-          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: stable }
-          # Tilt head
+          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0' }
+          # Tilt
+          - { ruby: 3.1, rack: '~> 2', puma: latest,   tilt: '~> 2', allow-failure: true }
           - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: latest, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
-          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
-          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
           # Never fail our build due to problems with head
-          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
-          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
-          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
+          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
+          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: '~> 2.0', allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0.0' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0.0' }
           # Puma head
-          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0.0' }
+          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0.0', allow-failure: true }
           # Tilt
           - { ruby: 3.1, rack: '~> 2', puma: latest,   tilt: '~> 2', allow-failure: true }
           - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: latest, allow-failure: true }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,10 @@ jobs:
           # Puma
           - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0.0' }
           - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0.0' }
-          # Puma head
           - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: '~> 2.0.0', allow-failure: true }
           # Tilt
-          - { ruby: 3.1, rack: '~> 2', puma: latest,   tilt: '~> 2', allow-failure: true }
-          - { ruby: 3.2, rack: '~> 2', puma: latest,   tilt: latest, allow-failure: true }
+          - { ruby: 3.1, rack: '~> 2', puma: stable,   tilt: '~> 2', allow-failure: true }
+          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: latest, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
           - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.puma }})
+    name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.tilt }})
     permissions:
       contents: read #  to fetch code (actions/checkout)
       actions: read #  to list jobs for workflow run (8398a7/action-slack)

--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,12 @@ gem 'rake'
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'latest'
+rack_version = { github: 'rack/rack' } if rack_version == 'head'
 gem 'rack', rack_version
 
 puma_version = ENV['puma'].to_s
 puma_version = nil if puma_version.empty? || (puma_version == 'stable')
-puma_version = { github: 'puma/puma' } if puma_version == 'latest'
+puma_version = { github: 'puma/puma' } if puma_version == 'head'
 gem 'puma', puma_version
 
 gem 'minitest', '~> 5.0'

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -7,7 +7,7 @@ gem 'rake'
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'latest'
+rack_version = { github: 'rack/rack' } if rack_version == 'head'
 gem 'rack', rack_version
 
 gem 'sinatra', path: '..'

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -7,7 +7,7 @@ gem 'rake'
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'main'
+rack_version = { github: 'rack/rack' } if rack_version == 'latest'
 gem 'rack', rack_version
 
 gem 'sinatra', path: '..'

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -37,9 +37,7 @@ rack_version = nil if rack_version.empty? || (rack_version == 'stable')
 rack_version = { github: 'rack/rack' } if rack_version == 'latest'
 gem 'rack', rack_version
 
-# tilt may move to https://github.com/jeremyevans/tilt
-# https://github.com/rtomayko/tilt/pull/394#issuecomment-1428522576
 tilt_version = ENV['tilt'].to_s
 tilt_version = nil if tilt_version.empty? || (tilt_version == 'stable')
-tilt_version = { github: 'rtomayko/tilt' } if tilt_version == 'latest'
+tilt_version = { github: 'jeremyevans/tilt' } if tilt_version == 'latest'
 gem 'tilt', tilt_version

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -34,10 +34,10 @@ end
 
 rack_version = ENV['rack'].to_s
 rack_version = nil if rack_version.empty? || (rack_version == 'stable')
-rack_version = { github: 'rack/rack' } if rack_version == 'latest'
+rack_version = { github: 'rack/rack' } if rack_version == 'head'
 gem 'rack', rack_version
 
 tilt_version = ENV['tilt'].to_s
 tilt_version = nil if tilt_version.empty? || (tilt_version == 'stable')
-tilt_version = { github: 'jeremyevans/tilt' } if tilt_version == 'latest'
+tilt_version = { github: 'jeremyevans/tilt' } if tilt_version == 'head'
 gem 'tilt', tilt_version

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -32,12 +32,14 @@ group :development, :test do
   gem 'multi_json'
 end
 
-# Allows stuff like `tilt=1.2.2 bundle install` or `tilt=master ...`.
-# Used by the CI.
-repos = { 'tilt' => 'rtomayko/tilt', 'rack' => 'rack/rack' }
-%w[tilt rack].each do |lib|
-  dep = (ENV[lib] || 'stable').sub "#{lib}-", ''
-  dep = nil if dep == 'stable'
-  dep = { github: repos[lib], branch: dep } if dep && dep !~ (/(\d+\.?)+(\d+)?/)
-  gem lib, dep if dep
-end
+rack_version = ENV['rack'].to_s
+rack_version = nil if rack_version.empty? || (rack_version == 'stable')
+rack_version = { github: 'rack/rack' } if rack_version == 'latest'
+gem 'rack', rack_version
+
+# tilt may move to https://github.com/jeremyevans/tilt
+# https://github.com/rtomayko/tilt/pull/394#issuecomment-1428522576
+tilt_version = ENV['tilt'].to_s
+tilt_version = nil if tilt_version.empty? || (tilt_version == 'stable')
+tilt_version = { github: 'rtomayko/tilt' } if tilt_version == 'latest'
+gem 'tilt', tilt_version


### PR DESCRIPTION
Adds [Tilt](https://rubygems.org/gems/tilt) to the CI matrix. It now resides at https://github.com/jeremyevans/tilt

Changes `latest` to `head` because "latest" sounds a lot like "latest release" but we mean using the main/master branch of the repo of the dependency we test with. Matches `ruby-head`.