### PR TITLE
Re-compute content length *only* if it makes sense to do so.

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -170,7 +170,12 @@ module Sinatra
 
     def body=(value)
       value = value.body while Rack::Response === value
-      @body = String === value ? [value.to_str] : value
+
+      if value.respond_to?(:to_str)
+        value = [value.to_str]
+      end
+
+      @body = value
     end
 
     def each
@@ -294,13 +299,18 @@ module Sinatra
         def block.each; yield(call) end
         response.body = block
       elsif value
-        unless request.head? || value.is_a?(Rack::Files::Iterator) || value.is_a?(Stream)
-          headers.delete 'content-length'
-        end
         response.body = value
-      else
-        response.body
+
+        # If this isn't a head request, try to recompute the content length:
+        if !request.head?
+          body = response.body
+          if body.is_a?(Array)
+            headers['content-length'] = body.sum(&:bytesize).to_s
+          end
+        end
       end
+
+      return response.body
     end
 
     # Halt processing and redirect to the URI provided.


### PR DESCRIPTION
A little bit of background thinking:

The `content-length` header is not needed in cases like this. In other words, in the case where the content length can be computed by the server trivially - where trivially means something like `body.sum(&:bytesize)` - the application layer should not bother to set it.

At best, the content-length is unused in chunked responses, meaning you are doing additional work for HTTP/1.1 when using `transfer-encoding: chunked` and all the time for HTTP/2 which doesn't need `content-length`.

At worst, if the content-length is wrong, the server may reject the response, or it may fail while being sent.

Therefore, while this fixes the current test suite, my advice would be to try to avoid adding `content-length` at all.

Regarding the specific test that was failing, in `error_block!`, it looks like this is assigning to the body and header, but honestly, this should probably just return a completely new response... In other words, the error response is merged with any user headers... that also seems wrong to me. Ideally the error handler is just:

```
return [400, {'content-type' => 'text/plain'}, ["bad things happened"]]
```

The current implementation sets the body, and adds a content-type header, but the rest of the response is from user code, which could lead to some pretty wild behaviour.