### PR TITLE
Remove dead code in `redirect` method

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -308,9 +308,7 @@ module Sinatra
 
     # Halt processing and redirect to the URI provided.
     def redirect(uri, *args)
-      # SERVER_PROTOCOL is required in Rack 3, fall back to HTTP_VERSION
-      # for servers not updated for Rack 3 (like Puma 5)
-      http_version = env['SERVER_PROTOCOL'] || env['HTTP_VERSION']
+      http_version = env['SERVER_PROTOCOL']
       if (http_version == 'HTTP/1.1') && (env['REQUEST_METHOD'] != 'GET')
         status 303
       else


### PR DESCRIPTION
Sinatra 4 require Rack 3, so it will never be used with servers not updated for Rack 3, hence we never need to fall back to `HTTP_VERSION`.

Related Puma PRs

* https://github.com/puma/puma/pull/2871
* https://github.com/puma/puma/pull/3706
* https://github.com/puma/puma/pull/3711

Close https://github.com/sinatra/sinatra/issues/2074