### PR TITLE
Add sass support via sass-embedded

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490
+        rubygems: ${{ matrix.ruby == '3.0' && 'latest' || 'default' }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'rainbows', platforms: [:mri] # uses #fork
 gem 'rdiscount', platforms: [:ruby]
 gem 'rdoc'
 gem 'redcarpet', platforms: [:ruby]
+gem 'sass-embedded', '~> 1.54'
 gem 'simplecov', require: false
 gem 'slim', '~> 4'
 gem 'yajl-ruby', platforms: [:ruby]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pick up if available.
       - [Erb Templates](#erb-templates)
       - [Builder Templates](#builder-templates)
       - [Nokogiri Templates](#nokogiri-templates)
+      - [Sass Templates](#sass-templates)
+      - [Scss Templates](#scss-templates)
       - [Liquid Templates](#liquid-templates)
       - [Markdown Templates](#markdown-templates)
       - [RDoc Templates](#rdoc-templates)
@@ -649,6 +651,39 @@ It also takes a block for inline templates (see [example](#inline-templates)).
 
 It also takes a block for inline templates (see [example](#inline-templates)).
 
+#### Sass Templates
+
+<table>
+  <tr>
+    <td>Dependency</td>
+    <td><a href="https://github.com/ntkme/sass-embedded-host-ruby" title="sass-embedded">sass-embedded</a></td>
+  </tr>
+  <tr>
+    <td>File Extension</td>
+    <td><tt>.sass</tt></td>
+  </tr>
+  <tr>
+    <td>Example</td>
+    <td><tt>sass :stylesheet, :style => :expanded</tt></td>
+  </tr>
+</table>
+
+#### Scss Templates
+
+<table>
+  <tr>
+    <td>Dependency</td>
+    <td><a href="https://github.com/ntkme/sass-embedded-host-ruby" title="sass-embedded">sass-embedded</a></td>
+  </tr>
+  <tr>
+    <td>File Extension</td>
+    <td><tt>.scss</tt></td>
+  </tr>
+  <tr>
+    <td>Example</td>
+    <td><tt>scss :stylesheet, :style => :expanded</tt></td>
+  </tr>
+</table>
 
 #### Liquid Templates
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -877,6 +877,7 @@ module Sinatra
       end
 
       if content_type
+        # sass-embedded returns a frozen string
         output = +output
         output.extend(ContentTyped).content_type = content_type
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -726,7 +726,7 @@ module Sinatra
   # Possible options are:
   #   :content_type   The content type to use, same arguments as content_type.
   #   :layout         If set to something falsy, no layout is rendered, otherwise
-  #                   the specified layout is used
+  #                   the specified layout is used (Ignored for `sass`)
   #   :layout_engine  Engine to use for rendering the layout.
   #   :locals         A hash with local variables that should be available
   #                   in the template
@@ -750,6 +750,20 @@ module Sinatra
 
     def haml(template, options = {}, locals = {}, &block)
       render(:haml, template, options, locals, &block)
+    end
+
+    def sass(template, options = {}, locals = {})
+      options[:default_content_type] = :css
+      options[:exclude_outvar] = true
+      options[:layout] = nil
+      render :sass, template, options, locals
+    end
+
+    def scss(template, options = {}, locals = {})
+      options[:default_content_type] = :css
+      options[:exclude_outvar] = true
+      options[:layout] = nil
+      render :scss, template, options, locals
     end
 
     def builder(template = nil, options = {}, locals = {}, &block)
@@ -862,7 +876,10 @@ module Sinatra
         catch(:layout_missing) { return render(layout_engine, layout, options, locals) { output } }
       end
 
-      output.extend(ContentTyped).content_type = content_type if content_type
+      if content_type
+        output = +output
+        output.extend(ContentTyped).content_type = content_type
+      end
       output
     end
 

--- a/sinatra-contrib/lib/sinatra/engine_tracking.rb
+++ b/sinatra-contrib/lib/sinatra/engine_tracking.rb
@@ -27,6 +27,16 @@ module Sinatra
       @current_engine == :haml
     end
 
+    # @return [Boolean] Returns true if current engine is `:sass`.
+    def sass?
+      @current_engine == :sass
+    end
+
+    # @return [Boolean] Returns true if current engine is `:scss`.
+    def scss?
+      @current_engine == :scss
+    end
+
     # @return [Boolean] Returns true if current engine is `:builder`.
     def builder?
       @current_engine == :builder

--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -229,7 +229,7 @@ module Sinatra
       attr_reader :base, :templates
 
       ALLOWED_ENGINES = %i[
-        erb erubi haml hamlit builder nokogiri
+        erb erubi haml hamlit builder nokogiri sass scss
         liquid markdown rdoc asciidoc markaby
         rabl slim yajl
       ]

--- a/sinatra-contrib/lib/sinatra/respond_with.rb
+++ b/sinatra-contrib/lib/sinatra/respond_with.rb
@@ -249,6 +249,7 @@ module Sinatra
 
     def self.engines
       engines = {
+        css: %i[sass scss],
         xml: %i[builder nokogiri],
         html: %i[erb erubi haml hamlit slim liquid
                  mab markdown rdoc],

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -54,5 +54,6 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'redcarpet'
   s.add_development_dependency 'rspec', '~> 3'
+  s.add_development_dependency 'sass-embedded', '~> 1.54'
   s.add_development_dependency 'slim'
 end

--- a/sinatra-contrib/spec/respond_with/not_html.sass
+++ b/sinatra-contrib/spec/respond_with/not_html.sass
@@ -1,0 +1,2 @@
+body
+  color: red

--- a/test/sass_test.rb
+++ b/test/sass_test.rb
@@ -1,0 +1,86 @@
+require_relative 'test_helper'
+
+begin
+require 'sass-embedded'
+
+class SassTest < Minitest::Test
+  def sass_app(options = {}, &block)
+    mock_app do
+      set :views, __dir__ + '/views'
+      set options
+      get('/', &block)
+    end
+    get '/'
+  end
+
+  it 'renders inline Sass strings' do
+    sass_app { sass "#sass\n  background-color: white\n" }
+    assert ok?
+    assert_equal "#sass {\n  background-color: white;\n}", body
+  end
+
+  it 'defaults content type to css' do
+    sass_app { sass "#sass\n  background-color: white\n" }
+    assert ok?
+    assert_equal "text/css;charset=utf-8", response['Content-Type']
+  end
+
+  it 'defaults allows setting content type per route' do
+    sass_app do
+      content_type :html
+      sass "#sass\n  background-color: white\n"
+    end
+    assert ok?
+    assert_equal "text/html;charset=utf-8", response['Content-Type']
+  end
+
+  it 'defaults allows setting content type globally' do
+    sass_app(:sass => { :content_type => 'html' }) {
+      sass "#sass\n  background-color: white\n"
+    }
+    assert ok?
+    assert_equal "text/html;charset=utf-8", response['Content-Type']
+  end
+
+  it 'renders .sass files in views path' do
+    sass_app { sass :hello }
+    assert ok?
+    assert_equal "#sass {\n  background-color: white;\n}", body
+  end
+
+  it 'ignores the layout option' do
+    sass_app { sass :hello, :layout => :layout2 }
+    assert ok?
+    assert_equal "#sass {\n  background-color: white;\n}", body
+  end
+
+  it "raises error if template not found" do
+    mock_app { get('/') { sass :no_such_template } }
+    assert_raises(Errno::ENOENT) { get('/') }
+  end
+
+  it "passes SASS options to the Sass engine" do
+    sass_app do
+      sass(
+        "#sass\n  background-color: white\n  color: black\n",
+        :style => :compressed
+      )
+    end
+    assert ok?
+    assert_equal("#sass{background-color:#fff;color:#000}", body)
+  end
+
+  it "passes default SASS options to the Sass engine" do
+    mock_app do
+      set :sass, {:style => :compressed} # default Sass style is :expanded
+      get('/') { sass("#sass\n  background-color: white\n  color: black\n") }
+    end
+    get '/'
+    assert ok?
+    assert_equal "#sass{background-color:#fff;color:#000}", body
+  end
+end
+
+rescue LoadError
+  warn "#{$!}: skipping sass tests"
+end

--- a/test/scss_test.rb
+++ b/test/scss_test.rb
@@ -1,0 +1,88 @@
+require_relative 'test_helper'
+
+begin
+require 'sass-embedded'
+
+class ScssTest < Minitest::Test
+  def scss_app(options = {}, &block)
+    mock_app do
+      set :views, __dir__ + '/views'
+      set options
+      get('/', &block)
+    end
+    get '/'
+  end
+
+  it 'renders inline Scss strings' do
+    scss_app { scss "#scss {\n  background-color: white; }\n" }
+    assert ok?
+    assert_equal "#scss {\n  background-color: white;\n}", body
+  end
+
+  it 'defaults content type to css' do
+    scss_app { scss "#scss {\n  background-color: white; }\n" }
+    assert ok?
+    assert_equal "text/css;charset=utf-8", response['Content-Type']
+  end
+
+  it 'defaults allows setting content type per route' do
+    scss_app do
+      content_type :html
+      scss "#scss {\n  background-color: white; }\n"
+    end
+    assert ok?
+    assert_equal "text/html;charset=utf-8", response['Content-Type']
+  end
+
+  it 'defaults allows setting content type globally' do
+    scss_app(:scss => { :content_type => 'html' }) {
+      scss "#scss {\n  background-color: white; }\n"
+    }
+    assert ok?
+    assert_equal "text/html;charset=utf-8", response['Content-Type']
+  end
+
+  it 'renders .scss files in views path' do
+    scss_app { scss :hello }
+    assert ok?
+    assert_equal "#scss {\n  background-color: white;\n}", body
+  end
+
+  it 'ignores the layout option' do
+    scss_app { scss :hello, :layout => :layout2 }
+    assert ok?
+    assert_equal "#scss {\n  background-color: white;\n}", body
+  end
+
+  it "raises error if template not found" do
+    mock_app { get('/') { scss(:no_such_template) } }
+    assert_raises(Errno::ENOENT) { get('/') }
+  end
+
+  it "passes scss options to the scss engine" do
+    scss_app do
+      scss(
+        "#scss {\n  background-color: white;\n  color: black\n}",
+        :style => :compressed
+      )
+    end
+    assert ok?
+    assert_equal "#scss{background-color:#fff;color:#000}", body
+  end
+
+  it "passes default scss options to the scss engine" do
+    mock_app do
+      set :scss, {:style => :compressed} # default scss style is :expanded
+      get('/') {
+        scss("#scss {\n  background-color: white;\n  color: black;\n}")
+      }
+    end
+    get '/'
+    assert ok?
+    assert_equal "#scss{background-color:#fff;color:#000}", body
+  end
+end
+
+rescue LoadError
+  warn "#{$!}: skipping scss tests"
+end

--- a/test/views/error.sass
+++ b/test/views/error.sass
@@ -1,0 +1,2 @@
+#sass
+  +argle-bargle

--- a/test/views/hello.sass
+++ b/test/views/hello.sass
@@ -1,0 +1,2 @@
+#sass
+  background-color: white

--- a/test/views/hello.scss
+++ b/test/views/hello.scss
@@ -1,0 +1,3 @@
+#scss {
+  background-color: white
+}


### PR DESCRIPTION
This PR adds support for sass back via [sass-embedded](https://github.com/ntkme/sass-embedded-host-ruby) (backed by currently maintained official [dart-sass-embedded](https://github.com/sass/dart-sass-embedded)).

It requires `tilt>=2.0.11`, which is the first version that introduced support for sass-embedded.