### PR TITLE
Add `Sinatra::HamlHelpers` to sinatra-contrib

### DIFF
--- a/sinatra-contrib/lib/sinatra/contrib.rb
+++ b/sinatra-contrib/lib/sinatra/contrib.rb
@@ -28,6 +28,8 @@ module Sinatra
     # Other extensions you don't want to be loaded unless needed.
     module Custom
       register :Reloader, 'sinatra/reloader'
+
+      helpers :HamlHelpers, 'sinatra/haml_helpers'
     end
 
     ##

--- a/sinatra-contrib/lib/sinatra/haml_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/haml_helpers.rb
@@ -7,7 +7,7 @@ module Sinatra
   # = Sinatra::HamlHelpers
   #
   # This extension provides some of the helper methods that existed in Haml 5
-  # but was removed in Haml 6. To use this in your app, just +register+ it:
+  # but were removed in Haml 6. To use this in your app, just +register+ it:
   #
   #   require 'sinatra/base'
   #   require 'sinatra/haml_helpers'

--- a/sinatra-contrib/lib/sinatra/haml_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/haml_helpers.rb
@@ -6,8 +6,8 @@ require 'sinatra/capture'
 module Sinatra
   # = Sinatra::HamlHelpers
   #
-  # This extension provides helper methods that existed in Haml 5 but was
-  # removed in Haml 6. To use this in your app, just +register+ it:
+  # This extension provides some of the helper methods that existed in Haml 5
+  # but was removed in Haml 6. To use this in your app, just +register+ it:
   #
   #   require 'sinatra/base'
   #   require 'sinatra/haml_helpers'

--- a/sinatra-contrib/lib/sinatra/haml_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/haml_helpers.rb
@@ -6,7 +6,7 @@ require 'sinatra/capture'
 module Sinatra
   # = Sinatra::HamlHelpers
   #
-  # This extensions provides helper methods that existed in Haml 5 but was
+  # This extension provides helper methods that existed in Haml 5 but was
   # removed in Haml 6. To use this in your app, just +register+ it:
   #
   #   require 'sinatra/base'

--- a/sinatra-contrib/lib/sinatra/haml_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/haml_helpers.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'sinatra/base'
+require 'sinatra/capture'
+
+module Sinatra
+  # = Sinatra::HamlHelpers
+  #
+  # This extensions provides helper methods that existed in Haml 5 but was
+  # removed in Haml 6. To use this in your app, just +register+ it:
+  #
+  #   require 'sinatra/base'
+  #   require 'sinatra/haml_helpers'
+  #
+  #   class Application < Sinatra::Base
+  #     register Sinatra::HamlHelpers
+  #
+  #     # now you can use the helpers in your views
+  #     get '/' do
+  #       haml_code = <<~HAML
+  #         %p
+  #           != surround "(", ")" do
+  #             %a{ href: "https://example.org/" } example.org
+  #       HAML
+  #       haml haml_code
+  #     end
+  #   end
+  #
+  module HamlHelpers
+    include Sinatra::Capture
+
+    def surround(front, back = front, &block)
+      "#{front}#{_capture_haml(&block).chomp}#{back}\n"
+    end
+
+    def precede(str, &block)
+      "#{str}#{_capture_haml(&block).chomp}\n"
+    end
+
+    def succeed(str, &block)
+      "#{_capture_haml(&block).chomp}#{str}\n"
+    end
+
+    def _capture_haml(*args, &block)
+      capture(*args, &block)
+    end
+  end
+
+  helpers HamlHelpers
+end

--- a/sinatra-contrib/spec/haml_helpers_spec.rb
+++ b/sinatra-contrib/spec/haml_helpers_spec.rb
@@ -1,0 +1,77 @@
+require 'haml'
+require 'spec_helper'
+require 'sinatra/haml_helpers'
+
+RSpec.describe Sinatra::HamlHelpers do
+  describe "#surround" do
+    it "renders correctly" do
+      mock_app do
+        helpers Sinatra::HamlHelpers
+        get "/" do
+          haml_code = <<~HAML
+            %p
+              != surround "(", ")" do
+                %a{ href: "https://example.org/" } surrounded
+          HAML
+          haml haml_code
+        end
+      end
+
+      get "/"
+      html_code = <<~HTML
+        <p>
+        (<a href='https://example.org/'>surrounded</a>)
+        </p>
+      HTML
+      expect(body).to eq(html_code)
+    end
+  end
+
+  describe "#precede" do
+    it "renders correctly" do
+      mock_app do
+        helpers Sinatra::HamlHelpers
+        get "/" do
+          haml_code = <<~HAML
+            %p
+              != precede "* " do
+                %a{ href: "https://example.org/" } preceded
+          HAML
+          haml haml_code
+        end
+      end
+
+      get "/"
+      html_code = <<~HTML
+        <p>
+        * <a href='https://example.org/'>preceded</a>
+        </p>
+      HTML
+      expect(body).to eq(html_code)
+    end
+  end
+
+  describe "#succeed" do
+    it "renders correctly" do
+      mock_app do
+        helpers Sinatra::HamlHelpers
+        get "/" do
+          haml_code = <<~HAML
+            %p
+              != succeed "." do
+                %a{ href: "https://example.org/" } succeeded
+          HAML
+          haml haml_code
+        end
+      end
+
+      get "/"
+      html_code = <<~HTML
+        <p>
+        <a href='https://example.org/'>succeeded</a>.
+        </p>
+      HTML
+      expect(body).to eq(html_code)
+    end
+  end
+end if defined?(Haml) && Haml::VERSION >= "6.0.0"

--- a/sinatra-contrib/spec/haml_helpers_spec.rb
+++ b/sinatra-contrib/spec/haml_helpers_spec.rb
@@ -74,4 +74,4 @@ RSpec.describe Sinatra::HamlHelpers do
       expect(body).to eq(html_code)
     end
   end
-end if defined?(Haml) && Haml::VERSION >= "6.0.0"
+end


### PR DESCRIPTION
Brings back three helpers from Haml 5:
https://github.com/haml/haml/blob/v5.2.2/lib/haml/helpers.rb#L294-L357