### PR TITLE
Tiny Rack::Protection README formatting fix

### DIFF
--- a/rack-protection/README.md
+++ b/rack-protection/README.md
@@ -74,6 +74,7 @@ Prevented by:
 ## Cookie Tossing
 
 Prevented by:
+
 * [`Rack::Protection::CookieTossing`][cookie-tossing] (not included by `use Rack::Protection`)
 
 ## IP Spoofing
@@ -95,6 +96,7 @@ Prevented by:
 # Instrumentation
 
 Instrumentation is enabled by passing in an instrumenter as an option.
+
 ```
 use Rack::Protection, instrumenter: ActiveSupport::Notifications
 ```


### PR DESCRIPTION
This added whitespace doesn't change anything in GitHub's README output but it fixes the generated HTML for https://sinatrarb.com/protection/ (the issue occurs when regenerating the HTML for the page and is correct on the currently-live version of the page).