### PR TITLE
Set `rubygems_mfa_required` for the `sinatra` gem

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -40,7 +40,8 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'homepage_uri' => 'http://sinatrarb.com/',
     'bug_tracker_uri' => 'https://github.com/sinatra/sinatra/issues',
     'mailing_list_uri' => 'http://groups.google.com/group/sinatrarb',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra'
+    'documentation_uri' => 'https://www.rubydoc.info/gems/sinatra',
+    'rubygems_mfa_required' => 'true',
   }
 
   s.required_ruby_version = '>= 2.7.8'


### PR DESCRIPTION
It is already set to true for sinatra-contrib and rack-protection, happened in https://github.com/sinatra/sinatra/pull/1537
