### PR TITLE
Avoid crash for integer values in `content_type` parameters

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -398,7 +398,7 @@ module Sinatra
       unless params.empty?
         mime_type << (mime_type.include?(';') ? ', ' : ';')
         mime_type << params.map do |key, val|
-          val = val.inspect if val =~ /[";,]/
+          val = val.inspect if val.to_s =~ /[";,]/
           "#{key}=#{val}"
         end.join(', ')
       end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -181,5 +181,17 @@ class BaseTest < Minitest::Test
       response = request_content_length.get('/forward')
       assert_equal '28', response['Content-Length']
     end
+
+    it 'formats integer values correctly in Content-Type parameters' do
+      mock_app do
+        get('/') do
+          content_type "foo/bar", baz: 1
+          'Ok'
+        end
+      end
+
+      get '/'
+      assert_equal 'foo/bar;baz=1', response['Content-Type']
+    end
   end
 end


### PR DESCRIPTION
Here we only ensure that `=~` is applicable by calling `to_s` before using it.

Close https://github.com/sinatra/sinatra/issues/2077