### PR TITLE
Add `HostAuthorization` rack-protection middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2005,7 +2005,7 @@ set :protection, :session => true
   <dd>
     Useful options are:
     <ul>
-      <li><tt>permitted_hosts</tt> – an array of hostnames your app recognizes, if empty all hostnames are permitted</li>
+      <li><tt>permitted_hosts</tt> – an array of hostnames (and `IPAddr` objects) your app recognizes, if empty all hostnames are permitted</li>
       <li><tt>status</tt> – the HTTP status code used in the response when a request is blocked</li>
       <li><tt>message</tt> – the body used in the response when a request is blocked</li>
       <li><tt>allow_if</tt> – supply a <tt>Proc</tt> to use custom allow/deny logic, the proc is passed the request environment</li>

--- a/README.md
+++ b/README.md
@@ -1992,6 +1992,25 @@ set :protection, :session => true
       <tt>"development"</tt> if not available.
     </dd>
 
+  <dt>host_authorization</dt>
+  <dd>
+    You can pass a hash of options to <tt>host_authorization</tt>,
+    to be used by the <tt>Rack::Protection::HostAuthorization</tt> middleware.
+  <dd>
+  <dd>
+    The middleware can block requests with unrecognized hostnames, to prevent DNS rebinding
+    and other host header attacks. It checks the <tt>Host</tt>, <tt>X-Forwarded-Host</tt>
+    and <tt>Forwarded</tt> headers.
+  </dd>
+  <dd>
+    Useful options are:
+    <ul>
+      <li><tt>permitted_hosts</tt> – an array of hostnames your app recognizes, if empty all hostnames are permitted</li>
+      <li><tt>status</tt> – the HTTP status code used in the response when a request is blcoked</li>
+      <li><tt>message</tt> – the body used in the response when a request is blocked</li>
+      <li><tt>allow_if</tt> – supply a <tt>Proc</tt> to use custom allow/deny logic, the proc is passed the request environment</li>
+  </dd>
+
   <dt>logging</dt>
     <dd>Use the logger.</dd>
 
@@ -2013,16 +2032,6 @@ set :protection, :session => true
     A default hash of options to pass to Mustermann.new when compiling routing
     paths.
   </dd>
-
-  <dt>permitted_hosts</dt>
-    <dd>
-      An array of hostnames your app recognizes. Requests with an unrecognized hostname
-      will be stopped to prevent DNS rebinding and other host header attacks.
-      Checks the <tt>Host</tt>, <tt>X-Forwarded-Host</tt> and <tt>Forwarded</tt> headers.
-    </dd>
-    <dd>
-      By default the array is empty and all hostnames are permitted.
-    </dd>
 
   <dt>port</dt>
     <dd>Port to listen on. Only used for built-in server.</dd>

--- a/README.md
+++ b/README.md
@@ -2005,10 +2005,16 @@ set :protection, :session => true
   <dd>
     Useful options are:
     <ul>
-      <li><tt>permitted_hosts</tt> – an array of hostnames (and `IPAddr` objects) your app recognizes, if empty all hostnames are permitted</li>
-      <li><tt>status</tt> – the HTTP status code used in the response when a request is blocked</li>
-      <li><tt>message</tt> – the body used in the response when a request is blocked</li>
+      <li><tt>permitted_hosts</tt> – an array of hostnames (and <tt>IPAddr</tt> objects) your app recognizes
+        <ul>
+          <li>in the <tt>development</tt> environment, it is set to <tt>.localhost</tt>, <tt>.test</tt> and any IPv4/IPv6 address</li>
+          <li>if empty, any hostname is permitted (the default for any other environment)</li>
+        </ul>
+      </li>
+      <li><tt>status</tt> – the HTTP status code used in the response when a request is blocked (defaults to <tt>403</tt>)</li>
+      <li><tt>message</tt> – the body used in the response when a request is blocked (defaults to <tt>Host not permitted</tt>)</li>
       <li><tt>allow_if</tt> – supply a <tt>Proc</tt> to use custom allow/deny logic, the proc is passed the request environment</li>
+    </ul>
   </dd>
 
   <dt>logging</dt>

--- a/README.md
+++ b/README.md
@@ -2014,6 +2014,16 @@ set :protection, :session => true
     paths.
   </dd>
 
+  <dt>permitted_hosts</dt>
+    <dd>
+      An array of hostnames your app recognizes. Requests with an unrecognized hostname
+      will be stopped to prevent DNS rebinding and other host header attacks.
+      Checks the <tt>Host</tt>, <tt>X-Forwarded-Host</tt> and <tt>Forwarded</tt> headers.
+    </dd>
+    <dd>
+      By default the array is empty and all hostnames are permitted.
+    </dd>
+
   <dt>port</dt>
     <dd>Port to listen on. Only used for built-in server.</dd>
 

--- a/README.md
+++ b/README.md
@@ -2006,7 +2006,7 @@ set :protection, :session => true
     Useful options are:
     <ul>
       <li><tt>permitted_hosts</tt> – an array of hostnames your app recognizes, if empty all hostnames are permitted</li>
-      <li><tt>status</tt> – the HTTP status code used in the response when a request is blcoked</li>
+      <li><tt>status</tt> – the HTTP status code used in the response when a request is blocked</li>
       <li><tt>message</tt> – the body used in the response when a request is blocked</li>
       <li><tt>allow_if</tt> – supply a <tt>Proc</tt> to use custom allow/deny logic, the proc is passed the request environment</li>
   </dd>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -63,7 +63,7 @@ module Sinatra
     alias secure? ssl?
 
     def forwarded?
-      Rack::Protection::HostAuthorization.forwarded?(self)
+      get_header(Request::HTTP_X_FORWARDED_HOST)
     end
 
     def safe?

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -63,7 +63,7 @@ module Sinatra
     alias secure? ssl?
 
     def forwarded?
-      get_header(Request::HTTP_X_FORWARDED_HOST)
+      !forwarded_authority.nil?
     end
 
     def safe?

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1867,8 +1867,7 @@ module Sinatra
       end
 
       def setup_host_authorization(builder)
-        options = { permitted_hosts: permitted_hosts }
-        builder.use Rack::Protection::HostAuthorization, options
+        builder.use Rack::Protection::HostAuthorization, host_authorization
       end
 
       def setup_sessions(builder)
@@ -1936,7 +1935,7 @@ module Sinatra
     set :sessions, false
     set :session_store, Rack::Session::Cookie
     set :logging, false
-    set :permitted_hosts, []
+    set :host_authorization, {}
     set :protection, true
     set :method_override, false
     set :use_code, false

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -330,7 +330,11 @@ module Sinatra
       uri = [host = String.new]
       if absolute
         host << "http#{'s' if request.secure?}://"
-        host << Rack::Protection::HostAuthorization.host_from(request: request)
+        host << if request.forwarded? || (request.port != (request.secure? ? 443 : 80))
+                  request.host_with_port
+                else
+                  request.host
+                end
       end
       uri << request.script_name.to_s if add_script_name
       uri << (addr || request.path_info).to_s

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -14,6 +14,7 @@ require 'mustermann/sinatra'
 require 'mustermann/regular'
 
 # stdlib dependencies
+require 'ipaddr'
 require 'time'
 require 'uri'
 
@@ -1939,7 +1940,6 @@ module Sinatra
     set :sessions, false
     set :session_store, Rack::Session::Cookie
     set :logging, false
-    set :host_authorization, {}
     set :protection, true
     set :method_override, false
     set :use_code, false
@@ -1973,6 +1973,21 @@ module Sinatra
     set :bind, proc { development? ? 'localhost' : '0.0.0.0' }
     set :port, Integer(ENV['PORT'] && !ENV['PORT'].empty? ? ENV['PORT'] : 4567)
     set :quiet, false
+    set :host_authorization, ->() do
+      if development?
+        {
+          permitted_hosts: [
+            "localhost",
+            ".localhost",
+            ".test",
+            IPAddr.new("0.0.0.0/0"),
+            IPAddr.new("::/0"),
+          ]
+        }
+      else
+        {}
+      end
+    end
 
     ruby_engine = defined?(RUBY_ENGINE) && RUBY_ENGINE
 

--- a/rack-protection/README.md
+++ b/rack-protection/README.md
@@ -34,6 +34,10 @@ run MyApp
 
 # Prevented Attacks
 
+## DNS rebinding and other Host header attacks
+
+* [`Rack::Protection::HostAuthorization`][host-authorization] (not included by `use Rack::Protection`)
+
 ## Cross Site Request Forgery
 
 Prevented by:
@@ -109,6 +113,7 @@ The instrumenter is passed a namespace (String) and environment (Hash). The name
 [escaped-params]: http://www.sinatrarb.com/protection/escaped_params
 [form-token]: http://www.sinatrarb.com/protection/form_token
 [frame-options]: http://www.sinatrarb.com/protection/frame_options
+[host-authorization]: https://github.com/sinatra/sinatra/blob/main/rack-protection/lib/rack/protection/host_authorization.rb
 [http-origin]: http://www.sinatrarb.com/protection/http_origin
 [ip-spoofing]: http://www.sinatrarb.com/protection/ip_spoofing
 [json-csrf]: http://www.sinatrarb.com/protection/json_csrf

--- a/rack-protection/lib/rack/protection.rb
+++ b/rack-protection/lib/rack/protection.rb
@@ -12,6 +12,7 @@ module Rack
     autoload :EscapedParams,         'rack/protection/escaped_params'
     autoload :FormToken,             'rack/protection/form_token'
     autoload :FrameOptions,          'rack/protection/frame_options'
+    autoload :HostAuthorization,     'rack/protection/host_authorization'
     autoload :HttpOrigin,            'rack/protection/http_origin'
     autoload :IPSpoofing,            'rack/protection/ip_spoofing'
     autoload :JsonCsrf,              'rack/protection/json_csrf'

--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -58,6 +58,13 @@ module Rack
         result if (Array === result) && (result.size == 3)
       end
 
+      def debug(env, message)
+        return unless options[:logging]
+
+        l = options[:logger] || env['rack.logger'] || ::Logger.new(env['rack.errors'])
+        l.debug(message)
+      end
+
       def warn(env, message)
         return unless options[:logging]
 

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -23,10 +23,6 @@ module Rack
       default_options allow_if: nil,
                       message: "Host not permitted"
 
-      def self.forwarded?(request)
-        request.get_header(Request::HTTP_X_FORWARDED_HOST)
-      end
-
       def initialize(*)
         super
         @permitted_hosts = Array(options[:permitted_hosts]).map(&:downcase)

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'ipaddr'
 require 'rack/protection'
+require 'ipaddr'
 
 module Rack
   module Protection

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -82,7 +82,7 @@ module Rack
       private
 
       def extract_host(authority)
-        authority&.split(PORT_REGEXP)&.first&.downcase
+        authority&.split(PORT_REGEXP)&.first&.downcase # rubocop:disable Style/SafeNavigationChainLength
       end
 
       def host_permitted?(host)

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -31,6 +31,7 @@ module Rack
         @permitted_hosts = @all_permitted_hosts
           .select { |host| host.is_a?(String) }
           .map(&:downcase)
+        @domain_hosts = @permitted_hosts.select { |host| host[0] == "." }
         @ip_hosts = @all_permitted_hosts.select { |host| host.is_a?(IPAddr) }
       end
 
@@ -60,9 +61,15 @@ module Rack
       end
 
       def host_permitted?(host)
-        return true if @permitted_hosts.include?(host)
+        exact_match?(host) || domain_match?(host) || ip_match?(host)
+      end
 
-        ip_match?(host)
+      def exact_match?(host)
+        @permitted_hosts.include?(host)
+      end
+
+      def domain_match?(host)
+        @domain_hosts.any? { |domain_host| host.end_with?(domain_host) }
       end
 
       def ip_match?(host)

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -82,7 +82,7 @@ module Rack
       private
 
       def extract_host(authority)
-        authority&.split(PORT_REGEXP)&.first&.downcase # rubocop:disable Style/SafeNavigationChainLength
+        authority.to_s.split(PORT_REGEXP).first&.downcase
       end
 
       def host_permitted?(host)

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -27,14 +27,6 @@ module Rack
         request.get_header(Request::HTTP_X_FORWARDED_HOST)
       end
 
-      def self.host_from(request:)
-        if forwarded?(request) || (request.port != (request.ssl? ? 443 : 80))
-          request.host_with_port
-        else
-          request.host
-        end
-      end
-
       def initialize(*)
         super
         @permitted_hosts = Array(options[:permitted_hosts]).map(&:downcase)
@@ -45,7 +37,7 @@ module Rack
         return true if @permitted_hosts.empty?
 
         request = Request.new(env)
-        origin_host = self.class.host_from(request: request)
+        origin_host = request.host
 
         @permitted_hosts.include?(origin_host.downcase)
       end

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -43,6 +43,13 @@ module Rack
         origin_host = extract_host(request.host_authority)
         forwarded_host = extract_host(request.forwarded_authority)
 
+        debug env, "#{self.class} " \
+                   "@all_permitted_hosts=#{@all_permitted_hosts.inspect} " \
+                   "@domain_hosts=#{@domain_hosts.inspect} " \
+                   "@ip_hosts=#{@ip_hosts.inspect} " \
+                   "origin_host=#{origin_host.inspect} " \
+                   "forwarded_host=#{forwarded_host.inspect}"
+
         if host_permitted?(origin_host)
           if forwarded_host.nil?
             true

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -22,7 +22,7 @@ module Rack
     class HostAuthorization < Base
       DOT = '.'
       PORT_REGEXP = /:\d+\z/.freeze
-      SUBDOMAINS = /[a-z0-9-.]+/.freeze
+      SUBDOMAINS = /[a-z0-9\-.]+/.freeze
       private_constant :DOT,
                        :PORT_REGEXP,
                        :SUBDOMAINS

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rack/protection'
+
+module Rack
+  module Protection
+    ##
+    # Prevented attack::   DNS rebinding and other Host header attacks
+    # Supported browsers:: all
+    # More infos::         https://en.wikipedia.org/wiki/DNS_rebinding
+    #                      https://portswigger.net/web-security/host-header
+    #
+    # Blocks HTTP requests with an unrecognized hostname in any of the following
+    # HTTP headers: Host, X-Forwarded-Host, Forwarded
+    #
+    # If you want to permit a specific hostname, you can pass in as the `:permitted_hosts` option:
+    #
+    #     use Rack::Protection::HostAuthorization, permitted_hosts: ["www.example.org", "sinatrarb.com"]
+    #
+    # The `:allow_if` option can also be set to a proc to use custom allow/deny logic.
+    class HostAuthorization < Base
+      default_reaction :deny
+      default_options allow_if: nil,
+                      message: "Host not permitted"
+
+      def self.forwarded?(request)
+        request.get_header(Request::HTTP_X_FORWARDED_HOST)
+      end
+
+      def self.host_from(request:)
+        if forwarded?(request) || (request.port != (request.ssl? ? 443 : 80))
+          request.host_with_port
+        else
+          request.host
+        end
+      end
+
+      def initialize(*)
+        super
+        @permitted_hosts = Array(options[:permitted_hosts]).map(&:downcase)
+      end
+
+      def accepts?(env)
+        return true if options[:allow_if]&.call(env)
+        return true if @permitted_hosts.empty?
+
+        request = Request.new(env)
+        origin_host = self.class.host_from(request: request)
+
+        @permitted_hosts.include?(origin_host.downcase)
+      end
+    end
+  end
+end

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -69,6 +69,8 @@ module Rack
       end
 
       def domain_match?(host)
+        return false if host.nil?
+
         @domain_hosts.any? { |domain_host| host.end_with?(domain_host) }
       end
 

--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -28,7 +28,7 @@ module Rack
                        :SUBDOMAINS
       default_reaction :deny
       default_options allow_if: nil,
-                      message: "Host not permitted"
+                      message: 'Host not permitted'
 
       def initialize(*)
         super

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
     end
 
     requests.call.each do |headers|
-      it "stops the request with headers '#{headers}'" do
+      it "allows the request with headers '#{headers}'" do
         permitted_hosts = [".test", ".example.com"]
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.describe Rack::Protection::HostAuthorization do
+  it_behaves_like 'any rack application'
+
+  def assert_response(outcome:, headers:, last_response:)
+    fail_message = "Expected outcome '#{outcome}' for headers '#{headers}' " \
+                   "last_response.status '#{last_response.status}'"
+
+    case outcome
+    when :allowed
+      expect(last_response).to be_ok, fail_message
+    when :stopped
+      expect(last_response.status).to eq(403), fail_message
+      expect(last_response.body).to eq("Host not permitted"), fail_message
+    end
+  end
+
+  allowed_host = "example.com"
+  bad_host = "evil.com"
+  test_cases = [
+    # good requests
+    [:allowed, { "HTTP_HOST" => allowed_host }],
+    [:allowed, { "HTTP_X_FORWARDED_HOST" => allowed_host }],
+    [:allowed, { "HTTP_FORWARDED" => "host=#{allowed_host}" }],
+
+    # bad requests
+    [:stopped, { "HTTP_HOST" => bad_host }],
+    [:stopped, { "HTTP_X_FORWARDED_HOST" => bad_host }],
+    [:stopped, { "HTTP_FORWARDED" => "host=#{bad_host}" }],
+    [:stopped, { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => bad_host }],
+    [:stopped, { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{bad_host}" }],
+  ]
+
+  test_cases.each do |outcome, headers|
+    it 'allows/stops requests based on the permitted hosts specified' do
+      mock_app do
+        use Rack::Protection::HostAuthorization, permitted_hosts: [allowed_host]
+        run DummyApp
+      end
+
+      get("/", {}, headers)
+
+      assert_response(outcome: outcome, headers: headers, last_response: last_response)
+    end
+  end
+
+  it "accepts requests for non-permitted hosts when allow_if is true" do
+    mock_app do
+      use Rack::Protection::HostAuthorization, allow_if: ->(_env) { true },
+                                               permitted_hosts: [allowed_host]
+      run DummyApp
+    end
+
+    get("/", {}, "HTTP_HOST" => bad_host)
+
+    expect(last_response).to be_ok
+  end
+
+  it "allows the response given for non-permitted requests to be customized" do
+    message = "Unrecognized host"
+    mock_app do
+      use Rack::Protection::HostAuthorization, message: message, status: 406,
+                                               permitted_hosts: [allowed_host]
+      run DummyApp
+    end
+
+    get("/", {}, "HTTP_HOST" => bad_host)
+
+    expect(last_response.status).to eq(406)
+    expect(last_response.body).to eq(message)
+  end
+
+  describe "when the header value is upcased but the permitted host not" do
+    allowed_host = "example.com"
+    host_in_request = allowed_host.upcase
+    test_cases = [
+      { "HTTP_HOST" => host_in_request },
+      { "HTTP_X_FORWARDED_HOST" => host_in_request },
+      { "HTTP_FORWARDED" => "host=#{host_in_request}" },
+    ]
+
+    test_cases.each do |headers|
+      it "works" do
+        mock_app do
+          use Rack::Protection::HostAuthorization, permitted_hosts: [allowed_host]
+          run DummyApp
+        end
+
+        get("/", {}, headers)
+
+        expect(last_response).to be_ok
+      end
+    end
+  end
+
+  describe "when the permitted host is upcased but the header value is not" do
+    allowed_host = "example.com".upcase
+    host_in_request = allowed_host
+    test_cases = [
+      { "HTTP_HOST" => host_in_request },
+      { "HTTP_X_FORWARDED_HOST" => host_in_request },
+      { "HTTP_FORWARDED" => "host=#{host_in_request}" },
+    ]
+
+    test_cases.each do |headers|
+      it "works" do
+        mock_app do
+          use Rack::Protection::HostAuthorization, permitted_hosts: [allowed_host]
+          run DummyApp
+        end
+
+        get("/", {}, headers)
+
+        expect(last_response).to be_ok
+      end
+    end
+  end
+end

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Rack::Protection::HostAuthorization do
     [
       { "HTTP_HOST" => allowed_host },
       { "HTTP_X_FORWARDED_HOST" => allowed_host },
+      { "HTTP_X_FORWARDED_HOST" => "example.com, #{allowed_host}" },
       { "HTTP_FORWARDED" => "host=#{allowed_host}" },
+      { "HTTP_FORWARDED" => "host=example.com; host=#{allowed_host}" },
     ]
   end
 
@@ -28,7 +30,9 @@ RSpec.describe Rack::Protection::HostAuthorization do
     [
       { "HTTP_HOST" => bad_host },
       { "HTTP_X_FORWARDED_HOST" => bad_host },
+      { "HTTP_X_FORWARDED_HOST" => "#{allowed_host}, #{bad_host}" },
       { "HTTP_FORWARDED" => "host=#{bad_host}" },
+      { "HTTP_FORWARDED" => "host=#{allowed_host}; host=#{bad_host}" },
       { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => bad_host },
       { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{bad_host}" },
     ]

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
   good_requests = lambda do |allowed_host|
     [
       { "HTTP_HOST" => allowed_host },
+      { "HTTP_HOST" => "#{allowed_host}:3000" },
       { "HTTP_X_FORWARDED_HOST" => allowed_host },
       { "HTTP_X_FORWARDED_HOST" => "example.com, #{allowed_host}" },
       { "HTTP_FORWARDED" => "host=#{allowed_host}" },

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -256,6 +256,22 @@ RSpec.describe Rack::Protection::HostAuthorization do
     expect(last_response.body).to eq(message)
   end
 
+  describe "when HTTP_HOST is not present in the environment" do
+    it "stops the request" do
+      app = mock_app do
+        use Rack::Protection::HostAuthorization, permitted_hosts: [".tld"]
+        run DummyApp
+      end
+
+      headers = { "HTTP_X_FORWARDED_HOST" => "foo.tld" }
+      request = Rack::MockRequest.new(app) # this is from rack, not rack-test
+      response = request.get("/", headers)
+
+      expect(response.status).to eq(403)
+      expect(response.body).to eq("Host not permitted")
+    end
+  end
+
   describe "when the header value is upcased but the permitted host not" do
     test_cases = lambda do |host_in_request|
       [

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
     requests.call("allowed.org").each do |headers|
       it "stops the request with headers '#{headers}'" do
         permitted_hosts = [IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0"), "allowed.org"]
-        rack_lint = false
-        mock_app(nil, rack_lint) do
+        mock_app(nil, lint: false) do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "stringio"
+require 'stringio'
 
 RSpec.describe Rack::Protection::HostAuthorization do
-  it_behaves_like "any rack application"
+  it_behaves_like 'any rack application'
 
   def assert_response(outcome:, headers:, last_response:)
     fail_message = "Expected outcome '#{outcome}' for headers '#{headers}' " \
@@ -14,36 +14,36 @@ RSpec.describe Rack::Protection::HostAuthorization do
       expect(last_response).to be_ok, fail_message
     when :stopped
       expect(last_response.status).to eq(403), fail_message
-      expect(last_response.body).to eq("Host not permitted"), fail_message
+      expect(last_response.body).to eq('Host not permitted'), fail_message
     end
   end
 
   # we always specify HTTP_HOST because when HTTP_HOST is not set in env,
   # requests are made with env { HTTP_HOST => Rack::Test::DEFAULT_HOST }
 
-  describe "when subdomains under .test and .example.com are permitted" do
+  describe 'when subdomains under .test and .example.com are permitted' do
     requests = lambda do
       [
-        { "HTTP_HOST" => "foo.test" },
-        { "HTTP_HOST" => "example.com" },
-        { "HTTP_HOST" => "foo.example.com" },
-        { "HTTP_HOST" => "foo.bar.example.com" },
-        { "HTTP_HOST" => "foo.test", "HTTP_X_FORWARDED_HOST" => "bar.baz.example.com" },
-        { "HTTP_HOST" => "foo.test", "HTTP_X_FORWARDED_HOST" => "bar.test, baz.test" },
-        { "HTTP_HOST" => "foo.test", "HTTP_FORWARDED" => %(host="baz.test") },
-        { "HTTP_HOST" => "foo.test", "HTTP_FORWARDED" => %(host="baz.test" host="baz.example.com") },
+        { 'HTTP_HOST' => 'foo.test' },
+        { 'HTTP_HOST' => 'example.com' },
+        { 'HTTP_HOST' => 'foo.example.com' },
+        { 'HTTP_HOST' => 'foo.bar.example.com' },
+        { 'HTTP_HOST' => 'foo.test', 'HTTP_X_FORWARDED_HOST' => 'bar.baz.example.com' },
+        { 'HTTP_HOST' => 'foo.test', 'HTTP_X_FORWARDED_HOST' => 'bar.test, baz.test' },
+        { 'HTTP_HOST' => 'foo.test', 'HTTP_FORWARDED' => %(host="baz.test") },
+        { 'HTTP_HOST' => 'foo.test', 'HTTP_FORWARDED' => %(host="baz.test" host="baz.example.com") }
       ]
     end
 
     requests.call.each do |headers|
       it "allows the request with headers '#{headers}'" do
-        permitted_hosts = [".test", ".example.com"]
+        permitted_hosts = ['.test', '.example.com']
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
         assert_response(outcome: :allowed, headers: headers, last_response: last_response)
       end
     end
@@ -52,140 +52,140 @@ RSpec.describe Rack::Protection::HostAuthorization do
   describe "when hosts under 'allowed.org' are permitted" do
     bad_requests = lambda do
       [
-        { "HTTP_HOST" => ".allowed.org" },
-        { "HTTP_HOST" => "attacker.com#x.allowed.org" },
+        { 'HTTP_HOST' => '.allowed.org' },
+        { 'HTTP_HOST' => 'attacker.com#x.allowed.org' }
       ]
     end
 
     bad_requests.call.each do |headers|
       it "stops the request with headers '#{headers}'" do
-        permitted_hosts = [".allowed.org"]
+        permitted_hosts = ['.allowed.org']
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
         assert_response(outcome: :stopped, headers: headers, last_response: last_response)
       end
     end
   end
 
-  describe "requests with bogus values in headers" do
+  describe 'requests with bogus values in headers' do
     requests = lambda do |allowed_host|
       [
-        { "HTTP_HOST" => "::1" },
-        { "HTTP_HOST" => "[0]" },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => "[0]" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=::1" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=[0]" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=\"::1\"" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=\"[0]\"" },
+        { 'HTTP_HOST' => '::1' },
+        { 'HTTP_HOST' => '[0]' },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => '[0]' },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => 'host=::1' },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => 'host=[0]' },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => 'host="::1"' },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => 'host="[0]"' }
       ]
     end
 
-    requests.call("allowed.org").each do |headers|
+    requests.call('allowed.org').each do |headers|
       it "stops the request with headers '#{headers}'" do
-        permitted_hosts = [IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0"), "allowed.org"]
+        permitted_hosts = [IPAddr.new('0.0.0.0/0'), IPAddr.new('::/0'), 'allowed.org']
         mock_app(nil, lint: false) do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
         assert_response(outcome: :stopped, headers: headers, last_response: last_response)
       end
     end
   end
 
-  describe "when permitted hosts include IPAddr instance for 0.0.0.0/0" do
+  describe 'when permitted hosts include IPAddr instance for 0.0.0.0/0' do
     good_requests = lambda do
       [
-        { "HTTP_HOST" => "127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1:3000" },
-        { "HTTP_HOST" => "127.0.0.1", "HTTP_X_FORWARDED_HOST" => "127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1:3000", "HTTP_X_FORWARDED_HOST" => "127.0.0.1:3000" },
-        { "HTTP_HOST" => "127.0.0.1", "HTTP_X_FORWARDED_HOST" => "example.com, 127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1:3000", "HTTP_X_FORWARDED_HOST" => "example.com, 127.0.0.1:3000" },
-        { "HTTP_HOST" => "127.0.0.1", "HTTP_FORWARDED" => "host=127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1", "HTTP_FORWARDED" => "host=example.com; host=127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1:3000", "HTTP_FORWARDED" => "host=example.com; host=127.0.0.1:3000" },
+        { 'HTTP_HOST' => '127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1:3000' },
+        { 'HTTP_HOST' => '127.0.0.1', 'HTTP_X_FORWARDED_HOST' => '127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1:3000', 'HTTP_X_FORWARDED_HOST' => '127.0.0.1:3000' },
+        { 'HTTP_HOST' => '127.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'example.com, 127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1:3000', 'HTTP_X_FORWARDED_HOST' => 'example.com, 127.0.0.1:3000' },
+        { 'HTTP_HOST' => '127.0.0.1', 'HTTP_FORWARDED' => 'host=127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1', 'HTTP_FORWARDED' => 'host=example.com; host=127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1:3000', 'HTTP_FORWARDED' => 'host=example.com; host=127.0.0.1:3000' }
       ]
     end
 
     good_requests.call.each do |headers|
       it "allows the request with headers '#{headers}'" do
-        permitted_hosts = [IPAddr.new("0.0.0.0/0")]
+        permitted_hosts = [IPAddr.new('0.0.0.0/0')]
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         assert_response(outcome: :allowed, headers: headers, last_response: last_response)
       end
     end
   end
 
-  describe "when permitted hosts include IPAddr instance for ::/0" do
+  describe 'when permitted hosts include IPAddr instance for ::/0' do
     good_requests = lambda do
       [
-        { "HTTP_HOST" => "[::1]" },
-        { "HTTP_HOST" => "[::1]:3000" },
-        { "HTTP_HOST" => "[::1]", "HTTP_X_FORWARDED_HOST" => "::1" },
-        { "HTTP_HOST" => "[::1]", "HTTP_X_FORWARDED_HOST" => "[::1]" },
-        { "HTTP_HOST" => "[::1]:3000", "HTTP_X_FORWARDED_HOST" => "[::1]:3000" },
-        { "HTTP_HOST" => "[::1]", "HTTP_X_FORWARDED_HOST" => "example.com, [::1]" },
-        { "HTTP_HOST" => "[::1]:3000", "HTTP_X_FORWARDED_HOST" => "example.com, [::1]:3000" },
-        { "HTTP_HOST" => "[::1]", "HTTP_FORWARDED" => "host=[::1]" },
-        { "HTTP_HOST" => "[::1]", "HTTP_FORWARDED" => "host=example.com; host=[::1]" },
-        { "HTTP_HOST" => "[::1]:3000", "HTTP_FORWARDED" => "host=example.com; host=[::1]:3000" },
+        { 'HTTP_HOST' => '[::1]' },
+        { 'HTTP_HOST' => '[::1]:3000' },
+        { 'HTTP_HOST' => '[::1]', 'HTTP_X_FORWARDED_HOST' => '::1' },
+        { 'HTTP_HOST' => '[::1]', 'HTTP_X_FORWARDED_HOST' => '[::1]' },
+        { 'HTTP_HOST' => '[::1]:3000', 'HTTP_X_FORWARDED_HOST' => '[::1]:3000' },
+        { 'HTTP_HOST' => '[::1]', 'HTTP_X_FORWARDED_HOST' => 'example.com, [::1]' },
+        { 'HTTP_HOST' => '[::1]:3000', 'HTTP_X_FORWARDED_HOST' => 'example.com, [::1]:3000' },
+        { 'HTTP_HOST' => '[::1]', 'HTTP_FORWARDED' => 'host=[::1]' },
+        { 'HTTP_HOST' => '[::1]', 'HTTP_FORWARDED' => 'host=example.com; host=[::1]' },
+        { 'HTTP_HOST' => '[::1]:3000', 'HTTP_FORWARDED' => 'host=example.com; host=[::1]:3000' }
       ]
     end
 
     good_requests.call.each do |headers|
       it "allows the request with headers '#{headers}'" do
-        permitted_hosts = [IPAddr.new("::/0")]
+        permitted_hosts = [IPAddr.new('::/0')]
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         assert_response(outcome: :allowed, headers: headers, last_response: last_response)
       end
     end
   end
 
-  describe "when permitted hosts include IPAddr instance for 192.168.0.1/32" do
+  describe 'when permitted hosts include IPAddr instance for 192.168.0.1/32' do
     bad_requests = lambda do
       [
-        { "HTTP_HOST" => "127.0.0.1" },
-        { "HTTP_HOST" => "127.0.0.1:3000" },
-        { "HTTP_HOST" => "example.com" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_X_FORWARDED_HOST" => "127.0.0.1" },
-        { "HTTP_HOST" => "192.168.0.1:3000", "HTTP_X_FORWARDED_HOST" => "127.0.0.1:3000" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_X_FORWARDED_HOST" => "example.com" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_X_FORWARDED_HOST" => "example.com, 127.0.0.1" },
-        { "HTTP_HOST" => "192.168.0.1:3000", "HTTP_X_FORWARDED_HOST" => "example.com, 127.0.0.1:3000" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_FORWARDED" => "host=127.0.0.1" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_FORWARDED" => "host=example.com" },
-        { "HTTP_HOST" => "192.168.0.1", "HTTP_FORWARDED" => "host=example.com; host=127.0.0.1" },
-        { "HTTP_HOST" => "192.168.0.1:3000", "HTTP_FORWARDED" => "host=example.com; host=127.0.0.1:3000" },
+        { 'HTTP_HOST' => '127.0.0.1' },
+        { 'HTTP_HOST' => '127.0.0.1:3000' },
+        { 'HTTP_HOST' => 'example.com' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_X_FORWARDED_HOST' => '127.0.0.1' },
+        { 'HTTP_HOST' => '192.168.0.1:3000', 'HTTP_X_FORWARDED_HOST' => '127.0.0.1:3000' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_X_FORWARDED_HOST' => 'example.com' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_X_FORWARDED_HOST' => 'example.com, 127.0.0.1' },
+        { 'HTTP_HOST' => '192.168.0.1:3000', 'HTTP_X_FORWARDED_HOST' => 'example.com, 127.0.0.1:3000' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_FORWARDED' => 'host=127.0.0.1' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_FORWARDED' => 'host=example.com' },
+        { 'HTTP_HOST' => '192.168.0.1', 'HTTP_FORWARDED' => 'host=example.com; host=127.0.0.1' },
+        { 'HTTP_HOST' => '192.168.0.1:3000', 'HTTP_FORWARDED' => 'host=example.com; host=127.0.0.1:3000' }
       ]
     end
 
     bad_requests.call.each do |headers|
       it "stops the request with headers '#{headers}'" do
-        permitted_hosts = [IPAddr.new("192.168.0.1")]
+        permitted_hosts = [IPAddr.new('192.168.0.1')]
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         assert_response(outcome: :stopped, headers: headers, last_response: last_response)
       end
@@ -195,24 +195,24 @@ RSpec.describe Rack::Protection::HostAuthorization do
   describe "when the permitted hosts are ['allowed.org']" do
     good_requests = lambda do |allowed_host|
       [
-        { "HTTP_HOST" => allowed_host },
-        { "HTTP_HOST" => "#{allowed_host}:3000" },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => allowed_host },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => "example.com, #{allowed_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{allowed_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=example.com; host=#{allowed_host}" },
+        { 'HTTP_HOST' => allowed_host },
+        { 'HTTP_HOST' => "#{allowed_host}:3000" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => allowed_host },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => "example.com, #{allowed_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => "host=#{allowed_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => "host=example.com; host=#{allowed_host}" }
       ]
     end
 
-    good_requests.call("allowed.org").each do |headers|
+    good_requests.call('allowed.org').each do |headers|
       it "allows the request with headers '#{headers}'" do
-        permitted_hosts = ["allowed.org"]
+        permitted_hosts = ['allowed.org']
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         assert_response(outcome: :allowed, headers: headers, last_response: last_response)
       end
@@ -220,70 +220,70 @@ RSpec.describe Rack::Protection::HostAuthorization do
 
     bad_requests = lambda do |allowed_host, bad_host|
       [
-        { "HTTP_HOST" => bad_host },
-        { "HTTP_HOST" => "#{bad_host}##{allowed_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => bad_host },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => "#{allowed_host}, #{bad_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{bad_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{allowed_host}; host=#{bad_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => bad_host },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{bad_host}" },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => %(host=".#{allowed_host}") },
-        { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => %(host="foo.#{allowed_host}") },
-        { "HTTP_HOST" => bad_host, "HTTP_X_FORWARDED_HOST" => allowed_host },
-        { "HTTP_HOST" => bad_host, "HTTP_FORWARDED" => "host=#{allowed_host}" },
+        { 'HTTP_HOST' => bad_host },
+        { 'HTTP_HOST' => "#{bad_host}##{allowed_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => bad_host },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => "#{allowed_host}, #{bad_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => "host=#{bad_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => "host=#{allowed_host}; host=#{bad_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_X_FORWARDED_HOST' => bad_host },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => "host=#{bad_host}" },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => %(host=".#{allowed_host}") },
+        { 'HTTP_HOST' => allowed_host, 'HTTP_FORWARDED' => %(host="foo.#{allowed_host}") },
+        { 'HTTP_HOST' => bad_host, 'HTTP_X_FORWARDED_HOST' => allowed_host },
+        { 'HTTP_HOST' => bad_host, 'HTTP_FORWARDED' => "host=#{allowed_host}" }
       ]
     end
 
-    bad_requests.call("allowed.org", "bad.org").each do |headers|
+    bad_requests.call('allowed.org', 'bad.org').each do |headers|
       it "stops the request with headers '#{headers}'" do
-        permitted_hosts = ["allowed.org"]
+        permitted_hosts = ['allowed.org']
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: permitted_hosts
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         assert_response(outcome: :stopped, headers: headers, last_response: last_response)
       end
     end
   end
 
-  it "has debug logging" do
+  it 'has debug logging' do
     io = StringIO.new
-    logger = ::Logger.new(io)
+    logger = Logger.new(io)
     logger.level = Logger::DEBUG
-    allowed_host = "allowed.org"
+    allowed_host = 'allowed.org'
     mock_app do
       use Rack::Protection::HostAuthorization, logger: logger,
                                                permitted_hosts: [allowed_host]
       run DummyApp
     end
 
-    get("/")
+    get('/')
 
     expect(io.string).to match(/Rack::Protection::HostAuthorization.+#{allowed_host}/)
   end
 
-  it "accepts requests for unrecognized hosts when allow_if is true" do
-    allowed_host = "allowed.org"
-    bad_host = "bad.org"
+  it 'accepts requests for unrecognized hosts when allow_if is true' do
+    allowed_host = 'allowed.org'
+    bad_host = 'bad.org'
     mock_app do
       use Rack::Protection::HostAuthorization, allow_if: ->(_env) { true },
                                                permitted_hosts: [allowed_host]
       run DummyApp
     end
 
-    get("/", {}, "HTTP_HOST" => bad_host)
+    get('/', {}, 'HTTP_HOST' => bad_host)
 
     expect(last_response).to be_ok
   end
 
-  it "allows the response for blocked requests to be customized" do
-    allowed_host = "allowed.org"
-    bad_host = "bad.org"
-    message = "Unrecognized host"
+  it 'allows the response for blocked requests to be customized' do
+    allowed_host = 'allowed.org'
+    bad_host = 'bad.org'
+    message = 'Unrecognized host'
     mock_app do
       use Rack::Protection::HostAuthorization, message: message,
                                                status: 406,
@@ -291,68 +291,68 @@ RSpec.describe Rack::Protection::HostAuthorization do
       run DummyApp
     end
 
-    get("/", {}, "HTTP_HOST" => bad_host)
+    get('/', {}, 'HTTP_HOST' => bad_host)
 
     expect(last_response.status).to eq(406)
     expect(last_response.body).to eq(message)
   end
 
-  describe "when HTTP_HOST is not present in the environment" do
-    it "stops the request" do
+  describe 'when HTTP_HOST is not present in the environment' do
+    it 'stops the request' do
       app = mock_app do
-        use Rack::Protection::HostAuthorization, permitted_hosts: [".tld"]
+        use Rack::Protection::HostAuthorization, permitted_hosts: ['.tld']
         run DummyApp
       end
 
-      headers = { "HTTP_X_FORWARDED_HOST" => "foo.tld" }
+      headers = { 'HTTP_X_FORWARDED_HOST' => 'foo.tld' }
       request = Rack::MockRequest.new(app) # this is from rack, not rack-test
-      response = request.get("/", headers)
+      response = request.get('/', headers)
 
       expect(response.status).to eq(403)
-      expect(response.body).to eq("Host not permitted")
+      expect(response.body).to eq('Host not permitted')
     end
   end
 
-  describe "when the header value is upcased but the permitted host not" do
+  describe 'when the header value is upcased but the permitted host not' do
     test_cases = lambda do |host_in_request|
       [
-        { "HTTP_HOST" => host_in_request },
-        { "HTTP_HOST" => host_in_request, "HTTP_X_FORWARDED_HOST" => host_in_request },
-        { "HTTP_HOST" => host_in_request, "HTTP_FORWARDED" => "host=#{host_in_request}" },
+        { 'HTTP_HOST' => host_in_request },
+        { 'HTTP_HOST' => host_in_request, 'HTTP_X_FORWARDED_HOST' => host_in_request },
+        { 'HTTP_HOST' => host_in_request, 'HTTP_FORWARDED' => "host=#{host_in_request}" }
       ]
     end
 
-    test_cases.call("allowed.org".upcase).each do |headers|
+    test_cases.call('allowed.org'.upcase).each do |headers|
       it "allows the request with headers '#{headers}'" do
         mock_app do
-          use Rack::Protection::HostAuthorization, permitted_hosts: ["allowed.org"]
+          use Rack::Protection::HostAuthorization, permitted_hosts: ['allowed.org']
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         expect(last_response).to be_ok
       end
     end
   end
 
-  describe "when the permitted host is upcased but the header value is not" do
+  describe 'when the permitted host is upcased but the header value is not' do
     test_cases = lambda do |host_in_request|
       [
-        { "HTTP_HOST" => host_in_request },
-        { "HTTP_HOST" => host_in_request, "HTTP_X_FORWARDED_HOST" => host_in_request },
-        { "HTTP_HOST" => host_in_request, "HTTP_FORWARDED" => "host=#{host_in_request}" },
+        { 'HTTP_HOST' => host_in_request },
+        { 'HTTP_HOST' => host_in_request, 'HTTP_X_FORWARDED_HOST' => host_in_request },
+        { 'HTTP_HOST' => host_in_request, 'HTTP_FORWARDED' => "host=#{host_in_request}" }
       ]
     end
 
-    test_cases.call("allowed.org").each do |headers|
+    test_cases.call('allowed.org').each do |headers|
       it "allows the request with headers '#{headers}'" do
         mock_app do
-          use Rack::Protection::HostAuthorization, permitted_hosts: ["allowed.org".upcase]
+          use Rack::Protection::HostAuthorization, permitted_hosts: ['allowed.org'.upcase]
           run DummyApp
         end
 
-        get("/", {}, headers)
+        get('/', {}, headers)
 
         expect(last_response).to be_ok
       end

--- a/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/host_authorization_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
     end
   end
 
-  it "accepts requests for non-permitted hosts when allow_if is true" do
+  it "accepts requests for unrecognized hosts when allow_if is true" do
     allowed_host = "allowed.org"
     bad_host = "bad.org"
     mock_app do
@@ -78,12 +78,13 @@ RSpec.describe Rack::Protection::HostAuthorization do
     expect(last_response).to be_ok
   end
 
-  it "allows the response given for non-permitted requests to be customized" do
+  it "allows the response for blocked requests to be customized" do
     allowed_host = "allowed.org"
     bad_host = "bad.org"
     message = "Unrecognized host"
     mock_app do
-      use Rack::Protection::HostAuthorization, message: message, status: 406,
+      use Rack::Protection::HostAuthorization, message: message,
+                                               status: 406,
                                                permitted_hosts: [allowed_host]
       run DummyApp
     end
@@ -104,7 +105,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
     end
 
     test_cases.call("allowed.org".upcase).each do |headers|
-      it "works" do
+      it "allows the request with headers '#{headers}'" do
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: ["allowed.org"]
           run DummyApp
@@ -127,7 +128,7 @@ RSpec.describe Rack::Protection::HostAuthorization do
     end
 
     test_cases.call("allowed.org").each do |headers|
-      it "works" do
+      it "allows the request with headers '#{headers}'" do
         mock_app do
           use Rack::Protection::HostAuthorization, permitted_hosts: ["allowed.org".upcase]
           run DummyApp

--- a/rack-protection/spec/lib/rack/protection/protection_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/protection_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 RSpec.describe Rack::Protection do
   it_behaves_like 'any rack application'
 

--- a/rack-protection/spec/support/spec_helpers.rb
+++ b/rack-protection/spec/support/spec_helpers.rb
@@ -13,7 +13,7 @@ module SpecHelpers
     @app || mock_app(DummyApp)
   end
 
-  def mock_app(app = nil, lint = true, &block)
+  def mock_app(app = nil, lint: true, &block)
     app = block if app.nil? && (block.arity == 1)
     if app
       klass = described_class

--- a/rack-protection/spec/support/spec_helpers.rb
+++ b/rack-protection/spec/support/spec_helpers.rb
@@ -13,7 +13,7 @@ module SpecHelpers
     @app || mock_app(DummyApp)
   end
 
-  def mock_app(app = nil, &block)
+  def mock_app(app = nil, lint = true, &block)
     app = block if app.nil? && (block.arity == 1)
     if app
       klass = described_class
@@ -23,8 +23,10 @@ module SpecHelpers
         use klass
         run app
       end
-    else
+    elsif lint
       @app = Rack::Lint.new Rack::Builder.new(&block).to_app
+    else
+      @app = Rack::Builder.new(&block).to_app
     end
   end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -258,32 +258,6 @@ class HelpersTest < Minitest::Test
       assert_equal 'http://example.com/foo', response['Location']
     end
 
-    it 'redirects to permitted hosts' do
-      mock_app do
-        set :permitted_hosts, ['example.com']
-
-        get('/') { redirect '/foo' }
-      end
-
-      request = Rack::MockRequest.new(@app)
-      response = request.get('/', 'HTTP_X_FORWARDED_HOST' => 'example.com')
-      assert_equal 302, response.status
-      assert_equal 'http://example.com/foo', response['Location']
-    end
-
-    it 'stops requests to non-permitted hosts' do
-      mock_app do
-        set :host_authorization, { permitted_hosts: ['example.com'] }
-
-        get('/') { redirect '/foo' }
-      end
-
-      request = Rack::MockRequest.new(@app)
-      response = request.get('/', 'HTTP_X_FORWARDED_HOST' => 'evil.com')
-      assert_equal 403, response.status
-      assert_equal 'Host not permitted', response.body
-    end
-
     it 'accepts absolute URIs' do
       mock_app do
         get('/') do

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -273,7 +273,7 @@ class HelpersTest < Minitest::Test
 
     it 'stops requests to non-permitted hosts' do
       mock_app do
-        set :permitted_hosts, ['example.com']
+        set :host_authorization, { permitted_hosts: ['example.com'] }
 
         get('/') { redirect '/foo' }
       end

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -54,7 +54,7 @@ class HostAuthorization < Minitest::Test
     end
   end
 
-  describe "in test (and production) environment" do
+  describe "in non-development environments" do
     it "allows requests based on the permitted hosts specified" do
       allowed_host = "allowed.org"
       mock_app do

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -6,7 +6,7 @@ class HostAuthorization < Minitest::Test
   it "allows requests based on the permitted hosts specified" do
     allowed_host = "allowed.org"
     mock_app do
-      set :permitted_hosts, [allowed_host]
+      set :host_authorization, { permitted_hosts: [allowed_host] }
 
       get("/") { "OK" }
     end
@@ -22,7 +22,7 @@ class HostAuthorization < Minitest::Test
   it "stops requests based on the permitted hosts specified" do
     allowed_host = "allowed.org"
     mock_app do
-      set :permitted_hosts, [allowed_host]
+      set :host_authorization, { permitted_hosts: [allowed_host] }
 
       get("/") { "OK" }
     end
@@ -37,7 +37,48 @@ class HostAuthorization < Minitest::Test
 
   it "allows any requests when no permitted hosts are specified" do
     mock_app do
-      set :permitted_hosts, []
+      set :host_authorization, { permitted_hosts: [] }
+
+      get("/") { "OK" }
+    end
+
+    headers = { "HTTP_HOST" => "some-host.org" }
+    request = Rack::MockRequest.new(@app)
+    response = request.get("/", headers)
+
+    assert_equal 200, response.status
+    assert_equal "OK", response.body
+  end
+
+  it "stops the request using the configured response" do
+    allowed_host = "allowed.org"
+    status = 418
+    message = "No coffee for you"
+    mock_app do
+      set :host_authorization, {
+        permitted_hosts: [allowed_host],
+        status: status,
+        message: message,
+      }
+
+      get("/") { "OK" }
+    end
+
+    headers = { "HTTP_HOST" => "bad-host.org" }
+    request = Rack::MockRequest.new(@app)
+    response = request.get("/", headers)
+
+    assert_equal status, response.status
+    assert_equal message, response.body
+  end
+
+  it "allows custom logic with 'allow_if'" do
+    allowed_host = "allowed.org"
+    mock_app do
+      set :host_authorization, {
+        permitted_hosts: [allowed_host],
+        allow_if: ->(_env) { true },
+      }
 
       get("/") { "OK" }
     end

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -3,98 +3,149 @@
 require_relative "test_helper"
 
 class HostAuthorization < Minitest::Test
-  it "allows requests based on the permitted hosts specified" do
-    allowed_host = "allowed.org"
-    mock_app do
-      set :host_authorization, { permitted_hosts: [allowed_host] }
-
-      get("/") { "OK" }
+  describe "in development environment" do
+    setup do
+      Sinatra::Base.set :environment, :development
     end
 
-    headers = { "HTTP_HOST" => allowed_host }
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/", headers)
-
-    assert_equal 200, response.status
-    assert_equal "OK", response.body
-  end
-
-  it "stops requests based on the permitted hosts specified" do
-    allowed_host = "allowed.org"
-    mock_app do
-      set :host_authorization, { permitted_hosts: [allowed_host] }
-
-      get("/") { "OK" }
-    end
-
-    headers = { "HTTP_HOST" => "bad-host.org" }
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/", headers)
-
-    assert_equal 403, response.status
-    assert_equal "Host not permitted", response.body
-  end
-
-  it "allows any requests when no permitted hosts are specified" do
-    mock_app do
-      set :host_authorization, { permitted_hosts: [] }
-
-      get("/") { "OK" }
-    end
-
-    headers = { "HTTP_HOST" => "some-host.org" }
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/", headers)
-
-    assert_equal 200, response.status
-    assert_equal "OK", response.body
-  end
-
-  it "stops the request using the configured response" do
-    allowed_host = "allowed.org"
-    status = 418
-    message = "No coffee for you"
-    mock_app do
-      set :host_authorization, {
-        permitted_hosts: [allowed_host],
-        status: status,
-        message: message,
-      }
-
-      get("/") { "OK" }
-    end
-
-    headers = { "HTTP_HOST" => "bad-host.org" }
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/", headers)
-
-    assert_equal status, response.status
-    assert_equal message, response.body
-  end
-
-  it "allows custom logic with 'allow_if'" do
-    allowed_host = "allowed.org"
-    mock_app do
-      set :host_authorization, {
-        permitted_hosts: [allowed_host],
-        allow_if: ->(env) do
-          request = Sinatra::Request.new(env)
-          request.path == "/allowed"
+    %w[
+      127.0.0.1
+      127.0.0.1:3000
+      [::1]
+      [::1]:3000
+      localhost
+      localhost:3000
+      foo.localhost
+      foo.test
+    ].each do |development_host|
+      it "allows a host like '#{development_host}'" do
+        mock_app do
+          get("/") { "OK" }
         end
-      }
 
-      get("/") { "OK" }
-      get("/allowed") { "OK" }
+        headers = { "HTTP_HOST" => development_host }
+        request = Rack::MockRequest.new(@app)
+        response = request.get("/", headers)
+
+        assert_equal 200, response.status
+        assert_equal "OK", response.body
+      end
     end
 
-    headers = { "HTTP_HOST" => "some-host.org" }
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/allowed", headers)
-    assert_equal 200, response.status
-    assert_equal "OK", response.body
+    it "stops non-development hosts by default" do
+      mock_app { get("/") { "OK" } }
 
-    request = Rack::MockRequest.new(@app)
-    response = request.get("/", headers)
-    assert_equal 403, response.status
+      get "/", { "HTTP_HOST" => "example.com" }
+
+      assert_equal 403, response.status
+      assert_equal "Host not permitted", body
+    end
+
+    it "allows any requests when no permitted hosts are specified" do
+      mock_app do
+        set :host_authorization, { permitted_hosts: [] }
+        get("/") { "OK" }
+      end
+
+      get "/", { "HTTP_HOST" => "example.com" }
+
+      assert_equal 200, response.status
+      assert_equal "OK", body
+    end
+  end
+
+  describe "in test (and production) environment" do
+    it "allows requests based on the permitted hosts specified" do
+      allowed_host = "allowed.org"
+      mock_app do
+        set :host_authorization, { permitted_hosts: [allowed_host] }
+
+        get("/") { "OK" }
+      end
+
+      headers = { "HTTP_HOST" => allowed_host }
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_equal 200, response.status
+      assert_equal "OK", response.body
+    end
+
+    it "stops requests based on the permitted hosts specified" do
+      allowed_host = "allowed.org"
+      mock_app do
+        set :host_authorization, { permitted_hosts: [allowed_host] }
+
+        get("/") { "OK" }
+      end
+
+      headers = { "HTTP_HOST" => "bad-host.org" }
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_equal 403, response.status
+      assert_equal "Host not permitted", response.body
+    end
+
+    it "defaults to permitt any hosts" do
+      mock_app do
+        get("/") { "OK" }
+      end
+
+      headers = { "HTTP_HOST" => "some-host.org" }
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_equal 200, response.status
+      assert_equal "OK", response.body
+    end
+
+    it "stops the request using the configured response" do
+      allowed_host = "allowed.org"
+      status = 418
+      message = "No coffee for you"
+      mock_app do
+        set :host_authorization, {
+          permitted_hosts: [allowed_host],
+          status: status,
+          message: message,
+        }
+
+        get("/") { "OK" }
+      end
+
+      headers = { "HTTP_HOST" => "bad-host.org" }
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_equal status, response.status
+      assert_equal message, response.body
+    end
+
+    it "allows custom logic with 'allow_if'" do
+      allowed_host = "allowed.org"
+      mock_app do
+        set :host_authorization, {
+          permitted_hosts: [allowed_host],
+          allow_if: ->(env) do
+            request = Sinatra::Request.new(env)
+            request.path == "/allowed"
+          end
+        }
+
+        get("/") { "OK" }
+        get("/allowed") { "OK" }
+      end
+
+      headers = { "HTTP_HOST" => "some-host.org" }
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/allowed", headers)
+      assert_equal 200, response.status
+      assert_equal "OK", response.body
+
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+      assert_equal 403, response.status
+    end
   end
 end

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -87,7 +87,7 @@ class HostAuthorization < Minitest::Test
       assert_equal "Host not permitted", response.body
     end
 
-    it "defaults to permitt any hosts" do
+    it "defaults to permit any hosts" do
       mock_app do
         get("/") { "OK" }
       end

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class HostAuthorization < Minitest::Test
+  def assert_response(outcome:, headers:, response:)
+    fail_message = "Expected outcome '#{outcome}' for headers '#{headers}'"
+
+    case outcome
+    when :allowed
+      assert_equal 200, response.status, fail_message
+      assert_equal "OK", response.body, fail_message
+    when :stopped
+      assert_equal 403, response.status, fail_message
+      assert_equal "Host not permitted", response.body, fail_message
+    end
+  end
+
+  allowed_host = "example.com"
+  bad_host = "evil.com"
+  test_cases = [
+    # good requests
+    [:allowed, { "HTTP_HOST" => allowed_host }],
+    [:allowed, { "HTTP_X_FORWARDED_HOST" => allowed_host }],
+    [:allowed, { "HTTP_FORWARDED" => "host=#{allowed_host}" }],
+
+    # bad requests
+    [:stopped, { "HTTP_HOST" => bad_host }],
+    [:stopped, { "HTTP_X_FORWARDED_HOST" => bad_host }],
+    [:stopped, { "HTTP_FORWARDED" => "host=#{bad_host}" }],
+    [:stopped, { "HTTP_HOST" => allowed_host, "HTTP_X_FORWARDED_HOST" => bad_host }],
+    [:stopped, { "HTTP_HOST" => allowed_host, "HTTP_FORWARDED" => "host=#{bad_host}" }],
+  ]
+
+  test_cases.each do |outcome, headers|
+    it "allows/stops requests based on the permitted hosts specified" do
+      mock_app do
+        set :permitted_hosts, [allowed_host]
+
+        get("/") { "OK" }
+      end
+
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_response(outcome: outcome, headers: headers, response: response)
+    end
+  end
+
+  it "allows any requests when no permitted hosts are specified" do
+    test_cases.each do |_outcome, headers|
+      mock_app do
+        set :permitted_hosts, []
+
+        get("/") { "OK" }
+      end
+
+      fail_message = "Expected request with headers '#{headers}' to be allowed"
+      request = Rack::MockRequest.new(@app)
+      response = request.get("/", headers)
+
+      assert_equal 200, response.status, fail_message
+      assert_equal "OK", response.body, fail_message
+    end
+  end
+end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -36,6 +36,11 @@ class RequestTest < Minitest::Test
     assert !request.secure?
   end
 
+  it 'respects X-Forwarded-Host header' do
+    request = Sinatra::Request.new('HTTP_X_FORWARDED_HOST' => 'example.com')
+    assert request.forwarded?
+  end
+
   it 'respects X-Forwarded-Proto header for proxied SSL' do
     request = Sinatra::Request.new('HTTP_X_FORWARDED_PROTO' => 'https')
     assert request.secure?

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -41,6 +41,14 @@ class RequestTest < Minitest::Test
     assert request.forwarded?
   end
 
+  it 'respects Forwarded header with host key' do
+    request = Sinatra::Request.new('HTTP_FORWARDED' => 'host=example.com')
+    assert request.forwarded?
+
+    request = Sinatra::Request.new('HTTP_FORWARDED' => 'for=192.0.2.60;proto=http;by=203.0.113.43')
+    refute request.forwarded?
+  end
+
   it 'respects X-Forwarded-Proto header for proxied SSL' do
     request = Sinatra::Request.new('HTTP_X_FORWARDED_PROTO' => 'https')
     assert request.secure?


### PR DESCRIPTION
The Sinatra project received a security report with the following details:

> Title: Reliance on Untrusted Inputs in a Security Decision
> CWE ID: CWE-807
> CVE ID: CVE-2024-21510
> Credit: t0rchwo0d
> Description: The sinatra package is vulnerable to Reliance on Untrusted
> Inputs in a Security Decision via the `X-Forwarded-Host (XFH)` header.
> When making a request to a method with redirect applied, it is possible
> to trigger an Open Redirect Attack by inserting an arbitrary address
> into this header. If used for caching purposes, such as with servers
> like Nginx, or as a reverse proxy, without handling the
> `X-Forwarded-Host` header, attackers can potentially exploit Cache
> Poisoning or Routing-based SSRF.

The vulnerable code was introduced in fae7c011. Sinatra can not know whether the header value can be trusted or not without input from the app creator. This change introduce the `host_authorization` settings for that.

It is implemented as a Rack middleware, bundled with rack-protection, but not exposed as a default nor opt-in protection. It is meant to be used by itself, as sharing reaction with other protections is not ideal (see https://github.com/sinatra/sinatra/issues/2012).