### PR TITLE
Require Ruby 2.7.8 as minimum Ruby version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
         rack:
           - stable
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
@@ -77,7 +76,7 @@ jobs:
         tilt:
           - stable
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
         include:
           # Rack
           - { ruby: 3.2, rack: head,   puma: stable,   tilt: stable, rack_session: stable, allow-failure: true }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@
 #
 # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
   NewCops: enable
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,6 @@ gem 'yard' # used by rake doc
 gem 'rack-protection', path: 'rack-protection'
 gem 'sinatra-contrib', path: 'sinatra-contrib'
 
-# traces 0.10.0 started to use Ruby 2.7 syntax without specifying required Ruby version
-# https://github.com/socketry/traces/pull/8#discussion_r1237988182
-# async-http 0.60.2 added traces 0.10.0 as dependency
-# https://github.com/socketry/async-http/pull/124/files#r1237988899
-gem 'traces', '< 0.10.0' if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
-
 gem 'asciidoctor'
 gem 'builder'
 gem 'childprocess', '>= 5'
@@ -46,13 +40,7 @@ gem 'falcon', '~> 0.40', platforms: [:ruby]
 gem 'haml', '~> 6'
 gem 'kramdown'
 gem 'liquid'
-# markaby 0.9.1 introduced Ruby 2.7 syntax in https://github.com/markaby/markaby/pull/44
-# and does not specify required_ruby_version
-if RUBY_VERSION >= '2.6.0' && RUBY_VERSION < '2.7.0'
-  gem 'markaby', '< 0.9.1'
-else
-  gem 'markaby'
-end
+gem 'markaby'
 gem 'nokogiri', '> 1.5.0'
 gem 'pandoc-ruby', '~> 2.0.2'
 gem 'rabl'

--- a/README.md
+++ b/README.md
@@ -2820,30 +2820,24 @@ uses a threaded model of concurrency.
 
 The following Ruby versions are officially supported:
 <dl>
-  <dt>Ruby 2.6</dt>
+  <dt>Ruby</dt>
   <dd>
-    2.6 is fully supported and recommended. There are currently no plans to
-    drop official support for it.
+    <a href="https://www.ruby-lang.org/en/downloads/">The stable releases</a> are fully supported and recommended.
   </dd>
 
-  <dt>Rubinius</dt>
+  <dt>TruffleRuby</dt>
   <dd>
-    Rubinius is officially supported (Rubinius >= 2.x). It is recommended to
-    <tt>gem install puma</tt>.
+    The latest stable release of TruffleRuby is supported.
   </dd>
 
   <dt>JRuby</dt>
   <dd>
-    The latest stable release of JRuby is officially supported. It is not
-    recommended to use C extensions with JRuby. It is recommended to
-    <tt>gem install trinidad</tt>.
+    The latest stable release of JRuby is supported. It is not
+    recommended to use C extensions with JRuby.
   </dd>
 </dl>
 
-Versions of Ruby before 2.6 are no longer supported as of Sinatra 3.0.0.
-
-We also keep an eye on upcoming Ruby versions. Expect upcoming
-3.x releases to be fully supported.
+Versions of Ruby before 2.7.8 are no longer supported as of Sinatra 4.0.0.
 
 Sinatra should work on any operating system supported by the chosen Ruby
 implementation.

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -36,7 +36,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.8'
 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -35,7 +35,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.8'
 
   s.add_dependency 'multi_json', '>= 0.0.2'
   s.add_dependency 'mustermann', '~> 3.0'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -43,7 +43,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
   }
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.8'
 
   s.add_dependency 'mustermann', '~> 3.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'


### PR DESCRIPTION
Ruby 2.6 reached end-of-life 2022-04: https://en.wikipedia.org/wiki/History_of_Ruby

Ruby 2.7.8 was still supported less than a year ago and doesn't cause and particular problems right now.