### PR TITLE
CI: use `async-io` 1.36.1 in Ruby 2.6 builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem 'sinatra-contrib', path: 'sinatra-contrib'
 # https://github.com/socketry/async-http/pull/124/files#r1237988899
 gem 'traces', '< 0.10.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
 
+# async-io started to use Ruby 2.7 syntax without specifying required Ruby version
+# https://github.com/socketry/async-io/issues/74
+gem 'async-io', '< 1.37.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
+
 gem 'asciidoctor'
 gem 'builder'
 gem 'commonmarker', '~> 0.23.4', platforms: [:ruby]


### PR DESCRIPTION
Due to https://github.com/socketry/async-io/pull/72 released in async-io 1.37.0

We will need this fix as long as we want to test Falcon in Ruby 2.6, as the "fix" in async-io will be to raise the min Ruby version: https://github.com/socketry/async-io/issues/74

Fail can be seen at https://github.com/sinatra/sinatra/actions/runs/6836408460/job/18591270458#step:5:19