### PR TITLE
Fix compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
       rack_session: ${{ matrix.rack_session }}
       puma: ${{ matrix.puma }}
       tilt: ${{ matrix.tilt }}
+      RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     steps:
     - name: Install dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'rdiscount', platforms: [:ruby]
 gem 'rdoc'
 gem 'redcarpet', platforms: [:ruby]
 gem 'simplecov', require: false
-gem 'slim', '~> 4'
+gem 'slim', '~> 5'
 gem 'yajl-ruby', platforms: [:ruby]
 gem 'zeitwerk'
 

--- a/sinatra-contrib/lib/sinatra/capture.rb
+++ b/sinatra-contrib/lib/sinatra/capture.rb
@@ -92,7 +92,7 @@ module Sinatra
         with_haml_buffer(buffer) { capture_haml(*args, &block) }
       else
         buf_was = @_out_buf
-        @_out_buf = ''
+        @_out_buf = +''
         begin
           raw = block[*args]
           captured = block.binding.eval('@_out_buf')

--- a/sinatra-contrib/lib/sinatra/link_header.rb
+++ b/sinatra-contrib/lib/sinatra/link_header.rb
@@ -88,6 +88,8 @@ module Sinatra
       http_pattern  = ['<%s>', *options].join ';'
       link          = (response['Link'] ||= '')
 
+      link = response['Link'] = +link
+
       urls.map do |url|
         link << "," unless link.empty?
         link << (http_pattern % url)

--- a/sinatra-contrib/lib/sinatra/runner.rb
+++ b/sinatra-contrib/lib/sinatra/runner.rb
@@ -92,7 +92,7 @@ module Sinatra
     end
 
     def log
-      @log ||= ''
+      @log ||= +''
       loop { @log << pipe.read_nonblock(1) }
     rescue Exception
       @log

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -46,7 +46,7 @@ module IntegrationHelper
     def run
       return unless installed?
       kill
-      @log     = ""
+      @log     = +""
       super
       at_exit { kill }
     end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -11,7 +11,7 @@ class PatternLookAlike
   end
 
   def params(input)
-    { "one" => "this", "two" => "is", "three" => "a", "four" => "test" }
+    { "one" => +"this", "two" => +"is", "three" => +"a", "four" => +"test" }
   end
 end
 


### PR DESCRIPTION
Ever since Ruby 2.3 it has been possible to enable frozen string literals globally via `RUBYOPT`, and it is scheduled to be the default in Ruby 4.