### PR TITLE
Add `base64` to rack-protection runtime dependencies

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -39,7 +39,9 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.6.0'
 
   # dependencies
+  s.add_dependency 'base64'
   s.add_dependency 'rack', '~> 2.2', '>= 2.2.4'
+
   s.add_development_dependency 'rack-test', '~> 2'
   s.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
This PR adds `base64` to rack-protection.gemspec because `base64` will not be part of the default gems since Ruby 3.4.0.

Resolves https://github.com/sinatra/sinatra/issues/1937