### PR TITLE
Add action-discord notifications to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,15 +86,6 @@ jobs:
       run: |
         bundle install --jobs=3 --retry=3
         bundle exec rake
-
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: repo,message,commit,author,ref,job,took # selectable (default: repo,message)
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
-        MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
-      if: failure() && env.SLACK_WEBHOOK_URL
     # because continue-on-error marks the steps as pass even if they fail
     - name: "setup-ruby (bundle install) outcome: ${{ steps.setup-ruby.outcome }}"
       run: ""
@@ -104,3 +95,12 @@ jobs:
       run: ""
     - name: "rack-protection tests outcome: ${{ steps.protection-tests.outcome }}"
       run: ""
+
+  notify:
+    uses: zzak/action-discord/.github/workflows/notify.yml@main
+    if: ${{ github.ref_name == 'main' }}
+    needs: test
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+    with:
+      result: ${{ needs.test.result }}


### PR DESCRIPTION
Some examples

## Failed

Multiple failed jobs

<img width="361" alt="Screenshot 2023-03-10 at 15 47 11" src="https://user-images.githubusercontent.com/277819/224243790-7d1e8427-e15c-4a72-ac99-3e5d09cd6c83.png">

A single failed job

<img width="408" alt="Screenshot 2023-03-10 at 15 47 34" src="https://user-images.githubusercontent.com/277819/224243836-5a87ba5d-83ec-4833-8773-303dff533b24.png">

## Fixed

If the previous run failed, but now it passes

<img width="296" alt="Screenshot 2023-03-10 at 15 47 28" src="https://user-images.githubusercontent.com/277819/224243940-43a5d053-ca79-49c0-aa84-cd84efefda92.png">

## Still failing

When the previous run failed, but still not fixed

<img width="307" alt="Screenshot 2023-03-10 at 15 47 22" src="https://user-images.githubusercontent.com/277819/224244003-3654896b-c10c-43ec-af5e-b0db2c13f52f.png">
