### PR TITLE
Use slim HEAD branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,25 +25,24 @@ jobs:
         rack:
           - '~> 2'
         tilt:
-          - '~> 2.0.0'
+          - stable
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
         include:
           # Puma
-          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: '~> 2.0.0' }
-          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: '~> 2.0.0' }
-          - { ruby: 3.2, rack: '~> 2', puma: head,     tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: stable }
+          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: stable }
+          - { ruby: 3.2, rack: '~> 2', puma: head,     tilt: stable, allow-failure: true }
           # Tilt
-          - { ruby: 3.1, rack: '~> 2', puma: stable,   tilt: '~> 2',     allow-failure: true }
-          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: head,       allow-failure: true }
+          - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: head, allow-failure: true }
           # Due to flaky tests, see https://github.com/sinatra/sinatra/pull/1870
-          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: jruby-9.3, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
           # Due to https://github.com/jruby/jruby/issues/7647
-          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: jruby-9.4, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
           # Never fail our build due to problems with head
-          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
-          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
-          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: '~> 2.0.0', allow-failure: true }
+          - { ruby: ruby-head,        rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: jruby-head,       rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: '~> 2', puma: stable, tilt: stable, allow-failure: true }
     env:
       rack: ${{ matrix.rack }}
       puma: ${{ matrix.puma }}

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -19,7 +19,9 @@ group :development, :test do
   platform :jruby, :ruby do
     gem 'hamlit', '>= 3'
     gem 'liquid', '~> 2.6.x'
-    gem 'slim'
+    # Use main until there's a slim release that can be used with Tilt 2.1.0
+    # https://github.com/slim-template/slim/pull/910
+    gem 'slim', github: 'slim-template/slim'
   end
 
   platform :ruby do


### PR DESCRIPTION
Needed to run with Tilt 2.1.0 in CI  until https://github.com/slim-template/slim/pull/910 is part of a Slim release.