### PR TITLE
Avoid crash in `uri` helper on Integer input

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -317,7 +317,7 @@ module Sinatra
     # Generates the absolute URI for a given path in the app.
     # Takes Rack routers and reverse proxies into account.
     def uri(addr = nil, absolute = true, add_script_name = true)
-      return addr if addr =~ /\A[a-z][a-z0-9+.\-]*:/i
+      return addr if addr.to_s =~ /\A[a-z][a-z0-9+.\-]*:/i
 
       uri = [host = String.new]
       if absolute

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1845,6 +1845,12 @@ class HelpersTest < Minitest::Test
       assert_equal 'http://example.org/foo/bar', body
     end
 
+    it 'handles integer input' do
+      mock_app { get('/') { uri 123 }}
+      get '/'
+      assert_equal 'http://example.org/123', body
+    end
+
     it 'handles absolute URIs' do
       mock_app { get('/') { uri 'http://google.com' }}
       get '/'


### PR DESCRIPTION
I hope this makes sense, WDYT @sinatra/sinatras-helpers?

Close #1889