### PR TITLE
docs: add more Rack::Protection usage examples

### DIFF
--- a/rack-protection/README.md
+++ b/rack-protection/README.md
@@ -32,6 +32,62 @@ use Rack::Protection::AuthenticityToken
 run MyApp
 ```
 
+
+## More examples
+
+Enable host authorization with an explicit allowlist:
+
+``` ruby
+# config.ru
+require 'rack/protection'
+
+use Rack::Protection::HostAuthorization,
+  permitted_hosts: ['example.com', '.example.org']
+
+run MyApp
+```
+
+Enable HTTPS-related headers in production only:
+
+``` ruby
+# config.ru
+require 'rack/protection'
+
+if ENV['RACK_ENV'] == 'production'
+  use Rack::Protection::StrictTransport,
+    max_age: 31_536_000, # 1 year
+    include_subdomains: true
+end
+
+run MyApp
+```
+
+Customize CSP directives:
+
+``` ruby
+# config.ru
+require 'rack/protection'
+
+use Rack::Protection::ContentSecurityPolicy,
+  default_src: "'self'",
+  script_src: ["'self'", 'https://cdn.example.com']
+
+run MyApp
+```
+
+Disable more than one protection middleware:
+
+``` ruby
+# config.ru
+require 'rack/protection'
+
+use Rack::Protection,
+  except: [:path_traversal, :json_csrf]
+
+run MyApp
+```
+
+
 # Prevented Attacks
 
 ## DNS rebinding and other Host header attacks


### PR DESCRIPTION
## Summary

Adds a new **"More examples"** section to `rack-protection/README.md` to address the long-standing request in #1154.

## What this PR adds

Practical `config.ru` examples for common setups:

1. `Rack::Protection::HostAuthorization` with `permitted_hosts`
2. `Rack::Protection::StrictTransport` enabled only in production
3. `Rack::Protection::ContentSecurityPolicy` with custom directives
4. `Rack::Protection` with multiple middlewares excluded via `except:`

## Why

Issue #1154 asks for more documentation examples. The existing README explains *what* protections exist, but has limited configuration examples for real app setups.

This PR keeps the docs concise while giving copy-paste friendly snippets for frequently requested configurations.

## Scope

- Docs only (`rack-protection/README.md`)
- No behavior/runtime changes
- No API changes

## Validation

- Confirmed option names in examples match implementation:
  - `HostAuthorization` uses `permitted_hosts`
  - `StrictTransport` uses `max_age` / `include_subdomains`
  - `ContentSecurityPolicy` accepts directive options like `default_src`, `script_src`
- Reviewed markdown rendering and section flow under existing Usage docs.

Closes #1154
