### PR TITLE
Document options and behavior for `Rack::Protection::EscapedParams`

### DIFF
--- a/rack-protection/lib/rack/protection/escaped_params.rb
+++ b/rack-protection/lib/rack/protection/escaped_params.rb
@@ -16,12 +16,57 @@ module Rack
     # Supported browsers:: all
     # More infos::         http://en.wikipedia.org/wiki/Cross-site_scripting
     #
-    # Automatically escapes Rack::Request#params so they can be embedded in HTML
+    # Automatically escapes <tt>Rack::Request#params</tt> so they can be embedded in HTML
     # or JavaScript without any further issues.
     #
-    # Options:
-    # escape:: What escaping modes to use, should be Symbol or Array of Symbols.
-    #          Available: :html (default), :javascript, :url
+    # == Options
+    #
+    # [<tt>:escape</tt>] What escaping modes to use. Should be Symbol or Array of Symbols of one of the following:
+    #                    <tt>:html</tt>:: escape HTML
+    #                    <tt>:url</tt>:: escape URLs
+    #                    <tt>:javascript</tt>:: escape JavaScript (requires the <tt>escape_utils</tt>
+    #                                           gem or a custom <tt>:escaper</tt>).
+    #
+    #                    Default is <tt>:html</tt>.
+    #
+    # [<tt>:escaper</tt>] Object to use for escaping. It must respond to the following methods:
+    #                     <tt>#escape_url</tt>:: if <tt>:escape</tt> is or contains <tt>:url</tt>
+    #                     <tt>#escape_html</tt>:: if <tt>:escape</tt> is or contains <tt>:html</tt>
+    #                     <tt>#escape_javascript</tt>:: if <tt>:escape</tt> is or contains <tt>:javascript</tt>
+    #
+    #                     By default, this class is used for escaping, however this class
+    #                     does not implement <tt>#escape_javascript</tt>.  If <tt>:escape</tt> is
+    #                     or includes <tt>:javascript</tt>, an exception will be raised.
+    #
+    #                     To avoid this, include the {<tt>escape_utils</tt>}[https://rubygems.org/gems/escape_utils]
+    #                     gem in your app, *or* provide your own <tt>:escaper</tt> object.
+    #
+    # [Rack::Protection::Base options] any option supported by Rack::Protection::Base.
+    #
+    # == Example: Default usage
+    #
+    #     use Rack::Protection::EscapedParams
+    #
+    # == Example: Escape URLs and HTML
+    #
+    #     use Rack::Protection::EscapedParams, escape: [:html, :url]
+    #
+    # == Example: Escape everything using custom escaper
+    #
+    #    module MyEscaper
+    #      def self.escape_url(str)
+    #        # your custom code here
+    #      end
+    #      def self.escape_html(str)
+    #        # your custom code here
+    #      end
+    #      def self.escape_javascrtip(str)
+    #        # your custom code here
+    #      end
+    #    end
+    #    
+    #    use Rack::Protection::EscapedParams, escape: [:html, :url, :javascript],
+    #                                         escaper: MyEscaper
     class EscapedParams < Base
       extend Rack::Utils
 


### PR DESCRIPTION
# Problem

The behavior and options for `Rack::Protection::EscapedParams` aren't fully documented.

# Solution

* Reformat options header to match other classes
* Document `:escaper`
* Document how `escape_javascript` works and the optional dependency on the `escape_utils` gem
* Provide examples
