### PR TITLE
Use `Exception#detailed_message` to show backtrace

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1261,7 +1261,19 @@ module Sinatra
     end
 
     def dump_errors!(boom)
-      msg = ["#{Time.now.strftime('%Y-%m-%d %H:%M:%S')} - #{boom.class} - #{boom.message}:", *boom.backtrace].join("\n\t")
+      if boom.respond_to?(:detailed_message)
+        msg = boom.detailed_message(highlight: false)
+        if msg =~ /\A(.*?)(?: \(#{ Regexp.quote(boom.class.to_s) }\))?\n/
+          msg = $1
+          additional_msg = $'.lines.map {|s| s.chomp }
+        else
+          additional_msg = []
+        end
+      else
+        msg = boom.message
+        additional_msg = []
+      end
+      msg = ["#{Time.now.strftime('%Y-%m-%d %H:%M:%S')} - #{boom.class} - #{msg}:", *additional_msg, *boom.backtrace].join("\n\t")
       @env['rack.errors'].puts(msg)
     end
 


### PR DESCRIPTION
Before:

```
Use Ctrl-C to stop
        test.rb:4:in `block in <main>'
        /home/mame/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sinatra-3.1.0/lib/sinatra/base.rb:1775:in `call'
```

After:

```
Use Ctrl-C to stop
2023-10-13 18:49:17 - NoMethodError - undefined method `time' for 1:Integer:

          1.time {}
           ^^^^^
        Did you mean?  times
        test.rb:4:in `block in <main>'
        /home/mame/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sinatra-3.1.0/lib/sinatra/base.rb:1775:in `call'
```

What do you think?