### PR TITLE
Some slight doc improvements in rack-protection

### DIFF
--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -26,16 +26,11 @@ module Rack
     #
     # == Options
     #
-    # [<tt>:authenticity_param</tt>] the name of the param that should contain
-    #                                the token on a request. Default value:
-    #                                <tt>"authenticity_token"</tt>
+    # [<tt>:authenticity_param</tt>] the name of the param that should contain the token on a request. Default value: <tt>"authenticity_token"</tt>
     #
-    # [<tt>:key</tt>] the name of the param that should contain
-    #                                the token in the session. Default value:
-    #                                <tt>:csrf</tt>
+    # [<tt>:key</tt>] the name of the param that should contain the token in the session. Default value: <tt>:csrf</tt>
     #
-    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Default value:
-    #                                <tt>nil</tt>
+    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Default value: <tt>nil</tt>
     #
     # == Example: Forms application
     #

--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -26,11 +26,18 @@ module Rack
     #
     # == Options
     #
-    # [<tt>:authenticity_param</tt>] the name of the param that should contain the token on a request. Default value: <tt>"authenticity_token"</tt>
+    # [<tt>:authenticity_param</tt>] the name of the param that should contain
+    #                                the token on a request. Default value:
+    #                                <tt>"authenticity_token"</tt>
     #
-    # [<tt>:key</tt>] the name of the param that should contain the token in the session. Default value: <tt>:csrf</tt>
+    # [<tt>:key</tt>] the name of the param that should contain
+    #                 the token in the session. Default value: <tt>:csrf</tt>
     #
-    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Will be passed <tt>env</tt> as the only arg and should return true if the request is allowed, regardless of the authenticity token. Default is <tt>nil</tt>, which means there is no special logic for allowing requests that don't have a valid token.
+    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Will be passed <tt>env</tt>
+    #                      as the only arg and should return true if the request is allowed,
+    #                      regardless of the authenticity token. Default is <tt>nil</tt>,
+    #                      which means there is no special logic for allowing requests that
+    #                      don't have a valid token.
     #
     # [Rack::Protection::Base options] any option supported by Rack::Protection::Base.
     #
@@ -99,7 +106,8 @@ module Rack
                       key: :csrf,
                       allow_if: nil
 
-      # Access the token from the given session.  Useful for building a form that should include the current authenticity token.
+      # Access the token from the given session.  Useful for building a
+      # form that should include the current authenticity token.
       def self.token(session, path: nil, method: :post)
         new(nil).mask_authenticity_token(session, path: path, method: method)
       end

--- a/rack-protection/lib/rack/protection/authenticity_token.rb
+++ b/rack-protection/lib/rack/protection/authenticity_token.rb
@@ -30,7 +30,9 @@ module Rack
     #
     # [<tt>:key</tt>] the name of the param that should contain the token in the session. Default value: <tt>:csrf</tt>
     #
-    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Default value: <tt>nil</tt>
+    # [<tt>:allow_if</tt>] a proc for custom allow/deny logic. Will be passed <tt>env</tt> as the only arg and should return true if the request is allowed, regardless of the authenticity token. Default is <tt>nil</tt>, which means there is no special logic for allowing requests that don't have a valid token.
+    #
+    # [Rack::Protection::Base options] any option supported by Rack::Protection::Base.
     #
     # == Example: Forms application
     #
@@ -97,6 +99,7 @@ module Rack
                       key: :csrf,
                       allow_if: nil
 
+      # Access the token from the given session.  Useful for building a form that should include the current authenticity token.
       def self.token(session, path: nil, method: :post)
         new(nil).mask_authenticity_token(session, path: path, method: method)
       end

--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -18,11 +18,11 @@ module Rack
     # [<tt>:reaction</tt>] - name of a method of the class that will be used to respond when the
     #                        middleware rejects the response. Default behavior is to use #default_reaction.
     # [<tt>:logging</tt>] - if true, debug and warning statements are sent to the logger.
-    # [<tt>:message</tt>] - if set, and <tt>:reaction</tt> has not been set, this is the
-    #                       text of the message sent to the client when the request is rejected. See DEFAULT_OPTIONS.
+    # [<tt>:message</tt>] - if set, this is the message sent when a request is rejected via <tt>deny</tt>.
+    #                       See DEFAULT_OPTIONS.
     # [<tt>:session_key</tt>] - string to use as the key into <tt>env</tt> where the current
     #                           session is stored. See DEFAULT_OPTIONS.
-    # [<tt>:status</tt>] - HTTP status to use when a request is rejected.
+    # [<tt>:status</tt>] - HTTP status to use when a request is rejected via <tt>deny</tt>.
     #                      See DEFAULT_OPTIONS.
     # [<tt>:report_key</tt>] - key set in <tt>env</tt> if the request has been denied
     #                          and <tt>:reaction</tt> is set to <tt>:report</tt> (see #report). See DEFAULT_OPTIONS.

--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -15,13 +15,19 @@ module Rack
     #
     # These may be given to any subclass, however they may affect different subclasses differently.
     #
-    # [<tt>:reaction</tt>] - name of a method of the class that will be used to respond when the middleware rejects the response. Default behavior is to use #default_reaction.
+    # [<tt>:reaction</tt>] - name of a method of the class that will be used to respond when the
+    #                        middleware rejects the response. Default behavior is to use #default_reaction.
     # [<tt>:logging</tt>] - if true, debug and warning statements are sent to the logger.
-    # [<tt>:message</tt>] - if set, and <tt>:reaction</tt> has not been set, this is the text of the message sent to the client when the request is rejected. See DEFAULT_OPTIONS.
-    # [<tt>:session_key</tt>] - string to use as the key into <tt>env</tt> where the current session is stored. See DEFAULT_OPTIONS.
-    # [<tt>:status</tt>] - HTTP status to use when a request is rejected. See DEFAULT_OPTIONS.
-    # [<tt>:report_key</tt>] - key set in <tt>env</tt> if the request has been denied and <tt>:reaction</tt> is set to <tt>:report</tt> (see #report). See DEFAULT_OPTIONS.
-    # [<tt>:html_types</tt>] - Array of strings containing content types that are consider HTML for the purposes of this gem. See DEFAULT_OPTIONS.
+    # [<tt>:message</tt>] - if set, and <tt>:reaction</tt> has not been set, this is the
+    #                       text of the message sent to the client when the request is rejected. See DEFAULT_OPTIONS.
+    # [<tt>:session_key</tt>] - string to use as the key into <tt>env</tt> where the current
+    #                           session is stored. See DEFAULT_OPTIONS.
+    # [<tt>:status</tt>] - HTTP status to use when a request is rejected.
+    #                      See DEFAULT_OPTIONS.
+    # [<tt>:report_key</tt>] - key set in <tt>env</tt> if the request has been denied
+    #                          and <tt>:reaction</tt> is set to <tt>:report</tt> (see #report). See DEFAULT_OPTIONS.
+    # [<tt>:html_types</tt>] - Array of strings containing content types that are consider HTML
+    #                          for the purposes of this gem. See DEFAULT_OPTIONS.
     #
     class Base
       DEFAULT_OPTIONS = {
@@ -35,12 +41,14 @@ module Rack
 
       attr_reader :app, :options
 
-      # Used by subclasses to declare default values for options they require. These defaults are merged onto the DEFAULT_OPTIONS provided by this class.
+      # Used by subclasses to declare default values for options they require.
+      # These defaults are merged onto the DEFAULT_OPTIONS provided by this class.
       def self.default_options(options)
         define_method(:default_options) { super().merge(options) }
       end
 
-      # Used by subclasses to declare default reaction when a request is rejected.  This replaces the default provided by this class.
+      # Used by subclasses to declare default reaction when a request is rejected.
+      # This replaces the default provided by this class.
       # See #default_reaction.
       def self.default_reaction(reaction)
         alias_method(:default_reaction, reaction)
@@ -97,13 +105,17 @@ module Rack
         i.instrument('rack.protection', env)
       end
 
-      # Deny the request.  Sends a content type of "text/plain" using the status and message set in the options.
+      # Deny the request.  Sends a content type of "text/plain" using
+      # the status and message set in the options.
       def deny(env)
         warn env, "attack prevented by #{self.class}"
         [options[:status], { 'content-type' => 'text/plain' }, [options[:message]]]
       end
 
-      # When used as a reaction (with option <tt>reaction: :report</tt>), any rejected request will be allowed through, and a warning is omitted (note that warnings will not be shown if the <tt>:logging</tt> option has been set to false).
+      # When used as a reaction (with option <tt>reaction: :report</tt>),
+      # any rejected request will be allowed through, and a warning is
+      # omitted (note that warnings will not be shown if the
+      # <tt>:logging</tt> option has been set to false).
       def report(env)
         warn env, "attack reported by #{self.class}"
         env[options[:report_key]] = true

--- a/rack-protection/lib/rack/protection/base.rb
+++ b/rack-protection/lib/rack/protection/base.rb
@@ -8,6 +8,21 @@ require 'uri'
 
 module Rack
   module Protection
+    ##
+    # Base class for middlewares provided by rack-protection.
+    #
+    # == Options
+    #
+    # These may be given to any subclass, however they may affect different subclasses differently.
+    #
+    # [<tt>:reaction</tt>] - name of a method of the class that will be used to respond when the middleware rejects the response. Default behavior is to use #default_reaction.
+    # [<tt>:logging</tt>] - if true, debug and warning statements are sent to the logger.
+    # [<tt>:message</tt>] - if set, and <tt>:reaction</tt> has not been set, this is the text of the message sent to the client when the request is rejected. See DEFAULT_OPTIONS.
+    # [<tt>:session_key</tt>] - string to use as the key into <tt>env</tt> where the current session is stored. See DEFAULT_OPTIONS.
+    # [<tt>:status</tt>] - HTTP status to use when a request is rejected. See DEFAULT_OPTIONS.
+    # [<tt>:report_key</tt>] - key set in <tt>env</tt> if the request has been denied and <tt>:reaction</tt> is set to <tt>:report</tt> (see #report). See DEFAULT_OPTIONS.
+    # [<tt>:html_types</tt>] - Array of strings containing content types that are consider HTML for the purposes of this gem. See DEFAULT_OPTIONS.
+    #
     class Base
       DEFAULT_OPTIONS = {
         reaction: :default_reaction, logging: true,
@@ -20,10 +35,13 @@ module Rack
 
       attr_reader :app, :options
 
+      # Used by subclasses to declare default values for options they require. These defaults are merged onto the DEFAULT_OPTIONS provided by this class.
       def self.default_options(options)
         define_method(:default_options) { super().merge(options) }
       end
 
+      # Used by subclasses to declare default reaction when a request is rejected.  This replaces the default provided by this class.
+      # See #default_reaction.
       def self.default_reaction(reaction)
         alias_method(:default_reaction, reaction)
       end
@@ -79,11 +97,13 @@ module Rack
         i.instrument('rack.protection', env)
       end
 
+      # Deny the request.  Sends a content type of "text/plain" using the status and message set in the options.
       def deny(env)
         warn env, "attack prevented by #{self.class}"
         [options[:status], { 'content-type' => 'text/plain' }, [options[:message]]]
       end
 
+      # When used as a reaction (with option <tt>reaction: :report</tt>), any rejected request will be allowed through, and a warning is omitted (note that warnings will not be shown if the <tt>:logging</tt> option has been set to false).
       def report(env)
         warn env, "attack reported by #{self.class}"
         env[options[:report_key]] = true

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -8,7 +8,9 @@ module Rack
     # Prevented attack::   XSS and others
     # Supported browsers:: Firefox 23+, Safari 7+, Chrome 25+, Opera 15+
     #
-    # Description:: Content Security Policy, a mechanism web applications
+    # Sets the 'content-security-policy' or the 'content-security-policy-report-only]' header, based on options provided.
+    #
+    # Description:: Content Security Policy, is a mechanism web applications
     #               can use to mitigate a broad class of content injection
     #               vulnerabilities, such as cross-site scripting (XSS).
     #               Content Security Policy is a declarative policy that lets
@@ -16,25 +18,28 @@ module Rack
     #               inform the client about the sources from which the
     #               application expects to load resources.
     #
-    # More info::   W3C CSP Level 1 : https://www.w3.org/TR/CSP1/ (deprecated)
-    #               W3C CSP Level 2 : https://www.w3.org/TR/CSP2/ (current)
-    #               W3C CSP Level 3 : https://www.w3.org/TR/CSP3/ (draft)
-    #               https://developer.mozilla.org/en-US/docs/Web/Security/CSP
-    #               http://caniuse.com/#search=ContentSecurityPolicy
-    #               http://content-security-policy.com/
-    #               https://securityheaders.io
-    #               https://scotthelme.co.uk/csp-cheat-sheet/
-    #               http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+    # More info::   * W3C CSP Level 1 : https://www.w3.org/TR/CSP1/ (deprecated)
+    #               * W3C CSP Level 2 : https://www.w3.org/TR/CSP2/ (current)
+    #               * W3C CSP Level 3 : https://www.w3.org/TR/CSP3/ (draft)
+    #               * https://developer.mozilla.org/en-US/docs/Web/Security/CSP
+    #               * http://caniuse.com/#search=ContentSecurityPolicy
+    #               * http://content-security-policy.com/
+    #               * https://securityheaders.io
+    #               * https://scotthelme.co.uk/csp-cheat-sheet/
+    #               * http://www.html5rocks.com/en/tutorials/security/content-security-policy/
     #
-    # Sets the 'content-security-policy[-report-only]' header.
+    # == Options
     #
-    # Options: ContentSecurityPolicy configuration is a complex topic with
-    #          several levels of support that has evolved over time.
-    #          See the W3C documentation and the links in the more info
-    #          section for CSP usage examples and best practices. The
-    #          CSP3 directives in the 'NO_ARG_DIRECTIVES' constant need to be
-    #          presented in the options hash with a boolean 'true' in order
-    #          to be used in a policy.
+    # ContentSecurityPolicy configuration is a complex topic with
+    # several levels of support that has evolved over time.
+    # See the W3C documentation and the links in the more info
+    # section for CSP usage examples and best practices.
+    #
+    # [<tt>:report_only</tt>] - if true, the <tt>content-security-policy-report-only</tt> header is set, instead of <tt>content-security-policy</tt>. Note that in this case, you should also set the <tt>:report_uri</tt> option and the <tt>:report_to</tt> option.  If you *do* set <tt>:report_to</tt>, you must also set the `reporting-endpoints` header yourself.
+    #
+    # [<tt>:default_src</tt>] - sets the <tt>default-src</tt> directive, which acts as a fallback for any directive you don't specify. Default is <tt>'self'</tt>.
+    #
+    # [Any Supported CSP Directive, underscorized] - All supported CSP directives can be configured individually. See DIRECTIVES and NO_ARG_DIRECTIVES for a list of what is supported. Note that this list is not necessarly complete as the spec and browser behavior is constantly evovling (for example, <tt>script-src-elem</tt> is not supported).  Pass in an underscorized symbol. For example, to set the <tt>script-src</tt> directive, use <tt>:script_src</tt>.  The value should be whatever value you want set in the header. Note that for directives that do not take an argument, you must set their value to <tt>true</tt> to ensure they are set. See NO_ARG_DIRECTIVES. Note that <tt>'self'</tt> and <tt>'none'</tt> require single quotes and this middleware will not add them. For example, to disallow <tt>iframe</tt>s, you would need to use <tt>frame_src: "'none'"</tt>.
     #
     class ContentSecurityPolicy < Base
       default_options default_src: "'self'", report_only: false

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -8,7 +8,7 @@ module Rack
     # Prevented attack::   XSS and others
     # Supported browsers:: Firefox 23+, Safari 7+, Chrome 25+, Opera 15+
     #
-    # Sets the 'content-security-policy' or the 'content-security-policy-report-only]' header, based on options provided.
+    # Sets the 'content-security-policy' or the 'content-security-policy-report-only' header, based on options provided.
     #
     # Description:: Content Security Policy, is a mechanism web applications
     #               can use to mitigate a broad class of content injection

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -35,11 +35,32 @@ module Rack
     # See the W3C documentation and the links in the more info
     # section for CSP usage examples and best practices.
     #
-    # [<tt>:report_only</tt>] - if true, the <tt>content-security-policy-report-only</tt> header is set, instead of <tt>content-security-policy</tt>. Note that in this case, you should also set the <tt>:report_uri</tt> option and the <tt>:report_to</tt> option.  If you *do* set <tt>:report_to</tt>, you must also set the `reporting-endpoints` header yourself.
+    # [<tt>:report_only</tt>] - if true, the <tt>content-security-policy-report-only</tt>
+    #                           header is set, instead of <tt>content-security-policy</tt>. Note that 
+    #                           in this case, you should also set the <tt>:report_uri</tt> option and the 
+    #                           <tt>:report_to</tt> option.  If you *do* set <tt>:report_to</tt>, you must 
+    #                           also set the `reporting-endpoints` header yourself.
     #
-    # [<tt>:default_src</tt>] - sets the <tt>default-src</tt> directive, which acts as a fallback for any directive you don't specify. Default is <tt>'self'</tt>.
+    # [<tt>:default_src</tt>] - sets the <tt>default-src</tt> directive, which acts as a
+    #                           fallback for any directive you don't specify. Default is <tt>'self'</tt>.
     #
-    # [Any Supported CSP Directive, underscorized] - All supported CSP directives can be configured individually. See DIRECTIVES and NO_ARG_DIRECTIVES for a list of what is supported. Note that this list is not necessarly complete as the spec and browser behavior is constantly evovling (for example, <tt>script-src-elem</tt> is not supported).  Pass in an underscorized symbol. For example, to set the <tt>script-src</tt> directive, use <tt>:script_src</tt>.  The value should be whatever value you want set in the header. Note that for directives that do not take an argument, you must set their value to <tt>true</tt> to ensure they are set. See NO_ARG_DIRECTIVES. Note that <tt>'self'</tt> and <tt>'none'</tt> require single quotes and this middleware will not add them. For example, to disallow <tt>iframe</tt>s, you would need to use <tt>frame_src: "'none'"</tt>.
+    # [Any Supported CSP Directive, underscorized] - All supported CSP directives can be configured individually. See DIRECTIVES 
+    #                                                and NO_ARG_DIRECTIVES for a list of what is supported.
+    #
+    #                                                Note that this list is not necessarly complete as the spec and
+    #                                                browser behavior is constantly evolving (for example,
+    #                                                <tt>script-src-elem</tt> is not supported).
+    #                                                
+    #                                                Pass in an underscorized symbol. For example, to set the <tt>script-src</tt> 
+    #                                                directive, use <tt>:script_src</tt>.  The value should be whatever value you 
+    #                                                want set in the header.
+    #
+    #                                                Note that for directives that do not take an argument, you must set their 
+    #                                                value to <tt>true</tt> to ensure they are set. See NO_ARG_DIRECTIVES.
+    #                                                Note that <tt>'self'</tt> and <tt>'none'</tt> require 
+    #                                                single quotes and this middleware will not add them. For example, to 
+    #                                                disallow <tt>iframe</tt>s, you would need to use <tt>frame_src: 
+    #                                                "'none'"</tt>.
     #
     class ContentSecurityPolicy < Base
       default_options default_src: "'self'", report_only: false


### PR DESCRIPTION
# Problem(s)

* Base rack protection middleware does not document its options, and I found them hard to know about due to this absent documentation
* Formatting of `Rack::Protection::AuthenticityToken`s options rendered incorrectly (see screenshot)

   <img width="897" alt="Screenshot 2024-11-29 at 2 56 19 PM" src="https://github.com/user-attachments/assets/ff138d92-aea2-4632-ae0e-02af88e8f8e8">
* `Rack::Protection::ContentSecurityPolicy`'s docs were not specific as to the behavior of the class

# Solution

Updated the docs. I started to look at all the classes for a doc update, but decided to stop here as these addressed my issue and I wasn't sure if this sorts of changes would be accepted.  If they are, I would happy to refresh the docs in the other classes.
