### PR TITLE
Avoid running release workflow in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,10 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'sinatra/sinatra'
     runs-on: ubuntu-latest
-
     permissions:
       id-token: write # for trusted publishing
-
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
If tags are pushed to the fork.

Guard like this can be seen in https://github.com/segiddins/rubygems-await/blob/06fa16da619d334c0a2ff8e1f821bbbf1622a42e/.github/workflows/push_gem.yml#L10