### PR TITLE
Issue 1548: Describe raise_errors better in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2329,9 +2329,9 @@ end
 If `raise_errors` is `false`:
 
 * When `MyCustomError` or descendant is raised, the first handler is invoked.
-  The HTTP response body will contain `"A custom message"` with status code 500.
+  The HTTP response body will contain `"A custom message"`.
 * When any other error is raised, the second handler is invoked. The HTTP 
-  response body will contain `"A catch-all message"` with status code 500.
+  response body will contain `"A catch-all message"`.
 
 If `raise_errors` is `true`:
 

--- a/README.md
+++ b/README.md
@@ -2331,7 +2331,7 @@ If `raise_errors` is `false`:
 * When `MyCustomError` or descendant is raised, the first handler is invoked.
   The HTTP response body will contain `"A custom message"` with status code 500.
 * When any other error is raised, the second handler is invoked. The HTTP 
-  response body will contain "A catch-all message" with status code 500.
+  response body will contain `"A catch-all message"` with status code 500.
 
 If `raise_errors` is `true`:
 

--- a/README.md
+++ b/README.md
@@ -2339,6 +2339,13 @@ If `raise_errors` is `true`:
   when `raise_errors` is `false`, described above.
 * When any other error is raised, the second handler is *not* invoked, and 
   the error is raised outside of the application.
+  * If the environment is `production`, the HTTP response body will contain 
+    a generic error message, e.g. `"An unhandled lowlevel error occurred. The
+    application logs may have details."`
+  * If the environment is not `production`, the HTTP response body will contain
+    the verbose error backtrace.
+  * Regardless of environment, if `show_exceptions` is set to `:after_handler`, 
+    the HTTP response body will contain the verbose error backtrace.
 
 In the `test` environment, `raise_errors` is set to `true` by default. This 
 means that in order to write a test for a catch-all error handler, 


### PR DESCRIPTION
See https://github.com/sinatra/sinatra/issues/1548

The behavior of `raise_errors` isn't well-documented.

When `true`:

* The application will raise errors only for errors that do not have explicit handlers
* The application will raise errors despite any explicit catch-all handler, e.g. `error { ... }` or `error Exception { ... }`

As discussed in https://github.com/sinatra/sinatra/issues/1548, it seems that a future version of sinatra could afford a change to this behavior, since it is somewhat inconsistent, and some options are discussed therein.

In the short-term, we are proposing an update to the documentation.

Once we decide on the final language here, we can open up an accompanying PR for https://github.com/sinatra/sinatra.github.com/ since it [also describes](https://sinatrarb.com/configuration.html) `raise_errors`.