### PR TITLE
CI: use improved version of `childprocess` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,9 @@ gem 'traces', '< 0.10.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
 
 gem 'asciidoctor'
 gem 'builder'
-gem 'childprocess'
+# https://github.com/oracle/truffleruby/issues/1525
+# https://github.com/enkessler/childprocess/issues/172
+gem 'childprocess', github: 'https://github.com/enkessler/childprocess/pull/175'
 gem 'commonmarker', '~> 0.23.4', platforms: [:ruby]
 gem 'erubi'
 gem 'eventmachine'

--- a/test/integration_start_helper.rb
+++ b/test/integration_start_helper.rb
@@ -2,10 +2,6 @@ require "childprocess"
 require "expect"
 require "minitest/autorun"
 
-# https://github.com/enkessler/childprocess/issues/172
-# https://github.com/oracle/truffleruby/issues/1525
-ENV["CHILDPROCESS_POSIX_SPAWN"] = "true" if %w(jruby truffleruby).include?(RUBY_ENGINE)
-
 module IntegrationStartHelper
   def command_for(app_file)
     [


### PR DESCRIPTION
Use the awesome pull request by eregon: https://github.com/enkessler/childprocess/pull/175 that uses native Process.spawn on all platforms

JVM rubies can't use the default fork+exec approach in childprocess, so we fall back to CHILDPROCESS_POSIX_SPAWN, but that is not available on aarch64 (me using Docker on Apple silicon). Annoying when debugging tests.

(This should still work even after the PR is merged and the branch removed)