### PR TITLE
Revert "`PATH_INFO` can never be empty."

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1099,6 +1099,7 @@ module Sinatra
     # Returns pass block.
     def process_route(pattern, conditions, block = nil, values = [])
       route = @request.path_info
+      route = '/' if route.empty? && !settings.empty_path_info?
       route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
 
       params = pattern.params(route)
@@ -1775,6 +1776,7 @@ module Sinatra
       end
 
       def route(verb, path, options = {}, &block)
+        enable :empty_path_info if path == '' && empty_path_info.nil?
         signature = compile!(verb, path, block, **options)
         (@routes[verb] ||= []) << signature
         invoke_hook(:route_added, verb, path, block)
@@ -2000,6 +2002,7 @@ module Sinatra
 
     set :absolute_redirects, true
     set :prefixed_redirects, false
+    set :empty_path_info, nil
     set :strict_paths, true
 
     set :app_file, nil

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -245,6 +245,42 @@ class RoutingTest < Minitest::Test
     assert_equal 404, status
   end
 
+  it 'matches empty PATH_INFO to "/" if no route is defined for ""' do
+    mock_app do
+      get '/' do
+        'worked'
+      end
+    end
+
+    get '/', {}, "PATH_INFO" => ""
+    assert ok?
+    assert_equal 'worked', body
+  rescue Rack::Lint::LintError => error
+    # Temporary fix for https://github.com/sinatra/sinatra/issues/2113
+    skip error.message
+  end
+
+  it 'matches empty PATH_INFO to "" if a route is defined for ""' do
+    mock_app do
+      disable :protection
+
+      get '/' do
+        'did not work'
+      end
+
+      get '' do
+        'worked'
+      end
+    end
+
+    get '/', {}, "PATH_INFO" => ""
+    assert ok?
+    assert_equal 'worked', body
+  rescue Rack::Lint::LintError => error
+    # Temporary fix for https://github.com/sinatra/sinatra/issues/2113
+    skip error.message
+  end
+
   it 'takes multiple definitions of a route' do
     mock_app {
       user_agent(/Foo/)


### PR DESCRIPTION
This reverts commit fa99a21461d4f1f5337b9b9d7a38a1b51c8f4e55.

It causes problems, if you have an app like this

    class FooApp < Sinatra::Base
      get "/" do
        "hello foo"
      end
    end

and map it like this in config.ru

    map("/foo") { run FooApp.new }

`GET /foo` returns 404, which was not the case before. 
`GET /foo/` does reach the app.

Reported at https://github.com/sinatra/sinatra/issues/2113#issuecomment-3388476329