### PR TITLE
Remove use of Tilt::Cache

### DIFF
--- a/sinatra-contrib/lib/sinatra/namespace.rb
+++ b/sinatra-contrib/lib/sinatra/namespace.rb
@@ -210,7 +210,7 @@ module Sinatra
       end
 
       def template_cache
-        super.fetch(:nested, @namespace) { Tilt::Cache.new }
+        super.fetch(:nested, @namespace) { TemplateCache.new }
       end
 
       def redirect_to(uri, *args)

--- a/test/sinatra_test.rb
+++ b/test/sinatra_test.rb
@@ -7,6 +7,6 @@ class SinatraTest < Minitest::Test
   end
 
   it "responds to #template_cache" do
-    assert_kind_of Tilt::Cache, Sinatra::Base.new!.template_cache
+    assert_kind_of Sinatra::TemplateCache, Sinatra::Base.new!.template_cache
   end
 end


### PR DESCRIPTION
Tilt::Cache is deprecated and will be removed.  Copy the implementation currently used as Sinatra::TemplateCache, so Sinatra is not affected by the deprecation and removal of Tilt::Cache.

Fixes #1884