### PR TITLE
Address `URI` depreciation

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -974,7 +974,7 @@ module Sinatra
     include Helpers
     include Templates
 
-    URI_INSTANCE = URI::Parser.new
+    URI_INSTANCE = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::RFC2396_Parser.new
 
     attr_accessor :app, :env, :request, :response, :params
     attr_reader   :template_cache


### PR DESCRIPTION
Avoid this upcoming warning:

    # ruby -v -w -ruri -e 'p=URI::Parser.new; p.unescape("")'
    ruby 3.4.0dev (2024-11-07T00:17:16Z master 342455e56f) +PRISM [x86_64-linux]
    -e:1: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.

Close https://github.com/sinatra/sinatra/issues/2057