### PR TITLE
test: enable valid empty PATH_INFO mounted scenarios

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -245,22 +245,19 @@ class RoutingTest < Minitest::Test
     assert_equal 404, status
   end
 
-  it 'matches empty PATH_INFO to "/" if no route is defined for ""' do
+  it 'matches empty PATH_INFO to "/" if no route is defined for "" (valid with SCRIPT_NAME)' do
     mock_app do
       get '/' do
         'worked'
       end
     end
 
-    get '/', {}, "PATH_INFO" => ""
+    get '/', {}, "SCRIPT_NAME" => "/mounted", "PATH_INFO" => ""
     assert ok?
     assert_equal 'worked', body
-  rescue Rack::Lint::LintError => error
-    # Temporary fix for https://github.com/sinatra/sinatra/issues/2113
-    skip error.message
   end
 
-  it 'matches empty PATH_INFO to "" if a route is defined for ""' do
+  it 'matches empty PATH_INFO to "" if a route is defined for "" (valid with SCRIPT_NAME)' do
     mock_app do
       disable :protection
 
@@ -273,12 +270,9 @@ class RoutingTest < Minitest::Test
       end
     end
 
-    get '/', {}, "PATH_INFO" => ""
+    get '/', {}, "SCRIPT_NAME" => "/mounted", "PATH_INFO" => ""
     assert ok?
     assert_equal 'worked', body
-  rescue Rack::Lint::LintError => error
-    # Temporary fix for https://github.com/sinatra/sinatra/issues/2113
-    skip error.message
   end
 
   it 'takes multiple definitions of a route' do


### PR DESCRIPTION
## Summary

This PR updates the two temporary-skipped tests around empty `PATH_INFO` to use a **valid Rack scenario**:

- `PATH_INFO == ""`
- `SCRIPT_NAME` is non-empty (mounted app case)

This addresses the intent in #2113 while avoiding invalid env combinations that trigger `Rack::Lint` errors.

## Background

In Rack, an empty `PATH_INFO` can be valid when the request path is fully consumed by `SCRIPT_NAME` (e.g. mounted under `Rack::URLMap` / `map`).

The previous tests used `PATH_INFO == ""` with effectively empty script-name context and therefore wrapped assertions in temporary `skip` behavior on `Rack::Lint::LintError`.

## What changed

File: `test/routing_test.rb`

- Updated both empty `PATH_INFO` tests to send:
  - `SCRIPT_NAME` => `"/mounted"`
  - `PATH_INFO` => `""`
- Removed temporary rescue/skip blocks for `Rack::Lint::LintError`.
- Clarified test descriptions to indicate the mounted-valid scenario.

## Why this is better

- Tests now represent a realistic and Rack-valid mounted routing case.
- No temporary skip behavior; tests assert expected behavior directly.
- Keeps coverage for both:
  1. empty `PATH_INFO` mapping to `/` when no empty-route exists
  2. empty `PATH_INFO` mapping to `""` when empty-route exists

## Validation

### Targeted test run

```bash
docker run --rm -v "$PWD":/app -w /app ruby:3.3 \
  bash -lc 'bundle install >/tmp/bundle.log && bundle exec ruby -Itest test/routing_test.rb'
```

Result:

- `120 runs, 404 assertions`
- `0 failures, 0 errors, 0 skips`

### Manual verification (mounted empty `PATH_INFO`)

Ran a `Rack::MockRequest` script with:

- App A defines both `get '/'` and `get ''`  
  => `SCRIPT_NAME=/mounted, PATH_INFO=""` returns `200` body `empty`
- App B defines only `get '/'`  
  => `SCRIPT_NAME=/mounted, PATH_INFO=""` returns `200` body `root`

This matches expected mounted behavior and the updated tests.

Closes #2113
