### PR TITLE
slightly improve docs for `Rack::Protection::FrameOptions`

### DIFF
--- a/rack-protection/lib/rack/protection/frame_options.rb
+++ b/rack-protection/lib/rack/protection/frame_options.rb
@@ -6,18 +6,46 @@ module Rack
   module Protection
     ##
     # Prevented attack::   Clickjacking
-    # Supported browsers:: Internet Explorer 8, Firefox 3.6.9, Opera 10.50,
-    #                      Safari 4.0, Chrome 4.1.249.1042 and later
-    # More infos::         https://developer.mozilla.org/en/The_X-FRAME-OPTIONS_response_header
+    # Supported browsers:: * Chrome 26 and later
+    #                      * Edge 12 and later
+    #                      * Safari 5.1 and later
+    #                      * Mobile Safari 7 and later
+    #                      * Firefox 4 and later
+    #                      * Internet Explorer 8 and later
+    #                      * See full details at https://caniuse.com/mdn-http_headers_content-security-policy_frame-ancestors
+    # More info::          * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options
+    #                      * https://caniuse.com/x-frame-options
     #
     # Sets X-Frame-Options header to tell the browser avoid embedding the page
-    # in a frame.
+    # in a frame. Note that in modern browsers, the preferred approach is to use the
+    # {frame-ancestors directive}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors]
+    # in your content security policy.
     #
-    # Options:
+    # Notes:
     #
-    # frame_options:: Defines who should be allowed to embed the page in a
-    #                 frame. Use :deny to forbid any embedding, :sameorigin
-    #                 to allow embedding from the same origin (default).
+    # * This middleware won't do anything for non-HTML responses.
+    # * If your app sets <tt>X-Frame-Options</tt> header, this middleware will not override it.
+    #
+    # == Options
+    #
+    # [<tt>:frame_options</tt>] Defines who should be allowed to embed the page in a
+    #                           frame.
+    #                           [<tt>:deny</tt>] forbid any embedding
+    #                           [<tt>:sameorigin</tt>] allow embedding from the same origin
+    #
+    #                           The default is <tt>:sameorigin</tt>.
+    #
+    # [Rack::Protection::Base options] options supported by Rack::Protection::Base may affect this middleware.
+    #
+    # == Example: Default behavior
+    #
+    #     # Embedding from same origin is allowed
+    #     use Rack::Protection::FrameOptions 
+    #
+    # == Example: Deny embedding
+    #
+    #     # Embedding is not allowed
+    #     use Rack::Protection::FrameOptions, frame_options: :deny
     class FrameOptions < Base
       default_options frame_options: :sameorigin
 


### PR DESCRIPTION
# Problem

`Rack::Protection::FrameOptions` docs could use a refresh, given that this technique is not generally  needed in modern browsers.

# Solution

* Change options header to match other classes
* Expand and clarify options docs
* Show examples
* Update supported browsers and provide links to detailed compatibility info + alternatives