### PR TITLE
CI: remove redundant Puma job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
         include:
           # Puma
           - { ruby: 3.1, rack: '~> 2', puma: '~> 5',   tilt: stable }
-          - { ruby: 3.2, rack: '~> 2', puma: '~> 6.0', tilt: stable }
           - { ruby: 3.2, rack: '~> 2', puma: head,     tilt: stable, allow-failure: true }
           # Tilt
           - { ruby: 3.2, rack: '~> 2', puma: stable,   tilt: head, allow-failure: true }


### PR DESCRIPTION
`~> 6.0` will install latest Puma release, that's what `stable` do too

Better we add this job once Puma 7 exist.