### PR TITLE
Fixing issue when when ARGV has -v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix: Rescue `SystemExit` (in addition to `StandardError`) when parsing `ARGV` at `require 'sinatra'` time. Prevents host processes (e.g. `rake`, test runners) from being killed when `ARGV` contains options that match OptionParser's officious `--version` / `--help` handlers (notably `-v`), which call `abort`/`exit`.
+
 ## 4.2.1 / 2025-10-10
 
 * Fix: Revert "`PATH_INFO` can never be empty" ([#2124](https://github.com/sinatra/sinatra/pull/2124))

--- a/lib/sinatra/main.rb
+++ b/lib/sinatra/main.rb
@@ -20,7 +20,7 @@ module Sinatra
     end
     begin
       parser.parse!(ARGV.dup)
-    rescue StandardError => e
+    rescue StandardError, SystemExit => e
       PARAMS_CONFIG[:optparse_error] = e
     end
   end

--- a/test/sinatra_test.rb
+++ b/test/sinatra_test.rb
@@ -1,5 +1,9 @@
 require_relative 'test_helper'
 
+require 'open3'
+require 'rbconfig'
+require 'tempfile'
+
 class SinatraTest < Minitest::Test
   it 'creates a new Sinatra::Base subclass on new' do
     app = Sinatra.new { get('/') { 'Hello World' } }
@@ -8,5 +12,31 @@ class SinatraTest < Minitest::Test
 
   it "responds to #template_cache" do
     assert_kind_of Sinatra::TemplateCache, Sinatra::Base.new!.template_cache
+  end
+
+  # When sinatra is required from a library or test runner (i.e. the file
+  # doing the require is not the process entrypoint), ARGV must not be
+  # parsed. With -v in ARGV, OptionParser's officious --version handler
+  # runs abort("...: version unknown"), which raises SystemExit and kills
+  # the host process.
+  it "loads via require when ARGV contains '-v' and the requirer is not $0" do
+    ruby    = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+    lib_dir = File.expand_path('../lib', __dir__)
+
+    Tempfile.create(['sinatra_argv_', '.rb']) do |inner|
+      inner.write(<<~RUBY)
+        ARGV.replace(['-v'])
+        require 'sinatra'
+        puts 'sinatra-loaded-ok'
+      RUBY
+      inner.flush
+
+      output, status = Open3.capture2e(ruby, '-I', lib_dir, '-e', "require #{inner.path.inspect}")
+
+      assert status.success?,
+             "child exited with #{status.inspect}; output was:\n#{output}"
+      assert_includes output, 'sinatra-loaded-ok',
+                      "child did not reach the post-require line; output was:\n#{output}"
+    end
   end
 end


### PR DESCRIPTION
A recent change to rake. When called with "rake --trace" adds a -v to ARGV. This started breaking our apps unit tests that did a require 'sinatra".

This change only parses ARGV when sinatra is the process entrypoint