### PR TITLE
Use `Minitest` instead of `MiniTest`

### DIFF
--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -55,7 +55,7 @@ class ServerTest < Minitest::Test
       @app.on_start do
         dummy_class.start_hook
       end
-      mock = MiniTest::Mock.new
+      mock = Minitest::Mock.new
       mock.expect(:call, nil)
 
       dummy_class.stub(:start_hook, mock) do
@@ -69,7 +69,7 @@ class ServerTest < Minitest::Test
       @app.on_stop do
         dummy_class.stop_hook
       end
-      mock = MiniTest::Mock.new
+      mock = Minitest::Mock.new
       mock.expect(:call, nil)
 
       dummy_class.stub(:stop_hook, mock) do


### PR DESCRIPTION
The old MiniTest constant isn't defined out-of-the-box since minitest v5.19.0:

- https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6
- https://github.com/minitest/minitest/commit/96a9972916bc0102eb755e77d22dd51f1c69a309
- https://github.com/minitest/minitest/blob/ed88d196bc5dde30d48026ef7b338997b640e799/lib/minitest/unit.rb