### PR TITLE
CI: move rack-protection to its own job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,58 @@ on:
   pull_request:
 
 permissions:
-  contents: read #  to fetch code (actions/checkout)
+  contents: read # to fetch code (actions/checkout)
 
 jobs:
+  rack-protection:
+    name: rack-protection (${{ matrix.ruby }}, Rack ${{ matrix.rack }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        rack:
+          - "~> 2"
+        ruby:
+          - "2.6"
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "jruby"
+          - "truffleruby"
+          - "ruby-head"
+    env:
+      rack: ${{ matrix.rack }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      continue-on-error: ${{ matrix.allow-failure || false }}
+      id: setup-ruby
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+        working-directory: rack-protection
+    - name: Run rack-protection tests
+      continue-on-error: ${{ matrix.allow-failure || false }}
+      id: protection-tests
+      working-directory: rack-protection
+      run: |
+        bundle exec rake
+    # because continue-on-error marks the steps as pass even if they fail
+    - name: "setup-ruby (bundle install) outcome: ${{ steps.setup-ruby.outcome }}"
+      run: ""
+    - name: "rack-protection tests outcome: ${{ steps.protection-tests.outcome }}"
+      run: ""
+    - uses: zzak/action-discord@v6
+      if: failure() && github.ref_name == 'main'
+      continue-on-error: true # always allow failure
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
   test:
     name: ${{ matrix.ruby }} (Rack ${{ matrix.rack }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.tilt }})
-    permissions:
-      contents: read #  to fetch code (actions/checkout)
-      actions: read #  to list jobs for workflow run (8398a7/action-slack)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -82,21 +126,12 @@ jobs:
         bundle install --jobs=3 --retry=3
         bundle exec rake
 
-    - name: Run rack-protection tests
-      continue-on-error: ${{ matrix.allow-failure || false }}
-      id: protection-tests
-      working-directory: rack-protection
-      run: |
-        bundle install --jobs=3 --retry=3
-        bundle exec rake
     # because continue-on-error marks the steps as pass even if they fail
     - name: "setup-ruby (bundle install) outcome: ${{ steps.setup-ruby.outcome }}"
       run: ""
     - name: "sinatra tests outcome: ${{ steps.tests.outcome }}"
       run: ""
     - name: "sinatra-contrib tests outcome: ${{ steps.contrib-tests.outcome }}"
-      run: ""
-    - name: "rack-protection tests outcome: ${{ steps.protection-tests.outcome }}"
       run: ""
 
     - uses: zzak/action-discord@v6


### PR DESCRIPTION
This makes much more sense because it is common to use rack-protection without sinatra.

Ref: https://github.com/sinatra/sinatra/pull/1971#discussion_r1437616734