### PR TITLE
Only process route in filters if required

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1055,8 +1055,14 @@ module Sinatra
     def filter!(type, base = settings, &block)
       filter!(type, base.superclass, &block) if base.superclass.respond_to?(:filters)
       base.filters[type].each do |args|
-        result = process_route(*args)
-        block.call(result) if block_given?
+        if block_given?
+          if block.arity == 1
+            result = process_route(*args)
+            block.call(result)
+          else
+            block.call
+          end
+        end
       end
     end
 
@@ -2013,7 +2019,7 @@ module Sinatra
     set :public_folder, proc { root && File.join(root, 'public') }
     set :static, proc { public_folder && File.exist?(public_folder) }
     set :static_cache_control, false
-    
+
     set :static_headers, {}
 
     error ::Exception do


### PR DESCRIPTION
Currently `process_route` is called for each defined filter. If a filter doesn't use the processed route argument, there is no need to calculate it.

For a simple json call with 3 empty filters, the route parsing takes up significant resources:

## Before

<img width="1004" height="424" alt="image" src="https://github.com/user-attachments/assets/66aa37b4-a682-4d48-a76b-b987ce73f892" />

## After

<img width="1315" height="595" alt="image" src="https://github.com/user-attachments/assets/5e6400c7-45a1-444f-ada4-5ab2cd2c829c" />
