### PR TITLE
feature: add `except` to `IndifferntHash`

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -186,6 +186,12 @@ module Sinatra
       dup.tap(&:compact!)
     end
 
+    def except(*keys)
+      keys.map!(&method(:convert_key))
+
+      super(*keys)
+    end if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.0")
+
     private
 
     def convert_key(key)

--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -190,7 +190,7 @@ module Sinatra
       keys.map!(&method(:convert_key))
 
       super(*keys)
-    end if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.0")
+    end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 
     private
 

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -291,4 +291,9 @@ class TestIndifferentHash < Minitest::Test
     compacted_hash = non_empty_hash.compact
     assert_equal non_empty_hash, compacted_hash
   end
+
+  def test_except
+    hash = @hash.except(?b, 3, :simple_nested, 'nested')
+    assert_equal Sinatra::IndifferentHash[a: :a], hash
+  end if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.0")
 end

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -295,5 +295,5 @@ class TestIndifferentHash < Minitest::Test
   def test_except
     hash = @hash.except(?b, 3, :simple_nested, 'nested')
     assert_equal Sinatra::IndifferentHash[a: :a], hash
-  end if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.0")
+  end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 end


### PR DESCRIPTION
The method `Hash#except` [was added in Ruby 3.0](https://github.com/ruby/ruby/commit/82ca8c73034b0a522fd2970ea39edfcd801955fe) so it would be nice that calling `except` in a `Sinatra::IndifferntHash` supported the indifferent access that the latter provides – right now, calling `except(:a)` on `Sinatra::IndifferntHash[a: :a]` would not filter the `a` key.

This commits adds indifferent access support to except so that it will exclude the passed key independently if the key is passed as a `String` or `Symbol`.