### PR TITLE
fix (Sinatra::Helpers): remove null byte from provided address

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -338,7 +338,7 @@ module Sinatra
                 end
       end
       uri << request.script_name.to_s if add_script_name
-      uri << (addr || request.path_info).to_s
+      uri << (addr || request.path_info).to_s.delete("\u0000")
       File.join uri
     end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1899,6 +1899,12 @@ class HelpersTest < Minitest::Test
       get '/'
       assert_equal 'http://example.org/htt^p://google.com', body
     end
+
+    it 'handles null byte' do
+      mock_app { get('/') { uri "\u0000" }}
+      get '/'
+      assert_equal 'http://example.org/', body
+    end
   end
 
   describe 'logger' do


### PR DESCRIPTION
Closes https://github.com/sinatra/sinatra/issues/2080

## Context

Sinatra::Helpers#uri calls ruby File.join that does not expect that null bytes in its arguments
https://github.com/ruby/ruby/blob/master/string.c#L2836 - I suppose it's handled here

## Decision

Remove null byte from `addr` argument