### PR TITLE
[Draft] Issue 1548: Expected to see parent handler invoked.

### DIFF
--- a/test/mapped_error_test.rb
+++ b/test/mapped_error_test.rb
@@ -115,6 +115,18 @@ class MappedErrorTest < Minitest::Test
       end
       get '/'
       assert_equal 500, status
+      assert_equal "she's there.", body
+    end
+
+    it "uses the Exception handler before raising errors even when raise_errors is set" do
+      mock_app do
+        set :raise_errors, true
+        error(Exception) { "Parent handler" }
+        get('/') { raise FooError }
+      end
+      get '/'
+      assert_equal 500, status
+      assert_equal "Parent handler", body
     end
 
     it "never raises Sinatra::NotFound beyond the application" do


### PR DESCRIPTION
See https://github.com/sinatra/sinatra/issues/1548

If error handlers are meant to be invoked even when `raise_errors` is set, then it should also work for handlers set on ancestor classes.

Currently this PR demonstrates a failing test that should pass -- but the test does not pass.