### PR TITLE
Revert "Shorter `Sinatra::Runner` timeout"

### DIFF
--- a/sinatra-contrib/lib/sinatra/runner.rb
+++ b/sinatra-contrib/lib/sinatra/runner.rb
@@ -111,7 +111,7 @@ module Sinatra
       "bundle exec ruby #{app_file} -p #{port} -e production"
     end
 
-    def ping(timeout = 10)
+    def ping(timeout = 30)
       loop do
         return if alive?
 


### PR DESCRIPTION
This reverts commit 0e43702c3feeeed3495aa4590c0cecd04204d4d7.

This wasn't needed for anything more than making the tests fail faster when I was developing. It could be seen as a breaking change, so let's just back it out.