### PR TITLE
Mustermann 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         rack:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"
@@ -31,9 +27,9 @@ jobs:
           - "truffleruby"
         include:
           # Rack
-          - { ruby: 3.4, rack: "~>3.0.0" }
-          - { ruby: 3.4, rack: "~>3.1.0" }
-          - { ruby: 3.4, rack: head }
+          - { ruby: "4.0", rack: "~>3.0.0" }
+          - { ruby: "4.0", rack: "~>3.1.0" }
+          - { ruby: "4.0", rack: head }
           # Never fail our build due to problems with Ruby head
           - { ruby: ruby-head, rack: stable, allow-failure: true }
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
           - "truffleruby"
         include:
           # Rack
-          - { ruby: "4.0", rack: "~>3.0.0" }
-          - { ruby: "4.0", rack: "~>3.1.0" }
-          - { ruby: "4.0", rack: head }
+          - { ruby: "3.4", rack: "~>3.0.0" }
+          - { ruby: "3.4", rack: "~>3.1.0" }
+          - { ruby: "3.4", rack: head }
           # Never fail our build due to problems with Ruby head
           - { ruby: ruby-head, rack: stable, allow-failure: true }
     env:
@@ -63,7 +63,7 @@ jobs:
   sinatra:
     name: |
       ${{ matrix.ruby }}
-      (Rack ${{ matrix.rack }}, Rack::Session ${{ matrix.rack_session }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.tilt }}, Zeitwerk ${{ matrix.zeitwerk }})
+      (Rack ${{ matrix.rack }}, Rack::Session ${{ matrix.rack_session }}, Puma ${{ matrix.puma }}, Tilt ${{ matrix.tilt }}, Zeitwerk ${{ matrix.zeitwerk }}, Bundler ${{ matrix.bundler }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -82,7 +82,6 @@ jobs:
         ruby:
           - "3.3"
           - "3.4"
-          - "4.0"
         bundler:
           - default
         rubyopt:
@@ -141,6 +140,15 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler: ${{ matrix.bundler }}
         bundler-cache: true
+
+    # workaround for https://github.com/ruby/setup-ruby/issues/845
+    - name: Ensure Gemfile.lock is created with Bundler 2 for Ruby 4
+      if: matrix.ruby == '4.0' || matrix.ruby == 'ruby-head'
+      run: |
+        rm Gemfile.lock
+        bundle install
+      env:
+        BUNDLER_VERSION: ${{ matrix.bundler ==  'default' && '2.7.2' || matrix.bundler }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,12 +80,9 @@ jobs:
         zeitwerk:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         bundler:
           - default
         rubyopt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,18 +141,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler: ${{ matrix.bundler }}
         bundler-cache: true
-        # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490 (3.0)
-        # and https://github.com/sinatra/sinatra/issues/2051 (3.1)
-        rubygems: ${{ matrix.ruby == '3.0' && 'latest' || matrix.ruby == '3.1' && 'latest' || 'default' }}
-
-    # workaround for https://github.com/ruby/setup-ruby/issues/845
-    - name: Ensure Gemfile.lock is created with Bundler 2 for Ruby 4
-      if: matrix.ruby == '4.0' || matrix.ruby == 'ruby-head'
-      run: |
-        rm Gemfile.lock
-        bundle install
-      env:
-        BUNDLER_VERSION: ${{ matrix.bundler }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         rack:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"
@@ -84,10 +80,6 @@ jobs:
         zeitwerk:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
         rubyopt:
@@ -144,9 +136,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490 (3.0)
-        # and https://github.com/sinatra/sinatra/issues/2051 (3.1)
-        rubygems: ${{ matrix.ruby == '3.0' && 'latest' || matrix.ruby == '3.1' && 'latest' || 'default' }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1070,7 +1070,7 @@ module Sinatra
       end
 
       routes&.each do |match_or_signature|
-        response.delete_header('content-type') unless @pinned_response
+        reset_content_type!
 
         if match_or_signature.is_a?(Mustermann::Match)
           match = match_or_signature
@@ -1094,13 +1094,22 @@ module Sinatra
       end
 
       # Set-based routing only iterates matching routes, so the per-iteration
-      # reset above is skipped after a route that set a content-type then passed.
-      # Clear it so the pass block starts clean, as the legacy all-routes scan did.
+      # reset above is skipped after a matching route set a content-type then
+      # passed. Reset it here too so the pass block starts clean, uniformly for
+      # every verb. (main's all-routes scan cleared this only incidentally for
+      # GET, via the built-in /__sinatra__ image route, and leaked it otherwise.)
       if pass_block
-        response.delete_header('content-type') unless @pinned_response
+        reset_content_type!
         route_eval(&pass_block)
       end
       route_missing
+    end
+
+    # Reset the content-type a passed/previous route may have set, so the next
+    # handler -- route block or pass block -- starts from its baseline: nothing,
+    # or the value a before-filter pinned via @pinned_response.
+    def reset_content_type!
+      response.delete_header('content-type') unless @pinned_response
     end
 
     # Run a route block and throw :halt with the result.

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1070,18 +1070,21 @@ module Sinatra
       end
 
       routes&.each do |match_or_signature|
+        response.delete_header('content-type') unless @pinned_response
+
         if match_or_signature.is_a?(Mustermann::Match)
-          params = match_or_signature.params
+          match = match_or_signature
           pattern, conditions, block = match_or_signature.value
         else
           pattern, conditions, block = match_or_signature
         end
 
-        returned_pass_block = process_route(pattern, conditions, params: params) do |*args|
+        returned_pass_block = process_route(pattern, conditions, match: match) do |*args|
           env['sinatra.route'] = "#{@request.request_method} #{pattern}"
           route_eval { block[*args] }
         end
 
+         # don't wipe out pass_block in superclass
         pass_block = returned_pass_block if returned_pass_block
       end
 
@@ -1104,9 +1107,14 @@ module Sinatra
     # Revert params afterwards.
     #
     # Returns pass block.
-    def process_route(pattern, conditions, block = nil, values = [], params: nil)
-      params ||= pattern.params(route)
-      return unless params
+    def process_route(pattern, conditions, block = nil, values = [], match: nil)
+      if match
+        params   = match.params
+        captures = match.captures
+      else
+        params = pattern.params(route)
+        return unless params
+      end
 
       params = params.dup
       params.delete('ignore') # TODO: better params handling, maybe turn it into "smart" object or detect changes
@@ -1114,8 +1122,12 @@ module Sinatra
 
       @params = @params.merge(params) { |_k, v1, v2| v2 || v1 } if params.any?
 
-      if pattern.is_a?(Mustermann::Regular)
-        values += pattern.regexp.match(route).captures.map { |c| URI_INSTANCE.unescape(c) if c }
+      regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? { |subpattern| subpattern.is_a?(Mustermann::Regular) })
+      if regexp_exists
+        match            ||= pattern.match(route)
+        captures           = match.captures.map { |c| URI_INSTANCE.unescape(c) if c }
+        values            += captures
+        @params[:captures] = force_encoding(captures) unless captures.nil? || captures.empty?
       else
         values += params.values.flatten
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -10,6 +10,7 @@ require 'tilt'
 require 'rack/protection'
 require 'rack/session'
 require 'mustermann'
+require 'mustermann/set'
 require 'mustermann/sinatra'
 require 'mustermann/regular'
 
@@ -1062,17 +1063,25 @@ module Sinatra
 
     # Run routes defined on the class and all superclasses.
     def route!(base = settings, pass_block = nil)
-      routes = base.routes[@request.request_method]
+      if set = base.route_sets[@request.request_method]
+        routes = set.match_all(route)
+      else
+        routes = base.routes[@request.request_method]
+      end
 
-      routes&.each do |pattern, conditions, block|
-        response.delete_header('content-type') unless @pinned_response
+      routes&.each do |match_or_signature|
+        if match_or_signature.is_a?(Mustermann::Match)
+          params = match_or_signature.params
+          pattern, conditions, block = match_or_signature.value
+        else
+          pattern, conditions, block = match_or_signature
+        end
 
-        returned_pass_block = process_route(pattern, conditions) do |*args|
+        returned_pass_block = process_route(pattern, conditions, params: params) do |*args|
           env['sinatra.route'] = "#{@request.request_method} #{pattern}"
           route_eval { block[*args] }
         end
 
-        # don't wipe out pass_block in superclass
         pass_block = returned_pass_block if returned_pass_block
       end
 
@@ -1095,14 +1104,11 @@ module Sinatra
     # Revert params afterwards.
     #
     # Returns pass block.
-    def process_route(pattern, conditions, block = nil, values = [], params = nil)
-      route = @request.path_info
-      route = '/' if route.empty? && !settings.empty_path_info?
-      route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
-
-      params ||= pattern.params(route).dup
+    def process_route(pattern, conditions, block = nil, values = [], params: nil)
+      params ||= pattern.params(route)
       return unless params
 
+      params = params.dup
       params.delete('ignore') # TODO: better params handling, maybe turn it into "smart" object or detect changes
       force_encoding(params)
 
@@ -1124,6 +1130,14 @@ module Sinatra
     ensure
       params ||= {}
       params.each { |k, _| @params.delete(k) } unless @env['sinatra.error.params']
+    end
+
+    # The current route being processed. Used for pattern matching and URL generation.
+    def route
+      route = @request.path_info
+      route = '/' if route.empty? && !settings.empty_path_info?
+      route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
+      route
     end
 
     # No matching route was found or all routes passed. The default
@@ -1298,7 +1312,7 @@ module Sinatra
         %r{zeitwerk/(core_ext/)?kernel\.rb}                 # Zeitwerk kernel#require decorator
       ].freeze
 
-      attr_reader :routes, :filters, :templates, :errors, :on_start_callback, :on_stop_callback
+      attr_reader :routes, :route_sets, :filters, :templates, :errors, :on_start_callback, :on_stop_callback
 
       def callers_to_ignore
         CALLERS_TO_IGNORE
@@ -1309,6 +1323,7 @@ module Sinatra
       def reset!
         @conditions     = []
         @routes         = {}
+        @route_sets     = {}
         @filters        = { before: [], after: [] }
         @errors         = {}
         @middleware     = []
@@ -1773,8 +1788,17 @@ module Sinatra
 
       def route(verb, path, options = {}, &block)
         enable :empty_path_info if path == '' && empty_path_info.nil?
-        signature = compile!(verb, path, block, **options)
+        pattern, _ = signature = compile!(verb, path, block, **options)
+
         (@routes[verb] ||= []) << signature
+        
+        if pattern.is_a? Mustermann::AST::Pattern
+          @route_sets[verb] = Mustermann::Set.new(strict_order: true) if @route_sets[verb].nil?
+          @route_sets[verb]&.add(pattern, signature)
+        else
+          @route_sets[verb] = false
+        end
+
         invoke_hook(:route_added, verb, path, block)
         signature
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1095,23 +1095,21 @@ module Sinatra
     # Revert params afterwards.
     #
     # Returns pass block.
-    def process_route(pattern, conditions, block = nil, values = [])
+    def process_route(pattern, conditions, block = nil, values = [], params = nil)
       route = @request.path_info
       route = '/' if route.empty? && !settings.empty_path_info?
       route = route[0..-2] if !settings.strict_paths? && route != '/' && route.end_with?('/')
 
-      params = pattern.params(route)
+      params ||= pattern.params(route).dup
       return unless params
 
       params.delete('ignore') # TODO: better params handling, maybe turn it into "smart" object or detect changes
       force_encoding(params)
+
       @params = @params.merge(params) { |_k, v1, v2| v2 || v1 } if params.any?
 
-      regexp_exists = pattern.is_a?(Mustermann::Regular) || (pattern.respond_to?(:patterns) && pattern.patterns.any? { |subpattern| subpattern.is_a?(Mustermann::Regular) })
-      if regexp_exists
-        captures           = pattern.match(route).captures.map { |c| URI_INSTANCE.unescape(c) if c }
-        values            += captures
-        @params[:captures] = force_encoding(captures) unless captures.nil? || captures.empty?
+      if pattern.is_a?(Mustermann::Regular)
+        values += pattern.regexp.match(route).captures.map { |c| URI_INSTANCE.unescape(c) if c }
       else
         values += params.values.flatten
       end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1806,7 +1806,7 @@ module Sinatra
         
         if pattern.is_a? Mustermann::AST::Pattern
           @route_sets[verb] = Mustermann::Set.new(strict_order: true) if @route_sets[verb].nil?
-          @route_sets[verb]&.add(pattern, signature)
+          @route_sets[verb].add(pattern, signature) if @route_sets[verb]
         else
           @route_sets[verb] = false
         end

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1093,7 +1093,13 @@ module Sinatra
         return route!(base.superclass, pass_block)
       end
 
-      route_eval(&pass_block) if pass_block
+      # Set-based routing only iterates matching routes, so the per-iteration
+      # reset above is skipped after a route that set a content-type then passed.
+      # Clear it so the pass block starts clean, as the legacy all-routes scan did.
+      if pass_block
+        response.delete_header('content-type') unless @pinned_response
+        route_eval(&pass_block)
+      end
       route_missing
     end
 

--- a/rack-protection/rack-protection.gemspec
+++ b/rack-protection/rack-protection.gemspec
@@ -36,7 +36,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 2.7.8'
+  s.required_ruby_version = '>= 3.3.0'
 
   # dependencies
   s.add_dependency 'base64', '>= 0.1.0'

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -362,8 +362,9 @@ module Sinatra
       def deactivate(element)
         case element.type
         when :route
-          verb      = element.representation[:verb]
-          signature = element.representation[:signature]
+          verb             = element.representation[:verb]
+          signature        = element.representation[:signature]
+          route_sets[verb] = false # disable set based routing as we can't remove routes from sets
           (routes[verb] ||= []).delete(signature)
         when :middleware
           @middleware.delete(element.representation)

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -40,8 +40,6 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.7.8'
 
   s.add_dependency 'multi_json', '>= 0.0.2'
-  s.add_dependency 'mustermann', '~> 3.0'
-  s.add_dependency 'rack-protection', version
   s.add_dependency 'sinatra', version
   s.add_dependency 'tilt', '~> 2.0'
 end

--- a/sinatra-contrib/sinatra-contrib.gemspec
+++ b/sinatra-contrib/sinatra-contrib.gemspec
@@ -37,7 +37,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 2.7.8'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.add_dependency 'multi_json', '>= 0.0.2'
   s.add_dependency 'sinatra', version

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -47,7 +47,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 2.7.8'
 
   s.add_dependency 'logger', '>= 1.6.0'
-  s.add_dependency 'mustermann', '~> 3.0'
+  s.add_dependency 'mustermann', '>= 4.0.0.alpha3', '< 5'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'rack-session', '>= 2.0.0', '< 3'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -44,7 +44,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
     'rubygems_mfa_required' => 'true',
   }
 
-  s.required_ruby_version = '>= 2.7.8'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.add_dependency 'logger', '>= 1.6.0'
   s.add_dependency 'mustermann', '>= 4.0.0.alpha3', '< 5'

--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -47,7 +47,7 @@ RubyGems 2.0 or newer is required to protect against public gem pushes. You can 
   s.required_ruby_version = '>= 3.3.0'
 
   s.add_dependency 'logger', '>= 1.6.0'
-  s.add_dependency 'mustermann', '>= 4.0.0.alpha3', '< 5'
+  s.add_dependency 'mustermann', '>= 4.0.0.alpha4', '< 5'
   s.add_dependency 'rack', '>= 3.0.0', '< 4'
   s.add_dependency 'rack-protection', version
   s.add_dependency 'rack-session', '>= 2.0.0', '< 3'

--- a/test/readme_test.rb
+++ b/test/readme_test.rb
@@ -101,20 +101,6 @@ class ReadmeTest < Minitest::Test
 
     example do
       mock_app do
-        get(%r{/hello/([\w]+)}) {
-          "Hello, #{params[:captures].first}!"
-        }
-      end
-
-      get '/hello/foo'
-      assert_body 'Hello, foo!'
-
-      get '/hello/bar'
-      assert_body 'Hello, bar!'
-    end
-
-    example do
-      mock_app do
         get( %r{/hello/([\w]+)}) { |c|
           "Hello, #{c}!"
         }

--- a/test/readme_test.rb
+++ b/test/readme_test.rb
@@ -101,6 +101,20 @@ class ReadmeTest < Minitest::Test
 
     example do
       mock_app do
+        get(%r{/hello/([\w]+)}) {
+          "Hello, #{params[:captures].first}!"
+        }
+      end
+
+      get '/hello/foo'
+      assert_body 'Hello, foo!'
+
+      get '/hello/bar'
+      assert_body 'Hello, bar!'
+    end
+
+    example do
+      mock_app do
         get( %r{/hello/([\w]+)}) { |c|
           "Hello, #{c}!"
         }

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -415,6 +415,19 @@ class RoutingTest < Minitest::Test
     assert_equal "format=", body
   end
 
+  it 'uses the default encoding for named captures' do
+    mock_app {
+      set :default_encoding ,'ISO-8859-1'
+
+      get Regexp.new('/page(?<format>.[^/?#]+)?') do
+        "format=#{params[:format].encoding};captures=#{params[:captures][0].encoding}"
+      end
+    }
+    get '/page.f%C3%B6'
+    assert ok?
+    assert_equal 'format=ISO-8859-1;captures=ISO-8859-1', body
+  end
+
   it 'does not concatenate params with the same name' do
     mock_app { get('/:foo') { params[:foo] } }
     get '/a?foo=b'
@@ -702,8 +715,44 @@ class RoutingTest < Minitest::Test
 
     get '/foo/bar%e2%80%8cbaz'
     assert ok?
-    assert_equal "bar\xE2\x80\x8Cbaz".b, body
+    assert_equal "bar\xE2\x80\x8Cbaz", body
     assert_predicate body, :valid_encoding?
+  end
+
+  it 'makes regular expression captures available in params[:captures]' do
+    mock_app {
+      get(/\/fo(.*)\/ba(.*)/) do
+        assert_equal ['orooomma', 'f'], params[:captures]
+        'right on'
+      end
+    }
+
+    get '/foorooomma/baf'
+    assert ok?
+    assert_equal 'right on', body
+  end
+
+  it 'makes regular expression captures available in params[:captures] for concatenated routes' do
+    with_regexp = Mustermann.new('/prefix') + Mustermann.new("/fo(.*)/ba(.*)", type: :regexp)
+    without_regexp = Mustermann.new('/prefix', type: :identity) + Mustermann.new('/baz')
+    mock_app {
+      get(with_regexp) do
+        assert_equal ['orooomma', 'f'], params[:captures]
+        'right on'
+      end
+      get(without_regexp) do
+        assert !params.keys.include?(:captures)
+        'no captures here'
+      end
+    }
+
+    get '/prefix/foorooomma/baf'
+    assert ok?
+    assert_equal 'right on', body
+
+    get '/prefix/baz'
+    assert ok?
+    assert_equal 'no captures here', body
   end
 
   it 'supports regular expression look-alike routes' do

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -936,7 +936,24 @@ class RoutingTest < Minitest::Test
     assert_equal 'from pass block', body
     # The content-type set by the passed route must not survive into the pass
     # block: set-based routing iterates only matching routes, so route! must
-    # clear it before the fallthrough just as the legacy all-routes scan did.
+    # clear it before the fallthrough.
+    assert_equal 'text/html;charset=utf-8', response.headers['content-type']
+  end
+
+  it "does not leak a passed route's content-type into the pass block for non-GET verbs" do
+    mock_app {
+      post('/a') do
+        content_type :json
+        pass { 'from pass block' }
+      end
+    }
+
+    post '/a'
+    assert_equal 200, status
+    assert_equal 'from pass block', body
+    # Non-GET verbs are the case main got wrong: it cleared a single-match GET
+    # only incidentally (via its built-in image route) and leaked every other
+    # verb. The shared-fallthrough reset covers them all.
     assert_equal 'text/html;charset=utf-8', response.headers['content-type']
   end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -922,6 +922,24 @@ class RoutingTest < Minitest::Test
     assert "this", body
   end
 
+  it "does not leak a passed route's content-type into the pass block" do
+    mock_app {
+      get('/a') do
+        content_type :json
+        pass { 'from pass block' }
+      end
+      get('/b') { 'b' } # later, non-matching route for the same verb
+    }
+
+    get '/a'
+    assert_equal 200, status
+    assert_equal 'from pass block', body
+    # The content-type set by the passed route must not survive into the pass
+    # block: set-based routing iterates only matching routes, so route! must
+    # clear it before the fallthrough just as the legacy all-routes scan did.
+    assert_equal 'text/html;charset=utf-8', response.headers['content-type']
+  end
+
   it "passes when matching condition returns false" do
     mock_app {
       condition { params[:foo] == 'bar' }

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -415,19 +415,6 @@ class RoutingTest < Minitest::Test
     assert_equal "format=", body
   end
 
-  it 'uses the default encoding for named captures' do
-    mock_app {
-      set :default_encoding ,'ISO-8859-1'
-
-      get Regexp.new('/page(?<format>.[^/?#]+)?') do
-        "format=#{params[:format].encoding};captures=#{params[:captures][0].encoding}"
-      end
-    }
-    get '/page.f%C3%B6'
-    assert ok?
-    assert_equal 'format=ISO-8859-1;captures=ISO-8859-1', body
-  end
-
   it 'does not concatenate params with the same name' do
     mock_app { get('/:foo') { params[:foo] } }
     get '/a?foo=b'
@@ -715,44 +702,8 @@ class RoutingTest < Minitest::Test
 
     get '/foo/bar%e2%80%8cbaz'
     assert ok?
-    assert_equal "bar\xE2\x80\x8Cbaz", body
+    assert_equal "bar\xE2\x80\x8Cbaz".b, body
     assert_predicate body, :valid_encoding?
-  end
-
-  it 'makes regular expression captures available in params[:captures]' do
-    mock_app {
-      get(/\/fo(.*)\/ba(.*)/) do
-        assert_equal ['orooomma', 'f'], params[:captures]
-        'right on'
-      end
-    }
-
-    get '/foorooomma/baf'
-    assert ok?
-    assert_equal 'right on', body
-  end
-
-  it 'makes regular expression captures available in params[:captures] for concatenated routes' do
-    with_regexp = Mustermann.new('/prefix') + Mustermann.new("/fo(.*)/ba(.*)", type: :regexp)
-    without_regexp = Mustermann.new('/prefix', type: :identity) + Mustermann.new('/baz')
-    mock_app {
-      get(with_regexp) do
-        assert_equal ['orooomma', 'f'], params[:captures]
-        'right on'
-      end
-      get(without_regexp) do
-        assert !params.keys.include?(:captures)
-        'no captures here'
-      end
-    }
-
-    get '/prefix/foorooomma/baf'
-    assert ok?
-    assert_equal 'right on', body
-
-    get '/prefix/baz'
-    assert ok?
-    assert_equal 'no captures here', body
   end
 
   it 'supports regular expression look-alike routes' do


### PR DESCRIPTION
Changes so far:
* [x] Mustermann 4.0 compatibility
* [ ] <s>Drop undocummented `params[:captures]` feature – this is technically a breaking change, so the major Sinatra version would need to be bumped</s>
* [x] Use `Mustermann::Set` for faster routing if possible