### PR TITLE
Restore WEBrick support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'redcarpet', platforms: [:ruby]
 gem 'simplecov', require: false
 gem 'slim', '~> 5'
 gem 'yajl-ruby', platforms: [:ruby]
+gem 'webrick'
 
 # sass-embedded depends on google-protobuf
 # which fails to be installed on JRuby and TruffleRuby under aarch64

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1969,7 +1969,7 @@ module Sinatra
     set :running_server, nil
     set :handler_name, nil
     set :traps, true
-    set :server, %w[]
+    set :server, %w[webrick]
     set :bind, proc { development? ? 'localhost' : '0.0.0.0' }
     set :port, Integer(ENV['PORT'] && !ENV['PORT'].empty? ? ENV['PORT'] : 4567)
     set :quiet, false

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -78,6 +78,10 @@ module IntegrationHelper
       end
     end
 
+    def webrick?
+      name.to_s == "webrick"
+    end
+
     def puma?
       name.to_s == "puma"
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -19,13 +19,15 @@ class IntegrationTest < Minitest::Test
     count = server.log.scan("GET /ping?x=#{random}").count
     if server.net_http_server?
       assert_equal 0, count
+    elsif server.webrick?
+      assert(count > 0)
     else
       assert_equal(1, count)
     end
   end
 
   it 'streams' do
-    next if server.trinidad?
+    next if server.webrick? or server.trinidad?
     times, chunks = [Process.clock_gettime(Process::CLOCK_MONOTONIC)], []
     server.get_stream do |chunk|
       next if chunk.empty?

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -479,6 +479,11 @@ class SettingsTest < Minitest::Test
   end
 
   describe 'server' do
+    it 'includes webrick' do
+      assert @base.server.include?('webrick')
+      assert @application.server.include?('webrick')
+    end
+
     it 'includes puma' do
       assert @base.server.include?('puma')
       assert @application.server.include?('puma')


### PR DESCRIPTION
4a55850 was a bit aggressive, it should not have dropped the "out of the box" experience for Sinatra and WEBrick when you have the required gems installed.