### PR TITLE
Add start and stop callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2230,7 +2230,7 @@ There are 2 lifecycle events currently exposed by Sinatra. One when the server s
 
 They can be used like this:
 
-```
+```ruby
 on_start do
   puts "===== Booting up ====="
 end

--- a/README.md
+++ b/README.md
@@ -2226,6 +2226,22 @@ set :protection, :session => true
 
 ## Lifecycle Events
 
+There are 2 lifecycle events currently exposed by Sinatra. One when the server starts and one when it stops.
+
+They can be used like this:
+
+```
+on_start do
+  puts "===== Booting up ====="
+end
+
+on_stop do
+  puts "===== Shutting down ====="
+end
+```
+
+Note that these callbacks only work when using Sinatra to start the web server.
+
 ## Environments
 
 There are three predefined `environments`: `"development"`,

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ pick up if available.
   - [Configuration](#configuration)
     - [Configuring attack protection](#configuring-attack-protection)
     - [Available Settings](#available-settings)
+  - [Lifecycle Events](#lifecycle-events)
   - [Environments](#environments)
   - [Error Handling](#error-handling)
     - [Not Found](#not-found)
@@ -2222,6 +2223,8 @@ set :protection, :session => true
       Defaults to <tt>true</tt>.
     </dd>
 </dl>
+
+## Lifecycle Events
 
 ## Environments
 

--- a/examples/lifecycle_events.rb
+++ b/examples/lifecycle_events.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby -I ../lib -I lib
+# frozen_string_literal: true
+
+require 'sinatra'
+
+get('/') do
+  'This shows how lifecycle events work'
+end
+
+on_start do
+  puts "=============="
+  puts "  Booting up"
+  puts "=============="
+end
+
+on_stop do
+  puts "================="
+  puts "  Shutting down"
+  puts "================="
+end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1568,7 +1568,7 @@ module Sinatra
         set :running_server, nil
         set :handler_name, nil
 
-        on_stop_callback.call
+        on_stop_callback.call if !on_stop_callback.nil?
       end
 
       alias stop! quit!
@@ -1656,8 +1656,7 @@ module Sinatra
           set :running_server, server
           set :handler_name,   handler_name
           server.threaded = settings.threaded if server.respond_to? :threaded=
-
-          on_start_callback.call
+          on_start_callback.call if !on_start_callback.nil?
           yield server if block_given?
         end
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1568,7 +1568,7 @@ module Sinatra
         set :running_server, nil
         set :handler_name, nil
 
-        on_stop_callback.call if !on_stop_callback.nil?
+        on_stop_callback.call unless on_stop_callback.nil?
       end
 
       alias stop! quit!

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1656,7 +1656,7 @@ module Sinatra
           set :running_server, server
           set :handler_name,   handler_name
           server.threaded = settings.threaded if server.respond_to? :threaded=
-          on_start_callback.call if !on_start_callback.nil?
+          on_start_callback.call unless on_start_callback.nil?
           yield server if block_given?
         end
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1277,7 +1277,7 @@ module Sinatra
         %r{zeitwerk/kernel\.rb}                             # Zeitwerk kernel#require decorator
       ].freeze
 
-      attr_reader :routes, :filters, :templates, :errors
+      attr_reader :routes, :filters, :templates, :errors, :on_start_callback, :on_stop_callback
 
       def callers_to_ignore
         CALLERS_TO_IGNORE
@@ -1470,6 +1470,14 @@ module Sinatra
         filters[type] << compile!(type, path, block, **options)
       end
 
+      def on_start(&on_start_callback)
+        @on_start_callback = on_start_callback
+      end
+
+      def on_stop(&on_stop_callback)
+        @on_stop_callback = on_stop_callback
+      end
+
       # Add a route condition. The route is considered non-matching when the
       # block returns false.
       def condition(name = "#{caller.first[/`.*'/]} condition", &block)
@@ -1559,6 +1567,8 @@ module Sinatra
         warn '== Sinatra has ended his set (crowd applauds)' unless suppress_messages?
         set :running_server, nil
         set :handler_name, nil
+
+        on_stop_callback.call
       end
 
       alias stop! quit!
@@ -1647,6 +1657,7 @@ module Sinatra
           set :handler_name,   handler_name
           server.threaded = settings.threaded if server.respond_to? :threaded=
 
+          on_start_callback.call
           yield server if block_given?
         end
       end
@@ -2037,7 +2048,7 @@ module Sinatra
     delegate :get, :patch, :put, :post, :delete, :head, :options, :link, :unlink,
              :template, :layout, :before, :after, :error, :not_found, :configure,
              :set, :mime_type, :enable, :disable, :use, :development?, :test?,
-             :production?, :helpers, :settings, :register
+             :production?, :helpers, :settings, :register, :on_start, :on_stop
 
     class << self
       attr_accessor :target

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -27,14 +27,6 @@ module Rack::Handler
   register 'mock', 'Rack::Handler::Mock'
 end
 
-class EventHookTest
-  def self.start
-  end
-
-  def self.stop
-  end
-end
-
 class ServerTest < Minitest::Test
   setup do
     mock_app do
@@ -54,14 +46,19 @@ class ServerTest < Minitest::Test
   end
 
   context "event hooks" do
+    dummy_class = Class.new do
+      def self.start_hook; end
+      def self.stop_hook; end
+    end
+
     it "runs the provided code when the server starts" do
       @app.on_start do
-        EventHookTest.start
+        dummy_class.start_hook
       end
       mock = MiniTest::Mock.new
       mock.expect(:call, nil)
 
-      EventHookTest.stub(:start, mock) do
+      dummy_class.stub(:start_hook, mock) do
         @app.run!
       end
 
@@ -70,12 +67,12 @@ class ServerTest < Minitest::Test
 
     it "runs the provided code when the server stops" do
       @app.on_stop do
-        EventHookTest.stop
+        dummy_class.stop_hook
       end
       mock = MiniTest::Mock.new
       mock.expect(:call, nil)
 
-      EventHookTest.stub(:stop, mock) do
+      dummy_class.stub(:stop_hook, mock) do
         @app.run!
         @app.quit!
       end


### PR DESCRIPTION
This PR adds lifecycle events to Sinatra. Related issue: #1184 