### PR TITLE
Make `session_hijacking` an optional protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1922,7 +1922,7 @@ set :protection, :except => :path_traversal
 You can also hand in an array in order to disable a list of protections:
 
 ```ruby
-set :protection, :except => [:path_traversal, :session_hijacking]
+set :protection, :except => [:path_traversal, :remote_token]
 ```
 
 By default, Sinatra will only set up session based protection if `:sessions`

--- a/rack-protection/README.md
+++ b/rack-protection/README.md
@@ -69,7 +69,7 @@ Prevented by:
 
 Prevented by:
 
-* [`Rack::Protection::SessionHijacking`][session-hijacking]
+* [`Rack::Protection::SessionHijacking`][session-hijacking] (not included by `use Rack::Protection`)
 
 ## Cookie Tossing
 

--- a/rack-protection/lib/rack/protection.rb
+++ b/rack-protection/lib/rack/protection.rb
@@ -27,12 +27,11 @@ module Rack
     autoload :XSSHeader,             'rack/protection/xss_header'
 
     def self.new(app, options = {})
-      # does not include: RemoteReferrer, AuthenticityToken and FormToken
       except = Array options[:except]
       use_these = Array options[:use]
 
       if options.fetch(:without_session, false)
-        except += %i[session_hijacking remote_token]
+        except += %i[remote_token]
       end
 
       Rack::Builder.new do
@@ -44,6 +43,7 @@ module Rack
         use ::Rack::Protection::FormToken,             options if use_these.include? :form_token
         use ::Rack::Protection::ReferrerPolicy,        options if use_these.include? :referrer_policy
         use ::Rack::Protection::RemoteReferrer,        options if use_these.include? :remote_referrer
+        use ::Rack::Protection::SessionHijacking,      options if use_these.include? :session_hijacking
         use ::Rack::Protection::StrictTransport,       options if use_these.include? :strict_transport
 
         # On by default, unless skipped
@@ -53,7 +53,6 @@ module Rack
         use ::Rack::Protection::JsonCsrf,              options unless except.include? :json_csrf
         use ::Rack::Protection::PathTraversal,         options unless except.include? :path_traversal
         use ::Rack::Protection::RemoteToken,           options unless except.include? :remote_token
-        use ::Rack::Protection::SessionHijacking,      options unless except.include? :session_hijacking
         use ::Rack::Protection::XSSHeader,             options unless except.include? :xss_header
         run app
       end.to_app

--- a/rack-protection/spec/lib/rack/protection/protection_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/protection_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Rack::Protection do
 
   it 'passes on options' do
     mock_app do
-      use Rack::Protection, track: ['HTTP_FOO']
+      # the :track option is used by session_hijacking
+      use Rack::Protection, track: ['HTTP_FOO'], use: [:session_hijacking], except: [:remote_token]
       run proc { |_e| [200, { 'content-type' => 'text/plain' }, ['hi']] }
     end
 
@@ -15,6 +16,8 @@ RSpec.describe Rack::Protection do
     expect(session[:foo]).to eq(:bar)
 
     get '/', {}, 'rack.session' => session, 'HTTP_FOO' => 'BAR'
+    # wont be empty if the remote_token middleware runs after session_hijacking
+    # why we run the mock app without remote_token
     expect(session).to be_empty
   end
 


### PR DESCRIPTION
Also remove the very old[1] `does not include ...` comment.

Fighting the test I had to change made me realize just how much the order of middlewares matters. Not very intuitive 😞. Maybe someday someone will get to https://github.com/sinatra/sinatra/issues/1659

Close #1930

1: https://github.com/sinatra/sinatra/commit/0985552f331b572d72ad96ce06f03816da57340c