### PR TITLE
Add workflow for Trusted Publishing to RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # for trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - uses: rubygems/configure-rubygems-credentials@v1.0.0
+      # ensure gems can be built and installed
+      - run: bundle exec rake install:rack-protection
+      - run: bundle exec rake install:sinatra
+      - run: bundle exec rake install:sinatra-contrib
+      # push gems to rubygems.org
+      - run: bundle exec rake release:rack-protection
+      - run: bundle exec rake release:sinatra
+      - run: bundle exec rake release:sinatra-contrib

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,35 +2,24 @@
 
 This document explains releasing process for all Sinatra gems.
 
-Since everything is bundled in same repo (except `Mustermann`), we now
-have one rake task to cut a release.
+Since everything is bundled in same repo (except `Mustermann`), we
+have some rake tasks and a GitHub Actions workflow to cut a release.
 
 (Please refer to [Mustermann](https://github.com/sinatra/mustermann) if that also needs a release.)
 
 ### Releasing
+
 For releasing new version of [`sinatra`, `sinatra-contrib`, `rack-protection`], this is the procedure:
 
+1. Update `CHANGELOG.md`
 1. Update `VERSION` file with target version
-2. Run `bundle exec rake release:all`
-3. ???
-4. Profit!!!
-
-Thats it!
-
-This rake task can be broken down as:
-
-* Pick up latest version string from `VERSION` file
-* Run all tests to ensure gems are not broken
-* Update `version.rb` file in all gems with latest `VERSION`
-* Create a new commit with new `VERSION` and `version.rb` files
-* Tag the commit with same version
-* Push the commit and tags to github
-* Package all the gems, ie create all `.gem` files
-* Ensure that all the gems can be installed locally
-* If no issues, push all gems to upstream.
-
-In addition to above rake task, there are other rake tasks which can help
-with development.
+1. Run `rake release:commit_version`
+1. Create pull request with all that ([example](https://github.com/sinatra/sinatra/pull/1893))
+1. Merge the pull request when CI is green
+1. Ensure you have latest changes locally
+1. Run `rake release:tag_version`
+1. Push tag to upstream
+1. Run `rake release:watch` and watch GitHub Actions push to RubyGems.org
 
 ### Packaging
 These rake tasks will generate `.gem` and `.tar.gz` files. For each gem,

--- a/Rakefile
+++ b/Rakefile
@@ -191,7 +191,7 @@ if defined?(Gem)
       end
     end
 
-    desc 'Commits the version to github repository'
+    desc 'Commits the version to git (no push)'
     task :commit_version do
       %w[
         lib/sinatra
@@ -203,10 +203,22 @@ if defined?(Gem)
       end
 
       sh <<-SH
-        git commit --allow-empty -a -m '#{source_version} release'  &&
-        git tag -s v#{source_version} -m '#{source_version} release'  &&
-        git push && (git push origin || true) &&
-        git push --tags && (git push origin --tags || true)
+        git commit --allow-empty --all --message '#{source_version} release'
+      SH
+    end
+
+    desc 'Tags the version in git (no push)'
+    task :tag_version do
+      sh <<-SH
+        git tag --sign v#{source_version} --message '#{source_version} release'
+      SH
+    end
+
+    desc 'Watch the release workflow run'
+    task :watch do
+      sh <<-SH
+        runId=$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[].databaseId')
+        gh run watch --interval 1 --exit-status $runId
       SH
     end
 


### PR DESCRIPTION
- https://blog.rubygems.org/2023/12/14/trusted-publishing.html
- https://guides.rubygems.org/trusted-publishing/

This makes it possible for anyone who can push a tag to sinatra/sinatra (or access the "Run workflow" button in the Actions UI) to cut a release.

I think that's OK, the overlap between https://rubygems.org/gems/sinatra/owners and https://github.com/orgs/sinatra/teams/team-sinatra is already great. It gives two more people access to cut releases.

Close https://github.com/sinatra/sinatra/issues/1920