### PR TITLE
Return an instance of Sinatra::IndifferentHash when calling #except

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -185,7 +185,7 @@ module Sinatra
     def except(*keys)
       keys.map!(&method(:convert_key))
 
-      super(*keys)
+      self.class[super(*keys)]
     end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 
     private

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -295,5 +295,6 @@ class TestIndifferentHash < Minitest::Test
   def test_except
     hash = @hash.except(?b, 3, :simple_nested, 'nested')
     assert_equal Sinatra::IndifferentHash[a: :a], hash
+    assert_instance_of Sinatra::IndifferentHash, hash
   end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 end


### PR DESCRIPTION
To keep consistency, make sure that `Sinatra::IndifferentHash#except` returns an instance of `Sinatra::IndifferentHash` instead of `Hash`. 

Before
```ruby
> h = Sinatra::IndifferentHash[{a: 1, b: 2}]
=> {"a"=>1, "b"=>2}
> h.class
=> Sinatra::IndifferentHash
> h.except(:b)
=> {"a"=>1}
> h.except(:b).class
=> Hash
```

After
```ruby
> h = Sinatra::IndifferentHash[{a: 1, b: 2}]
=> {"a"=>1, "b"=>2}
> h.class
=> Sinatra::IndifferentHash
> h.except(:b)
=> {"a"=>1}
> h.except(:b).class
=> Sinatra::IndifferentHash
```