### PR TITLE
Fix multi_json 1.21 deprecations in sinatra-contrib JSON helper (backward compatible)

### DIFF
--- a/sinatra-contrib/lib/sinatra/json.rb
+++ b/sinatra-contrib/lib/sinatra/json.rb
@@ -90,7 +90,17 @@ module Sinatra
   module JSON
     class << self
       def encode(object)
-        ::MultiJson.dump(object)
+        encoder = multi_json
+        encoder.respond_to?(:generate) ? encoder.generate(object) : encoder.dump(object)
+      end
+
+      # multi_json 1.21 renamed the +MultiJson+ constant to +MultiJSON+ and
+      # deprecated #dump/#load in favour of #generate/#parse. Prefer the new
+      # names when they're available while still supporting multi_json < 1.21
+      # (the gemspec floor), and resolve lazily so the lookup matches
+      # multi_json's load timing.
+      def multi_json
+        defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
       end
     end
 
@@ -110,17 +120,20 @@ module Sinatra
     end
 
     def resolve_encoder_action(object, encoder)
-      %i[encode generate].each do |method|
-        return encoder.send(method, object) if encoder.respond_to? method
+      if encoder.respond_to?(:generate)
+        encoder.generate(object)
+      elsif encoder.respond_to?(:encode)
+        encoder.encode(object)
+      elsif encoder.is_a?(Symbol)
+        object.__send__(encoder)
+      else
+        raise "#{encoder} does not respond to #generate nor #encode"
       end
-      raise "#{encoder} does not respond to #generate nor #encode" unless encoder.is_a? Symbol
-
-      object.__send__(encoder)
     end
   end
 
   Base.set :json_encoder do
-    ::MultiJson
+    Sinatra::JSON.multi_json
   end
 
   Base.set :json_content_type, :json

--- a/sinatra-contrib/spec/json_spec.rb
+++ b/sinatra-contrib/spec/json_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe Sinatra::JSON do
     results_in 'foo' => [1, 'bar', nil]
   end
 
+  it 'flags the multi_json compat shim for removal once the floor reaches 1.21' do
+    # multi_json 1.21.0 introduced ::MultiJSON and #generate, deprecating
+    # ::MultiJson and #dump. The defined?(::MultiJSON) / respond_to?(:generate)
+    # fallbacks in lib/sinatra/json.rb exist only to support multi_json < 1.21
+    # (the gemspec floor). Once the floor reaches 1.21 they are dead code.
+    spec = Gem::Specification.load(File.expand_path('../sinatra-contrib.gemspec', __dir__))
+    dep  = spec&.dependencies&.find { |d| d.name == 'multi_json' }
+    skip 'multi_json is no longer a dependency' unless dep
+
+    # 1.20.1 is the final pre-1.21 release; if the floor no longer admits it,
+    # every supported version has the new API and the shim is dead.
+    expect(dep.requirement.satisfied_by?(Gem::Version.new('1.20.1'))).to be(true),
+           "multi_json floor is now #{dep.requirement}; every supported version has " \
+           '::MultiJSON and #generate. Drop the defined?(::MultiJSON) / ' \
+           'respond_to?(:generate) fallbacks in lib/sinatra/json.rb and call ' \
+           '::MultiJSON.generate directly.'
+  end
+
   it "sets the content type to 'application/json'" do
     mock_app { get('/') { json({}) } }
     expect(get('/')["Content-Type"]).to include("application/json")


### PR DESCRIPTION
## What

Silences every multi_json 1.21 deprecation warning emitted by `sinatra-contrib`'s JSON helper, while keeping the existing `multi_json >= 0.0.2` gemspec floor.

## Why

multi_json **1.21.0** made three changes in a single release:

- renamed the `MultiJson` constant to `MultiJSON` (old name deprecated)
- added `#generate`/`#parse` and deprecated `#dump`/`#load`
- deprecated `#encode`

`lib/sinatra/json.rb` tripped all three on its default encoder path, so an app on multi_json 1.21 sees deprecation warnings on every `json` response. Because they share one root cause and one removal threshold (`>= 1.21`), they are fixed here together rather than spread across separate PRs that would conflict on the same method.

This supersedes the earlier one-line reorder on this branch and folds in the constant fix that was tracked separately in #2170 (option 2, the `defined?`-guarded reference that @jkowens and @dentarg agreed on).

## Changes

- **`resolve_encoder_action`**: probe `#generate` before `#encode`. Rewritten from the `%i[encode generate].each` loop back to an explicit `if`/`elsif`. Git history shows the array was introduced in the 2013 multi-json rewrite (9f0268b6) purely to DRY two identically shaped `respond_to?` branches that differ only by method name; the helper was an explicit `if`/`elsif` when it was first added in 2011 (e06d6417). The conditional restores that original shape, makes the generate-before-encode precedence visible in the code, and lets the Symbol and raise cases read inline where they belong.
- **`Sinatra::JSON.encode` and the `json_encoder` default**: resolve the constant via `defined?(::MultiJSON)` and call `#generate` when the encoder supports it, falling back to `::MultiJson` / `#dump` on multi_json `< 1.21`. The resolution is lazy (a small shared `multi_json` helper) so it matches multi_json's load timing and stays a single source of truth.

## Backward compatibility

Fully preserved. On multi_json `< 1.21` there is no `::MultiJSON` constant and encoders do not respond to `#generate`, so both fallbacks (`::MultiJson`, `#dump`) are taken exactly as before. The gemspec floor is unchanged.

## Self-cleaning shim

`spec/json_spec.rb` adds a tripwire that asserts the gemspec floor still admits the final pre-1.21 release (1.20.1). The moment the floor is raised to `1.21`, that assertion fails with instructions to delete the now-dead `defined?` / `respond_to?` fallbacks and call `::MultiJSON.generate` directly. This fits the longer-term plan in #2170 to drop multi_json for stdlib JSON at the next major version: the shim cannot silently outlive its purpose.

## Verification

On Ruby 3.4 with multi_json 1.21.1:

- `bundle exec rspec spec/json_spec.rb` passes (21 examples, 0 failures)
- no multi_json deprecation warnings remain on any encoder path (default `MultiJSON`, explicit `Sinatra::JSON`, `::JSON`, Yajl, Symbol)
- the tripwire passes at the current floor and fails (as designed) for `>= 1.21`, `>= 1.21.0`, and `~> 1.21`

Closes #2170.
