### PR TITLE
Remove the `IndifferentHash` initializer

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -43,12 +43,6 @@ module Sinatra
       new.merge!(Hash[*args])
     end
 
-    def initialize(*args)
-      args.map!(&method(:convert_value))
-
-      super(*args)
-    end
-
     def default(*args)
       args.map!(&method(:convert_key))
 

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -27,8 +27,8 @@ class TestIndifferentHashBasics < Minitest::Test
 
   def test_default_object
     hash = Sinatra::IndifferentHash.new(:a=>1, ?b=>2)
-    assert_equal({ ?a=>1, ?b=>2 }, hash.default)
-    assert_equal({ ?a=>1, ?b=>2 }, hash[:a])
+    assert_equal({ :a=>1, ?b=>2 }, hash.default)
+    assert_equal({ :a=>1, ?b=>2 }, hash[:a])
   end
 
   def test_default_assignment


### PR DESCRIPTION
See these links for background:
- https://github.com/sinatra/sinatra/pull/1951
- https://github.com/sinatra/sinatra/issues/1948

Before

    > Sinatra::IndifferentHash.new(a: 1)[:b]
    => {"a"=>1}

After

    > Sinatra::IndifferentHash.new(a: 1)[:b]
    => {:a=>1}

Close #1953