### PR TITLE
Use relative URL for the 404 image

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1995,7 +1995,7 @@ module Sinatra
           </head>
           <body>
             <h2>Sinatra doesn’t know this ditty.</h2>
-            <img src='#{uri '/__sinatra__/404.png'}'>
+            <img src='#{request.script_name}/__sinatra__/404.png'>
             <div id="c">
               Try this:
               <pre>#{Rack::Utils.escape_html(code)}</pre>


### PR DESCRIPTION
We already do for the 500 image, see 238eedeb52dbbf688d561751d9dd5ad79c59c6ff

Close #1939