### PR TITLE
Update broken links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2319,7 +2319,7 @@ end
 ```
 
 The semantics of `use` are identical to those defined for the
-[Rack::Builder](http://www.rubydoc.info/github/rack/rack/master/Rack/Builder) DSL
+[Rack::Builder](https://www.rubydoc.info/github/rack/rack/main/Rack/Builder) DSL
 (most frequently used from rackup files). For example, the `use` method
 accepts multiple/variable args as well as blocks:
 
@@ -2335,7 +2335,7 @@ many of these components automatically based on configuration so you
 typically don't have to `use` them explicitly.
 
 You can find useful middleware in
-[rack](https://github.com/rack/rack/tree/master/lib/rack),
+[rack](https://github.com/rack/rack/tree/main/lib/rack),
 [rack-contrib](https://github.com/rack/rack-contrib#readme),
 or in the [Rack wiki](https://github.com/rack/rack/wiki/List-of-Middleware).
 
@@ -2343,7 +2343,7 @@ or in the [Rack wiki](https://github.com/rack/rack/wiki/List-of-Middleware).
 
 Sinatra tests can be written using any Rack-based testing library or
 framework.
-[Rack::Test](http://www.rubydoc.info/github/brynary/rack-test/master/frames)
+[Rack::Test](https://www.rubydoc.info/github/rack/rack-test/main/frames)
 is recommended:
 
 ```ruby
@@ -2887,9 +2887,9 @@ SemVerTag.
 
 ## Further Reading
 
-* [Project Website](http://www.sinatrarb.com/) - Additional documentation,
+* [Project Website](https://sinatrarb.com/) - Additional documentation,
   news, and links to other resources.
-* [Contributing](http://www.sinatrarb.com/contributing) - Find a bug? Need
+* [Contributing](https://sinatrarb.com/contributing) - Find a bug? Need
   help? Have a patch?
 * [Issue tracker](https://github.com/sinatra/sinatra/issues)
 * [Twitter](https://twitter.com/sinatra)
@@ -2899,7 +2899,7 @@ SemVerTag.
 * [Sinatra Book](https://github.com/sinatra/sinatra-book) - Cookbook Tutorial
 * [Sinatra Recipes](http://recipes.sinatrarb.com/) - Community contributed
   recipes
-* API documentation for the [latest release](http://www.rubydoc.info/gems/sinatra)
-  or the [current HEAD](http://www.rubydoc.info/github/sinatra/sinatra) on
-  [RubyDoc](http://www.rubydoc.info/)
+* API documentation for the [latest release](https://www.rubydoc.info/gems/sinatra)
+  or the [current HEAD](https://www.rubydoc.info/github/sinatra/sinatra) on
+  [RubyDoc](https://www.rubydoc.info/)
 * [CI Actions](https://github.com/sinatra/sinatra/actions)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -19,7 +19,7 @@ require 'sinatra/version'
 
 module Sinatra
   # The request object. See Rack::Request for more info:
-  # http://rubydoc.info/github/rack/rack/master/Rack/Request
+  # https://rubydoc.info/github/rack/rack/main/Rack/Request
   class Request < Rack::Request
     HEADER_PARAM = /\s*[\w.]+=(?:[\w.]+|"(?:[^"\\]|\\.)*")?\s*/.freeze
     HEADER_VALUE_WITH_PARAMS = %r{(?:(?:\w+|\*)/(?:\w+(?:\.|-|\+)?|\*)*)\s*(?:;#{HEADER_PARAM})*}.freeze
@@ -158,8 +158,8 @@ module Sinatra
 
   # The response object. See Rack::Response and Rack::Response::Helpers for
   # more info:
-  # http://rubydoc.info/github/rack/rack/master/Rack/Response
-  # http://rubydoc.info/github/rack/rack/master/Rack/Response/Helpers
+  # https://rubydoc.info/github/rack/rack/main/Rack/Response
+  # https://rubydoc.info/github/rack/rack/main/Rack/Response/Helpers
   class Response < Rack::Response
     DROP_BODY_RESPONSES = [204, 304].freeze
 

--- a/rack-protection/spec/spec_helper.rb
+++ b/rack-protection/spec/spec_helper.rb
@@ -21,7 +21,7 @@ Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.
 #
-# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+# See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.

--- a/sinatra-contrib/README.md
+++ b/sinatra-contrib/README.md
@@ -157,7 +157,7 @@ end
 ### Documentation
 
 For more info check the [official docs](http://www.sinatrarb.com/contrib/) and
-[api docs](http://www.rubydoc.info/gems/sinatra-contrib).
+[api docs](https://www.rubydoc.info/gems/sinatra-contrib).
 
 [sinatra-reloader]: http://www.sinatrarb.com/contrib/reloader
 [sinatra-namespace]: http://www.sinatrarb.com/contrib/namespace

--- a/sinatra-contrib/lib/sinatra/test_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/test_helpers.rb
@@ -25,7 +25,7 @@ module Sinatra
     #
     # Body of last_response
     #
-    # @see http://www.rubydoc.info/github/rack/rack/master/Rack/Response#body-instance_method
+    # @see https://www.rubydoc.info/github/rack/rack/main/Rack/Response#body-instance_method
     # @return [String] body of the last response
 
     # @!method headers
@@ -104,7 +104,7 @@ module Sinatra
     # @!group Instance Methods delegated to rack_mock_session
     # @!method cookie_jar
     #
-    # Returns a {http://www.rubydoc.info/github/rack-test/rack-test/Rack/Test/CookieJar Rack::Test::CookieJar}.
+    # Returns a {https://www.rubydoc.info/github/rack/rack-test/Rack/Test/CookieJar Rack::Test::CookieJar}.
     #
     # @return [Rack::Test::CookieJar]
     def_delegators :rack_mock_session, :cookie_jar

--- a/sinatra-contrib/spec/spec_helper.rb
+++ b/sinatra-contrib/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'sinatra/contrib'
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.
 #
-# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+# See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
- Rack changed default branch to "main"
- rubydoc.info redirects to https://