### PR TITLE
Fix integration test corrupting Gemfile.lock under Bundler 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,33 +90,30 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
-        bundler:
-          - default
         rubyopt:
           - "--enable-frozen-string-literal --debug-frozen-string-literal"
         include:
-          # Avoid Bundler 4 for now: https://github.com/sinatra/sinatra/issues/2135
-          - { ruby: "4.0", bundler: 2.7.2, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: "4.0", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Rack
-          - { ruby: 3.4, bundler: default, rack: "~>3.0.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
-          - { ruby: 3.4, bundler: default, rack: "~>3.1.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
-          - { ruby: 3.4, bundler: default, rack: head, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: "~>3.0.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: "~>3.1.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: head, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Rack::Session
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: head, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: stable, rack_session: head, zeitwerk: stable }
           # Puma
-          - { ruby: 3.4, bundler: default, rack: stable, puma: head, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: head, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Tilt
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: stable }
           # Test Zeitwerk < 2.7.0 separately
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: '<2.7.0' }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: '<2.7.0' }
           # JRuby, tests are notable flaky
-          - { ruby: jruby,            bundler: default, rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby,            rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # Never fail our build due to problems with head rubies
-          - { ruby: ruby-head,        bundler: 2.7.2,   rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
-          - { ruby: jruby-head,       bundler: default, rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
-          - { ruby: truffleruby-head, bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: ruby-head,        rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby-head,       rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # truffleruby 24.1 fails, see https://github.com/oracle/truffleruby/issues/3788
-          - { ruby: truffleruby,      bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: truffleruby,      rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
 
     env:
       rack: ${{ matrix.rack }}
@@ -146,20 +143,10 @@ jobs:
       id: setup-ruby
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: ${{ matrix.bundler }}
         bundler-cache: true
         # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490 (3.0)
         # and https://github.com/sinatra/sinatra/issues/2051 (3.1)
         rubygems: ${{ matrix.ruby == '3.0' && 'latest' || matrix.ruby == '3.1' && 'latest' || 'default' }}
-
-    # workaround for https://github.com/ruby/setup-ruby/issues/845
-    - name: Ensure Gemfile.lock is created with Bundler 2 for Ruby 4
-      if: matrix.ruby == '4.0' || matrix.ruby == 'ruby-head'
-      run: |
-        rm Gemfile.lock
-        bundle install
-      env:
-        BUNDLER_VERSION: ${{ matrix.bundler }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/test/integration_start_test.rb
+++ b/test/integration_start_test.rb
@@ -21,7 +21,9 @@ class IntegrationStartTest < Minitest::Test
     gem_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb")
     lock_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb.lock")
     command = command_for(app_file)
-    env = { "BUNDLE_GEMFILE" => gem_file }
+    # BUNDLE_LOCKFILE is exported by Bundler 4; without clearing it the child would
+    # write the alternate gemfile's lock to the parent project's Gemfile.lock path
+    env = { "BUNDLE_GEMFILE" => gem_file, "BUNDLE_LOCKFILE" => nil }
 
     with_process(command: command, env: env) do |process, read_io|
       assert wait_for_output(read_io, /Sinatra could not start, the required gems weren't found/)


### PR DESCRIPTION
`test_app_start_without_rackup` spawns a child Ruby with a custom
`BUNDLE_GEMFILE`. Bundler 4 exports `BUNDLE_LOCKFILE` to subprocesses;
without overriding it the child writes the alternate gemfile's
(small) lock content to the parent project's `Gemfile.lock` path,
breaking later integration tests that `require "bundler/setup"`.

Clear `BUNDLE_LOCKFILE` in the child env so it derives from the
alternate gemfile.

Fixes #2135