### PR TITLE
`rack-protection`: specify `rack` version requirement

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -39,7 +39,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   # dependencies
-  s.add_dependency 'rack'
+  s.add_dependency 'rack', '~> 2.2', '>= 2.2.4'
   s.add_development_dependency 'rack-test', '~> 2'
   s.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
Using the same requirement as Sinatra have.

Close #1919