### PR TITLE
CI: use latest rack-test release, not trunk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ puma_version = { github: 'puma/puma' } if puma_version == 'head'
 gem 'puma', puma_version
 
 gem 'minitest', '~> 5.0'
-gem 'rack-test', github: 'rack/rack-test'
+gem 'rack-test'
 gem 'rubocop', '~> 1.32.0', require: false
 gem 'yard' # used by rake doc
 

--- a/rack-protection/Gemfile
+++ b/rack-protection/Gemfile
@@ -13,4 +13,4 @@ gem 'rack', rack_version
 
 gemspec
 
-gem 'rack-test', github: 'rack/rack-test'
+gem 'rack-test'

--- a/sinatra-contrib/Gemfile
+++ b/sinatra-contrib/Gemfile
@@ -17,7 +17,7 @@ gem 'haml'
 gem 'hamlit', '>= 3'
 gem 'rack', rack_version
 gem 'rack-protection', path: '../rack-protection'
-gem 'rack-test', github: 'rack/rack-test'
+gem 'rack-test'
 gem 'rake', '>= 12.3.3'
 gem 'rspec', '~> 3'
 gem 'sinatra', path: '..'


### PR DESCRIPTION
This comes from https://github.com/sinatra/sinatra/pull/1801 and maybe it was a reason back then but I don't see any now.

This just makes things simpler, for example, the Docker Ruby images based on Alpine does not come with git.