### PR TITLE
feature: add indifferent access support to `except`

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -186,6 +186,12 @@ module Sinatra
       dup.tap(&:compact!)
     end
 
+    def except(*keys)
+      keys.map!(&method(:convert_key))
+
+      super(*keys)
+    end
+
     private
 
     def convert_key(key)

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -291,4 +291,9 @@ class TestIndifferentHash < Minitest::Test
     compacted_hash = non_empty_hash.compact
     assert_equal non_empty_hash, compacted_hash
   end
+
+  def test_except
+    hash = @hash.except(?b, 3, :simple_nested, 'nested')
+    assert_equal Sinatra::IndifferentHash[a: :a], hash
+  end
 end


### PR DESCRIPTION
In Rails 6, [the implementation of `Hash#except` was changed](https://github.com/rails/rails/pull/35771) and stopped supporting the indifferent access that `Sinatra::IndifferntHash` provides – calling `except(:a)` on `Sinatra::IndifferntHash[a: :a]` would not filter the `a` key. It previous versions of Rails, `Sinatra::IndifferntHash#except` would end up calling `Sinatra::IndifferntHash#delete` on a copy of the hash which will delete the key no matter if it was passed as a `String` or a `Symbol`

This commits adds indifferent access support to it so it will filter the key independently if the key is passed as a `String` or `Symbol`.