### PR TITLE
Remove references `sysrandom` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,22 +1199,6 @@ $ ruby -e "require 'securerandom'; puts SecureRandom.hex(64)"
 99ae8af...snip...ec0f262ac
 ```
 
-**Session Secret Generation (Bonus Points)**
-
-Use the [sysrandom gem](https://github.com/cryptosphere/sysrandom#readme) to
-use the system RNG facilities to generate random values instead of
-userspace `OpenSSL` which MRI Ruby currently defaults to:
-
-```text
-$ gem install sysrandom
-Building native extensions.  This could take a while...
-Successfully installed sysrandom-1.x
-1 gem installed
-
-$ ruby -e "require 'sysrandom/securerandom'; puts SecureRandom.hex(64)"
-99ae8af...snip...ec0f262ac
-```
-
 **Session Secret Environment Variable**
 
 Set a `SESSION_SECRET` environment variable for Sinatra to the value you
@@ -1229,14 +1213,10 @@ purposes only:
 **Session Secret App Config**
 
 Set up your app config to fail-safe to a secure random secret
-if the `SESSION_SECRET` environment variable is not available.
-
-For bonus points use the [sysrandom
-gem](https://github.com/cryptosphere/sysrandom#readme) here as well:
+if the `SESSION_SECRET` environment variable is not available:
 
 ```ruby
 require 'securerandom'
-# -or- require 'sysrandom/securerandom'
 set :session_secret, ENV.fetch('SESSION_SECRET') { SecureRandom.hex(64) }
 ```
 


### PR DESCRIPTION
Remove any references to the `sysrandom` gem from the README. The gem has been archived because it is no longer needed. Ruby 2.5 introduced the fix that the gem previously handled.

Fixes #1963.