### PR TITLE
[CI] Fix up integration stream test for Puma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /coverage
 .yardoc
 /doc
+.bundle
+vendor

--- a/test/integration/app.rb
+++ b/test/integration/app.rb
@@ -20,7 +20,7 @@ get '/stream' do
   stream do |out|
     sleep 0.1
     out << "a"
-    sleep 1.2
+    sleep 1.25
     out << "b"
   end
 end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -35,6 +35,7 @@ module IntegrationHelper
 
     def initialize(server, port, async)
       @installed, @pipe, @server, @port = nil, nil, server, port
+      ENV['PUMA_MIN_THREADS'] = '1' if server == 'puma'
       if async
         Server.all_async << self
       else

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -28,15 +28,17 @@ class IntegrationTest < Minitest::Test
 
   it 'streams' do
     next if server.webrick? or server.trinidad?
-    times, chunks = [Time.now], []
+    times, chunks = [Process.clock_gettime(Process::CLOCK_MONOTONIC)], []
     server.get_stream do |chunk|
       next if chunk.empty?
       chunks << chunk
-      times << Time.now
+      times << Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
     assert_equal ["a", "b"], chunks
-    assert times[1] - times[0] < 1
-    assert times[2] - times[1] > 1
+    int1 = (times[1] - times[0]).round 2
+    int2 = (times[2] - times[1]).round 2
+    assert_operator 1, :>, int1
+    assert_operator 1, :<, int2
   end
 
   it 'starts the correct server' do


### PR DESCRIPTION
2nd commit fixes timing issue with Puma, adds 0.05 second to sleep, small changes to asserts and time calc

Two commits:

1. [.gitignore - add Bundler items](https://github.com/sinatra/sinatra/commit/963e92e7a8b9bd8bbe93bf6b17d6746d364fd4af)

2. [[CI] Fix up integration stream test](https://github.com/sinatra/sinatra/commit/1e4bb7727452c48a07a5f4cbf4e0fe702a3abe37)