### PR TITLE
-- Fix #2138: Read version from version.rb to fix Bundler vendoring

### DIFF
--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-version_file = File.expand_path('lib/rack/protection/version.rb', __dir__)
-version = File.read(version_file)[/VERSION = ['"](.+?)['"]/, 1]
+require_relative 'lib/rack/protection/version'
 
 Gem::Specification.new do |s|
   # general infos
   s.name        = 'rack-protection'
-  s.version     = version
+  s.version     = Rack::Protection::VERSION
   s.description = 'Protect against typical web attacks, works with all Rack apps, including Rails'
   s.homepage    = 'https://sinatrarb.com/protection/'
   s.summary     = "#{s.description}."

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-version = File.read(File.expand_path('../VERSION', __dir__)).strip
+version_file = File.expand_path('lib/rack/protection/version.rb', __dir__)
+version = File.read(version_file)[/VERSION = ['"](.+?)['"]/, 1]
 
 Gem::Specification.new do |s|
   # general infos

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-version = File.read(File.expand_path('../VERSION', __dir__)).strip
+version_file = File.expand_path('lib/sinatra/contrib/version.rb', __dir__)
+version = File.read(version_file)[/VERSION = ['"](.+?)['"]/, 1]
 
 Gem::Specification.new do |s|
   s.name        = 'sinatra-contrib'

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-version_file = File.expand_path('lib/sinatra/contrib/version.rb', __dir__)
-version = File.read(version_file)[/VERSION = ['"](.+?)['"]/, 1]
+require_relative 'lib/sinatra/contrib/version'
+
+version = Sinatra::Contrib::VERSION
 
 Gem::Specification.new do |s|
   s.name        = 'sinatra-contrib'


### PR DESCRIPTION
**The Problem**
When using Bundler's bundle package to vendor/cache gems, sinatra-contrib and rack-protection gemspecs failed with:
No such file or directory @ rb_sysopen - /path/to/vendor/cache/VERSION
Both gemspecs read the version from a parent VERSION file using ../VERSION. When Bundler copies gems to vendor/cache, the parent directory structure doesn't exist, so ../VERSION points to a non-existent file.

This affected anyone trying to:
Use bundle package to cache gems locally

Vendor gems for deployment
Use Bundler's caching features in CI/CD pipelines

**The Solution**
Instead of reading from a parent VERSION file, the gemspecs now read the version directly from the version.rb files that already exist in each gem's lib/ directory:
sinatra-contrib.gemspec → reads from lib/sinatra/contrib/version.rb
rack-protection.gemspec → reads from lib/rack/protection/version.rb


Fix for: [issue](https://github.com/sinatra/sinatra/issues/2138)