### PR TITLE
CI: unset `RUBYOPT` for JRuby jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,8 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+        rubyopt:
+          - "--enable-frozen-string-literal --debug-frozen-string-literal"
         include:
           # Rack
           - { ruby: 3.2, rack: "~>3.0.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
@@ -99,10 +101,10 @@ jobs:
           # Test Zeitwerk < 2.7.0 separately
           - { ruby: 3.2, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: '<2.7.0' }
           # JRuby, tests are flaky: https://github.com/sinatra/sinatra/issues/2027
-          - { ruby: jruby,            rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby,            rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # Never fail our build due to problems with head rubies
           - { ruby: ruby-head,        rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
-          - { ruby: jruby-head,       rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby-head,       rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           - { ruby: truffleruby-head, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # truffleruby 24 fails, see https://github.com/sinatra/sinatra/issues/2007
           - { ruby: truffleruby,      rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
@@ -113,7 +115,8 @@ jobs:
       puma: ${{ matrix.puma }}
       tilt: ${{ matrix.tilt }}
       zeitwerk: ${{ matrix.zeitwerk }}
-      RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
+      RUBYOPT: "${{ matrix.rubyopt }}"
+      # need to unset RUBYOPT for JRuby: https://github.com/jruby/ruby-maven/issues/12
 
     steps:
     - name: Install dependencies


### PR DESCRIPTION
Due to https://github.com/jruby/ruby-maven/issues/12