### PR TITLE
fix: raise BadRequest for null byte in uri/url helper

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -337,7 +337,11 @@ module Sinatra
       end
       uri << request.script_name.to_s if add_script_name
       uri << (addr || request.path_info).to_s
-      File.join uri
+      File.join(uri)
+    rescue ArgumentError => e
+      raise BadRequest, "Invalid URI: #{Rack::Utils.escape_html(e.message)}" if e.message.include?('null byte')
+
+      raise
     end
 
     alias url uri

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1899,6 +1899,13 @@ class HelpersTest < Minitest::Test
       get '/'
       assert_equal 'http://example.org/htt^p://google.com', body
     end
+
+    it 'raises BadRequest for null-byte input in uri helper' do
+      mock_app { get('/') { uri params[:foo] }}
+      get '/', { 'foo' => "\u0000" }
+      assert_equal 400, status
+      assert_includes body, 'Invalid URI: string contains null byte'
+    end
   end
 
   describe 'logger' do


### PR DESCRIPTION
## Summary

Fixes #2080 by handling null-byte failures in the `uri`/`url` helper with a Sinatra-level `BadRequest` instead of leaking a raw `ArgumentError` from `File.join`.

## Problem

When user input includes a null byte (for example `/?foo=%00`) and application code calls:

```ruby
url(params[:foo])
# or
uri(params[:foo])
```

the helper can currently blow up with:

- `ArgumentError: string contains null byte`
- stack trace pointing into `File.join`

This looks like an internal Sinatra crash instead of a handled client error.

## What changed

### 1) `lib/sinatra/base.rb`

Inside `Helpers#uri`:

- wrapped `File.join(...)` with rescue handling for `ArgumentError`
- when the error message includes `null byte`, we now raise:
  - `Sinatra::BadRequest`
  - message: `Invalid URI: string contains null byte` (HTML-escaped via `Rack::Utils.escape_html`)
- other `ArgumentError` cases are re-raised unchanged

This keeps behavior narrow and avoids swallowing unrelated argument errors.

### 2) `test/helpers_test.rb`

Added regression coverage:

- `raises BadRequest for null-byte input in uri helper`
- verifies response status `400`
- verifies body includes `Invalid URI: string contains null byte`

## Validation

### Automated (targeted)

Executed in Ruby 3.3 Docker environment:

```bash
bundle exec ruby -Itest test/helpers_test.rb
```

Result:

- `274 runs, 416 assertions`
- `0 failures, 0 errors`

### Manual reproduction

Using `Rack::MockRequest` against a minimal Sinatra app:

```ruby
get('/') { uri(params[:foo]) }
```

Request:

```bash
GET /?foo=%00
```

Observed result after fix:

- `STATUS=400`
- `BODY=Invalid URI: string contains null byte`

## Compatibility / risk

- No API signature changes.
- Only affects the null-byte `ArgumentError` path in `uri`/`url` helper.
- Existing valid URI behavior is unchanged.
