### PR TITLE
Use latest liquid release in sinatra-contrib CI

### DIFF
--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
 
   platform :jruby, :ruby do
     gem 'hamlit', '>= 3'
-    gem 'liquid', '~> 2.6.x'
+    gem 'liquid'
     # Use main until there's a slim release that can be used with Tilt 2.1.0
     # https://github.com/slim-template/slim/pull/910
     gem 'slim', github: 'slim-template/slim'


### PR DESCRIPTION
2.6.x is very old, https://rubygems.org/gems/liquid/versions

    2.6.3 - July 23, 2015 (45.5 KB)

Found these traces in history:

- https://github.com/sinatra/sinatra/commit/741677743cbebe2cca5992b4dd767eec89350c30
- https://github.com/sinatra/sinatra-contrib/commit/2dc03c879a858a418cfc3697fe7afd0b53e0f766