### PR TITLE
feat: skip host_authorization when protection is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix: Skip `host_authorization` when protection is disabled with `disable :protection` ([#2106](https://github.com/sinatra/sinatra/issues/2106))
+
 ## 4.2.1 / 2025-10-10
 
 * Fix: Revert "`PATH_INFO` can never be empty" ([#2124](https://github.com/sinatra/sinatra/pull/2124))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Fix: Skip `host_authorization` when protection is disabled with `disable :protection` ([#2106](https://github.com/sinatra/sinatra/issues/2106))
+* Fix: Skip `host_authorization` when protection is disabled with `disable :protection`, or when `host_authorization` itself is set to `false` ([#2106](https://github.com/sinatra/sinatra/issues/2106))
 
 ## 4.2.1 / 2025-10-10
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1874,6 +1874,8 @@ module Sinatra
       end
 
       def setup_host_authorization(builder)
+        return unless protection?
+
         builder.use Rack::Protection::HostAuthorization, host_authorization
       end
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1875,6 +1875,7 @@ module Sinatra
 
       def setup_host_authorization(builder)
         return unless protection?
+        return unless host_authorization
 
         builder.use Rack::Protection::HostAuthorization, host_authorization
       end

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -64,6 +64,18 @@ class HostAuthorization < Minitest::Test
       assert_equal 200, response.status
       assert_equal "OK", body
     end
+
+    it "allows any host when host_authorization is set to false" do
+      mock_app do
+        set :host_authorization, false
+        get("/") { "OK" }
+      end
+
+      get "/", { "HTTP_HOST" => "example.com" }
+
+      assert_equal 200, response.status
+      assert_equal "OK", body
+    end
   end
 
   describe "in non-development environments" do

--- a/test/host_authorization_test.rb
+++ b/test/host_authorization_test.rb
@@ -52,6 +52,18 @@ class HostAuthorization < Minitest::Test
       assert_equal 200, response.status
       assert_equal "OK", body
     end
+
+    it "allows any host when protection is disabled" do
+      mock_app do
+        disable :protection
+        get("/") { "OK" }
+      end
+
+      get "/", { "HTTP_HOST" => "example.com" }
+
+      assert_equal 200, response.status
+      assert_equal "OK", body
+    end
   end
 
   describe "in non-development environments" do


### PR DESCRIPTION
Fixes #2106. `disable :protection` previously left `Rack::Protection::HostAuthorization` in the middleware stack, so host checks kept running even with all protections off. This adds the same `return unless protection?` guard that `setup_protection` already uses, so disabling protection also disables host authorization.

Added a regression test covering the disabled case; existing host authorization tests still pass.