### PR TITLE
support bundler 2.5.0.dev

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1283,7 +1283,7 @@ module Sinatra
         /^\(.*\)$/,                                         # generated code
         %r{rubygems/(custom|core_ext/kernel)_require\.rb$}, # rubygems require hacks
         /active_support/,                                   # active_support require hacks
-        %r{bundler(/(?:runtime|inline))?\.rb},              # bundler require hacks
+        %r{bundler(/(?:runtime|inline|rubygems_integration))?\.rb}, # bundler require hacks
         /<internal:/,                                       # internal in ruby >= 1.9.2
         %r{zeitwerk/kernel\.rb}                             # Zeitwerk kernel#require decorator
       ].freeze


### PR DESCRIPTION
When I run the following command with Bundler version 2.5.0.dev, nothing happens.
Here is the patch.

$ bundle exec ./app.rb

$ cat ./app.rb 
#!/usr/bin/env ruby
require 'sinatra'
get '/' do
  'hello'
end
