### PR TITLE
Fix warning about Hash construction.

### DIFF
--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -26,7 +26,7 @@ class TestIndifferentHashBasics < Minitest::Test
   end
 
   def test_default_object
-    hash = Sinatra::IndifferentHash.new(:a=>1, ?b=>2)
+    hash = Sinatra::IndifferentHash.new({:a=>1, ?b=>2})
     assert_equal({ :a=>1, ?b=>2 }, hash.default)
     assert_equal({ :a=>1, ?b=>2 }, hash[:a])
   end


### PR DESCRIPTION
Fixes <https://github.com/sinatra/sinatra/issues/2026>.

```
sinatra/test/indifferent_hash_test.rb:29: warning: Calling Hash.new with keyword arguments is deprecated and will be removed in Ruby 3.4; use Hash.new({ key: value }) instead
```