### PR TITLE
CI: allow `truffleruby` to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,13 @@ jobs:
           - stable
         tilt:
           - stable
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
+        ruby:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "jruby"
         include:
           # Rack
           - { ruby: 3.2, rack: head,   puma: stable,   tilt: stable, rack_session: stable, allow-failure: true }
@@ -90,6 +95,9 @@ jobs:
           - { ruby: ruby-head,        rack: stable, puma: stable, tilt: stable, rack_session: stable, allow-failure: true }
           - { ruby: jruby-head,       rack: stable, puma: stable, tilt: stable, rack_session: stable, allow-failure: true }
           - { ruby: truffleruby-head, rack: stable, puma: stable, tilt: stable, rack_session: stable, allow-failure: true }
+          # truffleruby 24 fails, see https://github.com/sinatra/sinatra/issues/2007
+          - { ruby: truffleruby,      rack: stable, puma: stable, tilt: stable, rack_session: stable, allow-failure: true }
+
     env:
       rack: ${{ matrix.rack }}
       rack_session: ${{ matrix.rack_session }}


### PR DESCRIPTION
Due to https://github.com/sinatra/sinatra/issues/2007