### PR TITLE
Add :static_headers setting for custom headers in static file responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,15 @@ Note that the public directory name is not included in the URL. A file
 Use the `:static_cache_control` setting (see [below](#cache-control)) to add
 `Cache-Control` header info.
 
+By default, Sinatra serves static files from the `public/` folder without running middleware or filters. To add custom headers (e.g, for CORS or caching), use the `:static_headers` setting:
+
+```ruby
+  set :static_headers, {
+    'Access-Control-Allow-Origin' => '*',
+    'X-Static-Asset' => 'served-by-sinatra'
+  }
+```
+
 ## Views / Templates
 
 Each template language is exposed via its own rendering method. These

--- a/README.md
+++ b/README.md
@@ -2171,7 +2171,7 @@ set :protection, :session => true
 
   <dt>static_headers</dt>
     <dd>
-      Allows you to define custom header settings for static file responses. Header keys should be lowercase (as required by Rack 3).
+      Allows you to define custom header settings for static file responses.
     </dd>
     <dd>
       For example: <br>

--- a/README.md
+++ b/README.md
@@ -427,8 +427,8 @@ By default, Sinatra serves static files from the `public/` folder without runnin
 
 ```ruby
   set :static_headers, {
-    'Access-Control-Allow-Origin' => '*',
-    'X-Static-Asset' => 'served-by-sinatra'
+    'access-control-allow-origin' => '*',
+    'x-static-asset' => 'served-by-sinatra'
   }
 ```
 
@@ -2168,6 +2168,16 @@ set :protection, :session => true
       Use an explicit array when setting multiple values:
       <tt>set :static_cache_control, [:public, :max_age => 300]</tt>
     </dd>
+
+  <dt>static_headers</dt>
+    <dd>
+      Allows you to define custom header settings for static file responses. Header keys should be lowercase (as required by Rack 3).
+    </dd>
+    <dd>
+      For example: <br>
+      <tt>set :static_headers, {'access-control-allow-origin' => '*', 'x-static-asset' => 'served-by-sinatra'}</tt>
+    </dd>
+
 
   <dt>threaded</dt>
     <dd>

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1155,8 +1155,6 @@ module Sinatra
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path
-
-      # Add caching if configured
       cache_control(*settings.static_cache_control) if settings.static_cache_control?
 
       if settings.respond_to?(:static_headers) && settings.static_headers

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1152,16 +1152,13 @@ module Sinatra
 
       path = File.expand_path(path)
       return unless path.start_with?("#{File.expand_path(public_dir)}/")
+
       return unless File.file?(path)
 
       env['sinatra.static_file'] = path
       cache_control(*settings.static_cache_control) if settings.static_cache_control?
 
-      if settings.respond_to?(:static_headers) && settings.static_headers
-        settings.static_headers.each do |k, v|
-          headers[k] = v
-        end
-      end
+      headers(settings.static_headers) if settings.static_headers?
 
       send_file path, options.merge(disposition: nil)
     end

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -289,4 +289,32 @@ class StaticTest < Minitest::Test
     assert_equal 'yes', response['X-Static-Test']
   end
 
+  it 'does not apply static headers when static_headers is not set' do
+    mock_app do
+      set :static, true
+      set :public_folder, __dir__
+      # no static_headers
+    end
+
+    get "/#{File.basename(__FILE__)}"
+    assert ok?
+    assert_nil response['Access-Control-Allow-Origin']
+    assert_nil response['X-Static-Test']
+  end
+
+  it 'respects both static_cache_control and static_headers settings together' do
+    mock_app do
+      set :static, true
+      set :public_folder, __dir__
+      set :static_cache_control, [:public, max_age: 3600]
+      set :static_headers, { 'X-Static-Test' => 'yes' }
+    end
+
+    get "/#{File.basename(__FILE__)}"
+    assert ok?
+    assert_equal 'yes', response['X-Static-Test']
+    assert_includes response['Cache-Control'], 'public'
+    assert_match(/max-age=3600/, response['Cache-Control'])
+  end
+
 end

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -278,8 +278,8 @@ class StaticTest < Minitest::Test
       set :static, true
       set :public_folder, __dir__
       set :static_headers, {
-        'Access-Control-Allow-Origin' => '*',
-        'X-Static-Test' => 'yes'
+        'access-control-allow-origin' => '*',
+        'x-static-test' => 'yes'
       }
     end
 
@@ -289,25 +289,12 @@ class StaticTest < Minitest::Test
     assert_equal 'yes', response['X-Static-Test']
   end
 
-  it 'does not apply static headers when static_headers is not set' do
-    mock_app do
-      set :static, true
-      set :public_folder, __dir__
-      # no static_headers
-    end
-
-    get "/#{File.basename(__FILE__)}"
-    assert ok?
-    assert_nil response['Access-Control-Allow-Origin']
-    assert_nil response['X-Static-Test']
-  end
-
   it 'respects both static_cache_control and static_headers settings together' do
     mock_app do
       set :static, true
       set :public_folder, __dir__
       set :static_cache_control, [:public, max_age: 3600]
-      set :static_headers, { 'X-Static-Test' => 'yes' }
+      set :static_headers, { 'x-static-test' => 'yes' }
     end
 
     get "/#{File.basename(__FILE__)}"

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -273,4 +273,20 @@ class StaticTest < Minitest::Test
     assert response.headers.include?('Last-Modified')
   end
 
+  it 'applies custom headers defined in static_headers setting' do
+    mock_app do
+      set :static, true
+      set :public_folder, __dir__
+      set :static_headers, {
+        'Access-Control-Allow-Origin' => '*',
+        'X-Static-Test' => 'yes'
+      }
+    end
+
+    get "/#{File.basename(__FILE__)}"
+    assert ok?
+    assert_equal '*', response['Access-Control-Allow-Origin']
+    assert_equal 'yes', response['X-Static-Test']
+  end
+
 end

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -285,8 +285,8 @@ class StaticTest < Minitest::Test
 
     get "/#{File.basename(__FILE__)}"
     assert ok?
-    assert_equal '*', response['Access-Control-Allow-Origin']
-    assert_equal 'yes', response['X-Static-Test']
+    assert_equal '*', response['access-control-allow-origin']
+    assert_equal 'yes', response['x-static-test']
   end
 
   it 'respects both static_cache_control and static_headers settings together' do
@@ -299,9 +299,9 @@ class StaticTest < Minitest::Test
 
     get "/#{File.basename(__FILE__)}"
     assert ok?
-    assert_equal 'yes', response['X-Static-Test']
-    assert_includes response['Cache-Control'], 'public'
-    assert_match(/max-age=3600/, response['Cache-Control'])
+    assert_equal 'yes', response['x-static-test']
+    assert_includes response['cache-control'], 'public'
+    assert_match(/max-age=3600/, response['cache-control'])
   end
 
 end


### PR DESCRIPTION
## Description 
This PR implements recent feature request related to static file responses. It introduces a new configuration setting, `:static_headers`, which allows developers to define custom headers that will be applied to all static file responses served by `static!` -method.

## Why?
Fixes #2088
Sinatra serves static files directly via `static!`, bypassing filters and middleware. This makes it so that there is no good ways to add headers like `Access-Control-Allow-Origin`, which are often needed for CORS access (e.g., when using fonts or images on canvas).