### PR TITLE
Fix regex in etag_matches? to prevent ReDoS in 3.2-stable

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -702,7 +702,7 @@ module Sinatra
     def etag_matches?(list, new_resource = request.post?)
       return !new_resource if list == '*'
 
-      list.to_s.split(/\s*,\s*/).include? response['ETag']
+      list.to_s.split(',').map(&:strip).include?(response['ETag'])
     end
 
     def with_params(temp_params)


### PR DESCRIPTION
Hi!

This is a backport to 3.2-stable for CVE-2025-61921 from https://github.com/sinatra/sinatra/issues/2120

Thanks!