### PR TITLE
CI: use bundler when starting integration servers

### DIFF
--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -63,7 +63,7 @@ module IntegrationHelper
 
     def command
       @command ||= begin
-        cmd = ["APP_ENV=#{environment}", "bundle exec"]
+        cmd = ["APP_ENV=#{environment}", "bundle", "exec"]
         if RbConfig.respond_to? :ruby
           cmd << RbConfig.ruby.inspect
         else

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -73,7 +73,7 @@ module IntegrationHelper
         cmd << "-w" unless net_http_server?
         cmd << "-I" << File.expand_path('../lib', __dir__).inspect
         cmd << app_file.inspect << '-s' << server << '-o' << '127.0.0.1' << '-p' << port
-        cmd << "-e" << environment.to_s << '2>&1'
+        cmd << "-e" << environment.to_s
         cmd.join " "
       end
     end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -63,7 +63,7 @@ module IntegrationHelper
 
     def command
       @command ||= begin
-        cmd = ["APP_ENV=#{environment}", "exec"]
+        cmd = ["APP_ENV=#{environment}", "bundle exec"]
         if RbConfig.respond_to? :ruby
           cmd << RbConfig.ruby.inspect
         else


### PR DESCRIPTION
We could see ruby-head (ruby 3.3.0dev (2023-12-21T17:17:22Z :detached: 1f0304218c)) fail at https://github.com/sinatra/sinatra/actions/runs/7301204154/job/19897392383#step:5:14

The real error didn't show in the logs, it could be seen when running the command standalone:

    $ APP_ENV=development "/Users/dentarg/.arm64_rubies/3.3.0-rc1/bin/ruby" -w -I "/Users/dentarg/src/sinatra/sinatra/lib" "/Users/dentarg/src/sinatra/sinatra/test/integration/app.rb" -s puma -o 127.0.0.1 -p 5055 -e development
    loading
    <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require': cannot load such file -- rack/protection (LoadError)
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from /Users/dentarg/src/sinatra/sinatra/lib/sinatra/base.rb:6:in `<top (required)>'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from /Users/dentarg/src/sinatra/sinatra/lib/sinatra/main.rb:28:in `<module:Sinatra>'
            from /Users/dentarg/src/sinatra/sinatra/lib/sinatra/main.rb:3:in `<top (required)>'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from /Users/dentarg/src/sinatra/sinatra/lib/sinatra.rb:3:in `<top (required)>'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from <internal:/Users/dentarg/.arm64_rubies/3.3.0-rc1/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
            from /Users/dentarg/src/sinatra/sinatra/test/integration/app.rb:2:in `<main>'

Using bundler solves this.