### PR TITLE
Fix RDoc 6.16+ compatibility by relaxing the check

### DIFF
--- a/test/rdoc_test.rb
+++ b/test/rdoc_test.rb
@@ -16,13 +16,13 @@ class RdocTest < Minitest::Test
   it 'renders inline rdoc strings' do
     rdoc_app { rdoc '= Hiya' }
     assert ok?
-    assert_body(/<h1[^>]*>Hiya(<span><a href=\"#label-Hiya\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/)
+    assert_body(/<h1[^>]*>(<.*>)?Hiya(<.*>)?<\/h1>/)
   end
 
   it 'renders .rdoc files in views path' do
     rdoc_app { rdoc :hello }
     assert ok?
-    assert_body(/<h1[^>]*>Hello From RDoc(<span><a href=\"#label-Hello\+From\+RDoc\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/)
+    assert_body(/<h1[^>]*>(<.*>)?Hello From RDoc(<.*>)?<\/h1>/)
   end
 
   it "raises error if template not found" do


### PR DESCRIPTION
With RDoc 6.16.0, the following test started to fail:

~~~
  1) Failure:
RdocTest#test_renders_inline_rdoc_strings_0 [test/rdoc_test.rb:19]: Expected /<h1[^>]*>Hiya(<span><a href=\"#label-Hiya\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/ to match # encoding: ASCII-8BIT
#    valid: true
"\n<h1 id=\"label-Hiya\"><a href=\"#label-Hiya\">Hiya</a></h1>\n".

  2) Failure:
RdocTest#test_renders_rdoc_files_in_views_path_0 [test/rdoc_test.rb:25]: Expected /<h1[^>]*>Hello From RDoc(<span><a href=\"#label-Hello\+From\+RDoc\">&para;<\/a> <a href=\"#(documentation|top)\">&uarr;<\/a><\/span>)?<\/h1>/ to match # encoding: ASCII-8BIT
#    valid: true
"\n<h1 id=\"label-Hello+From+RDoc\"><a href=\"#label-Hello+From+RDoc\">Hello From RDoc</a></h1>\n".
~~~

and it is caused by this change: https://github.com/ruby/rdoc/pull/1465

The error happens due to over-prescriptive RDoc check, it seems. Looking into history, it seems the intention was just to check if RDoc works. However, the check later started to look too much into details of rendering.

Therefore, relax the check to look only for know text and basic formatting and leave the rest as RDoc implementation detail.

Fixes #2131