### PR TITLE
Add additionally-supported CSP directives not listed in `Rack::Protection::ContentSecurityPolicy`

### DIFF
--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -39,35 +39,75 @@ module Rack
     class ContentSecurityPolicy < Base
       default_options default_src: "'self'", report_only: false
 
-      DIRECTIVES = %i[base_uri child_src connect_src default_src
-                      font_src form_action frame_ancestors frame_src
-                      img_src manifest_src media_src object_src
-                      plugin_types referrer reflected_xss report_to
-                      report_uri require_sri_for sandbox script_src
-                      style_src worker_src webrtc_src navigate_to
-                      prefetch_src].freeze
+      # Please try to maintain this
+      # list from https://www.w3.org/TR/CSP3/#csp-directives
+      SUPPORTED_DIRECTIVES = %i[
+        child_src
+        connect_src
+        default_src
+        font_src
+        frame_src
+        img_src
+        manifest_src
+        media_src
+        object_src
+        script_src
+        script_src_elem
+        script_src_attr
+        style_src
+        style_src_elem
+        style_src_attr
+        webrtc
+        worker_src
+        base_uri
+        sandbox
+        form_action
+        frame_ancestors
+        report_uri
+        report_to
+        upgrade_insecure_requests
+      ].freeze
 
-      NO_ARG_DIRECTIVES = %i[block_all_mixed_content disown_opener
-                             upgrade_insecure_requests].freeze
+      DEPRECATED_DIRECTIVES = [
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/block-all-mixed-content
+        :block_all_mixed_content,
+        # https://github.com/w3c/webappsec-csp/issues/194
+        :disown_opener,
+        # https://github.com/w3c/webappsec-csp/pull/456
+        :plugin_types,
+        # https://web.archive.org/web/20250320135738/https://centralcsp.com/directives/referrer
+        :referrer,
+        # https://security.stackexchange.com/questions/223022/what-was-the-real-reason-for-dropping-reflected-xss-directive-from-csp
+        :reflected_xss,
+        # https://udn.realityripple.com/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for https://security.stackexchange.com/questions/180450/why-does-chrome-tell-me-that-the-csp-require-sri-for-directive-is-implemented
+        :require_sri_for,
+        :webrtc_src,
+        # https://content-security-policy.com/navigate-to/
+        :navigate_to,
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/prefetch-src
+        :prefetch_src,
+      ].freeze
+
+      DIRECTIVES = (SUPPORTED_DIRECTIVES + DEPRECATED_DIRECTIVES).freeze
+      NO_ARG_DIRECTIVES = [
+        :disown_opener,
+        :block_all_mixed_content,
+        :upgrade_insecure_requests,
+      ]
 
       def csp_policy
         directives = []
 
-        DIRECTIVES.each do |d|
+        DIRECTIVES.each do |d,type|
           if options.key?(d)
-            directives << "#{d.to_s.sub(/_/, '-')} #{options[d]}"
+            if NO_ARG_DIRECTIVES.include?(d)
+              if options[d].is_a?(TrueClass)
+                directives << d.to_s.tr('_', '-')
+              end
+            else
+              directives << "#{d.to_s.sub(/_/, '-')} #{options[d]}"
+            end
           end
-        end
-
-        # Set these key values to boolean 'true' to include in policy
-        NO_ARG_DIRECTIVES.each do |d|
-          if options.key?(d) && options[d].is_a?(TrueClass)
-            directives << d.to_s.tr('_', '-')
-          end
-        end
-
-        (options[:custom_directives] ||{}).each do |d,value|
-          directives << "#{d.to_s.gsub(/_/, '-')} #{value}"
         end
 
         directives.compact.sort.join('; ')

--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -66,6 +66,10 @@ module Rack
           end
         end
 
+        (options[:custom_directives] ||{}).each do |d,value|
+          directives << "#{d.to_s.gsub(/_/, '-')} #{value}"
+        end
+
         directives.compact.sort.join('; ')
       end
 

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -65,19 +65,4 @@ RSpec.describe Rack::Protection::ContentSecurityPolicy do
     mock_app with_headers('content-security-policy' => 'default-src: none')
     expect(get('/', {}, 'wants' => 'text/html').headers['Content-Security-Policy']).to eq('default-src: none')
   end
-
-  it 'should allow directives not in the pre-determined list' do
-    mock_app do
-      use Rack::Protection::ContentSecurityPolicy, custom_directives: {
-        script_src_elem: 'https://example.com',
-        style_src_attr: 'https://example.com',
-      }
-
-      run DummyApp
-    end
-
-    headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers['Content-Security-Policy']).to eq("default-src 'self'; script-src-elem https://example.com; style-src-attr https://example.com")
-    expect(headers['Content-Security-Policy-Report-Only']).to be_nil
-  end
 end

--- a/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/rack-protection/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -65,4 +65,19 @@ RSpec.describe Rack::Protection::ContentSecurityPolicy do
     mock_app with_headers('content-security-policy' => 'default-src: none')
     expect(get('/', {}, 'wants' => 'text/html').headers['Content-Security-Policy']).to eq('default-src: none')
   end
+
+  it 'should allow directives not in the pre-determined list' do
+    mock_app do
+      use Rack::Protection::ContentSecurityPolicy, custom_directives: {
+        script_src_elem: 'https://example.com',
+        style_src_attr: 'https://example.com',
+      }
+
+      run DummyApp
+    end
+
+    headers = get('/', {}, 'wants' => 'text/html').headers
+    expect(headers['Content-Security-Policy']).to eq("default-src 'self'; script-src-elem https://example.com; style-src-attr https://example.com")
+    expect(headers['Content-Security-Policy-Report-Only']).to be_nil
+  end
 end


### PR DESCRIPTION
# Problem

`Rack::Protection::ContentSecurityPolicy` itemizes out the directives it will include in the header, however this list is missing some standard directives, such as `script-src-elem`.

This means you cannot use this middleware if you want to set those directives in your CSP header.

# Solution

I was not sure what made the most sense.  At first, I thought to add the missing directives to the list inside the class.  But then this list would need to be maintained.

Allowing *any* option to be a CSP directive doesn't exactly work since options for the middleware that aren't directives could not be distinguishes from options that *are* directives.

So what I did was a somewhat naive implementation that adds a `custom_directives` option.

```ruby
use Rack::Protection::ContentSecurityPolicy, custom_directives: {
  script_src_elem: 'https://example.com',
  style_src_attr: 'https://example.com',
}
```

I've only made one test and the impl, no doc updates or refactoring or anything.  Does this seem useful/reasonable?  Or would it be better to just add the missing directives?