### PR TITLE
CI: Avoid Zeitwerk 2.7.0+ for testes, for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'redcarpet', platforms: [:ruby]
 gem 'simplecov', require: false
 gem 'slim', '~> 4'
 gem 'yajl-ruby', platforms: [:ruby]
-gem 'zeitwerk'
+gem 'zeitwerk', '< 2.7.0' # https://github.com/sinatra/sinatra/issues/2047
 
 # sass-embedded depends on google-protobuf
 # which fails to be installed on JRuby and TruffleRuby under aarch64


### PR DESCRIPTION
Not sure what's going on, but we need green CI.

See https://github.com/sinatra/sinatra/issues/2047