### PR TITLE
CI: remove sinatra from rack-protection bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,11 @@ end
 gem 'nokogiri', '> 1.5.0'
 gem 'pandoc-ruby', '~> 2.0.2'
 gem 'rabl'
-gem 'rdiscount', platforms: [:ruby]
+if RUBY_ENGINE == 'truffleruby'
+  gem 'rdiscount', '< 2.2.7.2' # https://github.com/oracle/truffleruby/issues/3362
+else
+  gem 'rdiscount', platforms: [:ruby]
+end
 gem 'rdoc'
 gem 'redcarpet', platforms: [:ruby]
 gem 'sass-embedded', '~> 1.54'

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -11,8 +11,6 @@ rack_version = nil if rack_version.empty? || (rack_version == 'stable')
 rack_version = { github: 'rack/rack' } if rack_version == 'head'
 gem 'rack', rack_version
 
-gem 'sinatra', path: '..'
-
 gemspec
 
 gem 'rack-test', github: 'rack/rack-test'


### PR DESCRIPTION
It is not needed.

Including it hides real problems: https://github.com/sinatra/sinatra/pull/1857#discussion_r1434926762