### PR TITLE
CI: Always allow `notify` job to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     if: always() && github.ref_name == 'main'
+    continue-on-error: true # always allow failure
     needs: test
     steps:
       - uses: zzak/action-discord@v4


### PR DESCRIPTION
Noticed that the action failed due to being rate limited by GitHub, and it is not much we can do about that right now, the action needs to be updated to take the GitHub token as an input, not try to read it from ENV, I think:
https://github.com/zzak/action-discord/blob/2edb53786004cf3d17fa27315d671f3dcbc2b269/main.rb#L22

It doesn't matter much if this workflow fails, more important that CI looks green IMHO.