### PR TITLE
Use latest `async-io`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,10 +37,6 @@ gem 'sinatra-contrib', path: 'sinatra-contrib'
 # https://github.com/socketry/async-http/pull/124/files#r1237988899
 gem 'traces', '< 0.10.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
 
-# async-io started to use Ruby 2.7 syntax without specifying required Ruby version
-# https://github.com/socketry/async-io/issues/74
-gem 'async-io', '< 1.37.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
-
 gem 'asciidoctor'
 gem 'builder'
 gem 'commonmarker', '~> 0.23.4', platforms: [:ruby]


### PR DESCRIPTION
async-io >= 1.38.0 should work with Ruby 2.6 again.

This reverts 734df89affd8de6350195bb7692848da2e3a7ec1.