### PR TITLE
Declare missing dependencies for Ruby 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'simplecov', require: false
 gem 'slim', '~> 4'
 gem 'yajl-ruby', platforms: [:ruby]
 gem 'zeitwerk'
+gem 'ostruct'
 
 # sass-embedded depends on google-protobuf
 # which fails to be installed on JRuby and TruffleRuby under aarch64

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'kramdown'
 gem 'liquid'
 gem 'markaby'
 gem 'nokogiri', '> 1.5.0'
+gem 'ostruct'
 gem 'pandoc-ruby', '~> 2.0.2'
 gem 'rabl'
 gem 'rdiscount', platforms: [:ruby]
@@ -51,7 +52,6 @@ gem 'simplecov', require: false
 gem 'slim', '~> 4'
 gem 'yajl-ruby', platforms: [:ruby]
 gem 'zeitwerk'
-gem 'ostruct'
 
 # sass-embedded depends on google-protobuf
 # which fails to be installed on JRuby and TruffleRuby under aarch64

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -40,6 +40,6 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'
+  s.add_dependency 'logger', '>= 1.6.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
-  s.add_dependency 'logger'
 end

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -41,4 +41,5 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
+  s.add_dependency 'logger'
 end


### PR DESCRIPTION
```
rack-protection/lib/rack/protection/base.rb:6: warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add logger to your Gemfile or gemspec.
test/rabl_test.rb:5: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
```