### PR TITLE
fix(hostAuth): allow underscores in subdomains

### DIFF
--- a/rack-protection/lib/rack/protection/host_authorization.rb
+++ b/rack-protection/lib/rack/protection/host_authorization.rb
@@ -22,7 +22,7 @@ module Rack
     class HostAuthorization < Base
       DOT = '.'
       PORT_REGEXP = /:\d+\z/.freeze
-      SUBDOMAINS = /[a-z0-9\-.]+/.freeze
+      SUBDOMAINS = /[a-z0-9\-_.]+/.freeze
       private_constant :DOT,
                        :PORT_REGEXP,
                        :SUBDOMAINS


### PR DESCRIPTION
As best I can tell underscores are perfectly valid in subdomains. When deploying the host authorization in Sinatra 4.1, some of our customers that used underscores in their subdomains were not able to login.

Here's some supporting evidence: https://stackoverflow.com/a/2183140/2187010

but then again there is newer stuff that seems to suggest underscores are in the process of being sunset: https://www.ssl.com/faqs/underscores-not-allowed-in-domain-names/ 

Totally ok if you think this is not a welcome change.