### PR TITLE
Don't depend on `Rack::Logger`.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1837,7 +1837,7 @@ module Sinatra
       end
 
       def setup_null_logger(builder)
-        builder.use Sinatra::Middleware::NullLogger
+        builder.use Sinatra::Middleware::Logger, ::Logger::FATAL
       end
 
       def setup_common_logger(builder)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -22,6 +22,8 @@ require 'sinatra/indifferent_hash'
 require 'sinatra/show_exceptions'
 require 'sinatra/version'
 
+require_relative 'middleware/logger'
+
 module Sinatra
   # The request object. See Rack::Request for more info:
   # https://rubydoc.info/github/rack/rack/main/Rack/Request
@@ -1835,7 +1837,7 @@ module Sinatra
       end
 
       def setup_null_logger(builder)
-        builder.use Rack::NullLogger
+        builder.use Sinatra::Middleware::NullLogger
       end
 
       def setup_common_logger(builder)
@@ -1844,9 +1846,9 @@ module Sinatra
 
       def setup_custom_logger(builder)
         if logging.respond_to? :to_int
-          builder.use Rack::Logger, logging
+          builder.use Sinatra::Middleware::Logger, logging
         else
-          builder.use Rack::Logger
+          builder.use Sinatra::Middleware::Logger
         end
       end
 

--- a/lib/sinatra/middleware/logger.rb
+++ b/lib/sinatra/middleware/logger.rb
@@ -17,48 +17,5 @@ module Sinatra
         @app.call(env)
       end
     end
-
-    class NullLogger
-      def initialize(app)
-        @app = app
-      end
-
-      def call(env)
-        env[Rack::RACK_LOGGER] = self
-        @app.call(env)
-      end
-
-      def info(progname = nil, &block); end
-      def debug(progname = nil, &block); end
-      def warn(progname = nil, &block); end
-      def error(progname = nil, &block); end
-      def fatal(progname = nil, &block); end
-      def unknown(progname = nil, &block); end
-      def info? ;  end
-      def debug? ; end
-      def warn? ;  end
-      def error? ; end
-      def fatal? ; end
-      def debug! ; end
-      def error! ; end
-      def fatal! ; end
-      def info! ; end
-      def warn! ; end
-      def level ; end
-      def progname ; end
-      def datetime_format ; end
-      def formatter ; end
-      def sev_threshold ; end
-      def level=(level); end
-      def progname=(progname); end
-      def datetime_format=(datetime_format); end
-      def formatter=(formatter); end
-      def sev_threshold=(sev_threshold); end
-      def close ; end
-      def add(severity, message = nil, progname = nil, &block); end
-      def log(severity, message = nil, progname = nil, &block); end
-      def <<(msg); end
-      def reopen(logdev = nil); end
-    end
   end
 end

--- a/lib/sinatra/middleware/logger.rb
+++ b/lib/sinatra/middleware/logger.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module Sinatra
+  module Middleware
+    class Logger
+      def initialize(app, level = ::Logger::INFO)
+        @app, @level = app, level
+      end
+
+      def call(env)
+        logger = ::Logger.new(env[Rack::RACK_ERRORS])
+        logger.level = @level
+
+        env[Rack::RACK_LOGGER] = logger
+        @app.call(env)
+      end
+    end
+
+    class NullLogger
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env[Rack::RACK_LOGGER] = self
+        @app.call(env)
+      end
+
+      def info(progname = nil, &block); end
+      def debug(progname = nil, &block); end
+      def warn(progname = nil, &block); end
+      def error(progname = nil, &block); end
+      def fatal(progname = nil, &block); end
+      def unknown(progname = nil, &block); end
+      def info? ;  end
+      def debug? ; end
+      def warn? ;  end
+      def error? ; end
+      def fatal? ; end
+      def debug! ; end
+      def error! ; end
+      def fatal! ; end
+      def info! ; end
+      def warn! ; end
+      def level ; end
+      def progname ; end
+      def datetime_format ; end
+      def formatter ; end
+      def sev_threshold ; end
+      def level=(level); end
+      def progname=(progname); end
+      def datetime_format=(datetime_format); end
+      def formatter=(formatter); end
+      def sev_threshold=(sev_threshold); end
+      def close ; end
+      def add(severity, message = nil, progname = nil, &block); end
+      def log(severity, message = nil, progname = nil, &block); end
+      def <<(msg); end
+      def reopen(logdev = nil); end
+    end
+  end
+end

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -50,4 +50,5 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.add_dependency 'rack-session', '>= 2.0.0', '< 3'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'tilt', '~> 2.0'
+  s.add_dependency 'logger'
 end


### PR DESCRIPTION
Fixes <https://github.com/sinatra/sinatra/issues/2018>.

I'd actually advise we go a bit further, but this is sufficient for compatibility.

By a bit further, I'd advise that we memoize the `Logger` instance if possible.