### PR TITLE
docs: replace dead Sinatra book link in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,9 @@ track patch requests.
   is where the website sources are managed. There are almost always people in
   `#sinatra` that are happy to discuss, apply, and publish website patches.
 
-* [The Book](http://sinatra-org-book.herokuapp.com/) has its own [Git
-  repository](http://github.com/sinatra/sinatra-book/) and build process but is
-  managed the same as the website and project codebase.
+* [The Book](https://github.com/sinatra/sinatra-book) has its own Git
+  repository and build process but is managed the same as the website and
+  project codebase.
 
 * [Sinatra Recipes](http://recipes.sinatrarb.com/) is a community
   project where anyone is free to contribute ideas, recipes and tutorials. Which


### PR DESCRIPTION
## Summary

This PR updates a dead documentation link in `CONTRIBUTING.md`.

- Replaces the obsolete Sinatra Book link (`sinatra-org-book.herokuapp.com`) that now returns **"No such app"**.
- Points contributors directly to the maintained Sinatra Book repository:
  - `https://github.com/sinatra/sinatra-book`

## Why this change

The current contributing guide links to an unavailable host, which creates confusion for new contributors looking for official docs resources.

There is already an open issue tracking this exact docs problem:
- https://github.com/sinatra/sinatra/issues/2118

This patch keeps the same intent and wording while updating the destination to a stable source of truth.

## Scope

- **Docs only** (`CONTRIBUTING.md`)
- No runtime, API, gemspec, or test changes.

## Validation

- Manually verified the old URL is no longer available (returns “No such app”).
- Confirmed the new URL resolves to the Sinatra Book repository.
- Reviewed rendered markdown diff for readability and consistency with existing style.

## Backward compatibility

No behavior changes. This is a documentation-only fix.
