### PR TITLE
Fix PR link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Fix: rack-protection: specify rack version requirement [#1932] by Patrik Ragnarsson
 
+[#1911]: https://github.com/sinatra/sinatra/pull/1911
 [#1913]: https://github.com/sinatra/sinatra/pull/1913
 [#1900]: https://github.com/sinatra/sinatra/pull/1900
 [#1924]: https://github.com/sinatra/sinatra/pull/1924


### PR DESCRIPTION
Takes care of the missing link to PR 1911:

<img width="505" alt="Screenshot 2023-08-07 at 13 31 37" src="https://github.com/walro/sinatra/assets/2550510/a0b8d94c-02e7-4fb4-b95b-2b3bccb99737">