### PR TITLE
Rescue `RuntimeError` when trying to use `SecureRandom`

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1849,7 +1849,8 @@ module Sinatra
       require 'securerandom'
       set :session_secret, SecureRandom.hex(64)
     rescue LoadError, NotImplementedError, RuntimeError
-      # SecureRandom raises a NotImplementedError if no random device is available, or RuntimeError if urandom is not available
+      # SecureRandom raises a NotImplementedError if no random device is available
+      # RuntimeError raised due to broken openssl backend: https://bugs.ruby-lang.org/issues/19230
       set :session_secret, format('%064x', Kernel.rand((2**256) - 1))
     end
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1848,8 +1848,8 @@ module Sinatra
     begin
       require 'securerandom'
       set :session_secret, SecureRandom.hex(64)
-    rescue LoadError, NotImplementedError
-      # SecureRandom raises a NotImplementedError if no random device is available
+    rescue LoadError, NotImplementedError, RuntimeError
+      # SecureRandom raises a NotImplementedError if no random device is available, or RuntimeError if urandom is not available
       set :session_secret, format('%064x', Kernel.rand((2**256) - 1))
     end
 


### PR DESCRIPTION
Hello,

I got a report from a user that he couldn't run my app on his Synology. Turns out it doesn't have urandom. https://github.com/stefansundin/rssbox/issues/67

Relevant part of the log:

```
2023-02-25 15:21:22,stdout,	from /app/app.rb:4:in `require'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra.rb:3:in `<top (required)>'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra.rb:3:in `require'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/main.rb:3:in `<top (required)>'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/main.rb:28:in `<module:Sinatra>'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/main.rb:28:in `require'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/base.rb:20:in `<top (required)>'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/base.rb:908:in `<module:Sinatra>'
2023-02-25 15:21:22,stdout,	from /app/vendor/bundle/ruby/3.2.0/gems/sinatra-3.0.5/lib/sinatra/base.rb:1840:in `<class:Base>'
2023-02-25 15:21:22,stdout,	from /usr/local/ruby/lib/ruby/3.2.0/random/formatter.rb:94:in `hex'
2023-02-25 15:21:22,stdout,	from /usr/local/ruby/lib/ruby/3.2.0/random/formatter.rb:74:in `random_bytes'
2023-02-25 15:21:22,stdout,	from /usr/local/ruby/lib/ruby/3.2.0/securerandom.rb:55:in `gen_random_openssl'
2023-02-25 15:21:22,stdout,/usr/local/ruby/lib/ruby/3.2.0/securerandom.rb:55:in `urandom': �[1mfailed to get urandom (�[1;4mRuntimeError�[m�[1m)�[m
2023-02-25 15:21:22,stdout,�[31mbundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)�[0m
2023-02-25 15:21:22,stdout,! Unable to load application: RuntimeError: failed to get urandom
```

Where the exception is raised in the Ruby code: https://github.com/ruby/ruby/blob/381a373ab92e2a5869e75f43815993cef39d32cf/random.c#L767

I can't find anything that supports that `NotImplementedError` is raised, but perhaps that is if both random and urandom is missing?

Maybe it would be better to just rescue all errors instead?

I have not tested this fix myself since I don't know if it is simple to get rid of urandom in a way that accurately represents the issue. I'll check with the user if he's willing to try out the change.. Maybe I'll build a special docker image for him to test.

Please let me know if you want me to change anything, or feel free to make changes on this branch directly. Thanks!
