### PR TITLE
Add IndifferentHash#symbolize_keys for keyword-argument splatting

### DIFF
--- a/lib/sinatra/indifferent_hash.rb
+++ b/lib/sinatra/indifferent_hash.rb
@@ -38,6 +38,12 @@ module Sinatra
   # But this class is intended for use cases where strings or symbols are the
   # expected keys and it is convenient to understand both as the same. For
   # example the +params+ hash in Sinatra.
+  #
+  # To splat the hash into keyword arguments, use +symbolize_keys+, e.g.
+  # <tt>some_method(**params.symbolize_keys)</tt>. Splatting an IndifferentHash
+  # directly does not work, because its keys are stored as strings and keyword
+  # arguments bind by symbol. The result of +symbolize_keys+ is a plain Hash,
+  # not an IndifferentHash, so do not keep using it for string-key access.
   class IndifferentHash < Hash
     def self.[](*args)
       new.merge!(Hash[*args])
@@ -166,6 +172,32 @@ module Sinatra
       super(&method(:convert_key))
     end
 
+    # Returns a plain Hash (not an IndifferentHash) with String keys converted
+    # to Symbols. Intended as the bridge for keyword-argument splatting:
+    #
+    #   some_method(**params.symbolize_keys)
+    #
+    # Symbol, Integer, and invalid-encoding String keys are left as-is. The
+    # result is a plain Hash and is no longer indifferent, so a string lookup
+    # that previously worked now returns nil:
+    #
+    #   h = Sinatra::IndifferentHash[a: 1]
+    #   s = h.symbolize_keys # => { a: 1 } (a plain Hash)
+    #   s[:a]  # => 1
+    #   s['a'] # => nil
+    #
+    # It is shallow: only top-level String keys become Symbols. Nested
+    # IndifferentHash values are left as-is, so they stay indifferent. The
+    # receiver is not mutated.
+    #
+    # Note this is intentionally not routed through #transform_keys, which would
+    # re-apply #convert_key and turn the symbols straight back into strings.
+    def symbolize_keys
+      each_with_object({}) do |(key, value), hash|
+        hash[symbolizable?(key) ? key.to_sym : key] = value
+      end
+    end
+
     def select(*args, &block)
       return to_enum(:select) unless block_given?
 
@@ -192,6 +224,14 @@ module Sinatra
 
     def convert_key(key)
       key.is_a?(Symbol) ? key.to_s : key
+    end
+
+    # A key is safe to symbolize only if it is a String with valid encoding.
+    # Param names are attacker-controlled, and #to_sym raises EncodingError on
+    # invalid-encoding strings, so malformed keys are left untouched (as are
+    # non-String keys such as Integers and existing Symbols).
+    def symbolizable?(key)
+      key.is_a?(String) && key.valid_encoding?
     end
 
     def convert_value(value)

--- a/test/indifferent_hash_test.rb
+++ b/test/indifferent_hash_test.rb
@@ -298,3 +298,89 @@ class TestIndifferentHash < Minitest::Test
     assert_instance_of Sinatra::IndifferentHash, hash
   end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 end
+
+class TestIndifferentHashSymbolizeKeys < Minitest::Test
+  def test_returns_a_plain_hash_with_symbol_keys
+    result = Sinatra::IndifferentHash[a: 1, b: 2].symbolize_keys
+    assert_equal({ a: 1, b: 2 }, result)
+    assert_instance_of Hash, result
+    refute_kind_of Sinatra::IndifferentHash, result
+  end
+
+  def test_keys_are_actual_symbols
+    # Load-bearing: guards against a refactor onto #transform_keys, which would
+    # re-apply convert_key and silently turn the keys back into strings. A
+    # value-only check would not catch that, so assert the key classes.
+    result = Sinatra::IndifferentHash[a: 1, b: 2].symbolize_keys
+    assert_equal [Symbol, Symbol], result.keys.map(&:class)
+  end
+
+  def test_splats_into_named_keyword_arguments
+    # The core #1592 regression: bare **indifferent_hash raises ArgumentError
+    # because keyword arguments bind by symbol, but the symbolized result binds.
+    method = ->(a:, b:) { [a, b] }
+    assert_equal [1, 2], method.call(**Sinatra::IndifferentHash[a: 1, b: 2].symbolize_keys)
+  end
+
+  def test_splats_into_keyword_collector
+    collector = ->(**kwargs) { kwargs }
+    assert_equal({ a: 1 }, collector.call(**Sinatra::IndifferentHash[a: 1].symbolize_keys))
+  end
+
+  def test_invalid_encoding_key_is_left_as_a_string
+    # Param names are attacker-controlled; an unguarded #to_sym would raise
+    # EncodingError on a malformed key, turning a request into a 500.
+    bad_key = "\xC3\x28".dup.force_encoding('UTF-8')
+    refute bad_key.valid_encoding?
+
+    hash = Sinatra::IndifferentHash.new
+    hash[bad_key] = 1
+    hash[:good] = 2
+
+    result = nil
+    assert_silent { result = hash.symbolize_keys }
+    assert_equal 1, result[bad_key]
+    assert_includes result.keys, bad_key
+    assert_equal 2, result[:good]
+  end
+
+  def test_binary_key_with_valid_encoding_is_symbolized
+    binary_key = "\xAB".b
+    assert binary_key.valid_encoding?
+
+    result = Sinatra::IndifferentHash[binary_key => 1].symbolize_keys
+    assert_equal 1, result[binary_key.to_sym]
+  end
+
+  def test_non_string_keys_pass_through_unchanged
+    hash = Sinatra::IndifferentHash.new
+    hash[:a] = 1   # stored as "a"
+    hash[0] = :zero
+
+    result = hash.symbolize_keys
+    assert_equal :zero, result[0]
+    assert_includes result.keys, 0
+    assert_equal 1, result[:a]
+  end
+
+  def test_result_is_no_longer_indifferent
+    result = Sinatra::IndifferentHash[a: 1].symbolize_keys
+    assert_equal 1, result[:a]
+    assert_nil result['a']
+  end
+
+  def test_nested_values_stay_indifferent
+    hash = Sinatra::IndifferentHash[outer: { inner: 1 }]
+    result = hash.symbolize_keys
+
+    assert_kind_of Sinatra::IndifferentHash, result[:outer]
+    assert_equal 1, result[:outer][:inner]
+    assert_equal 1, result[:outer]['inner']
+  end
+
+  def test_does_not_mutate_the_receiver
+    hash = Sinatra::IndifferentHash[a: 1]
+    hash.symbolize_keys
+    assert_equal ['a'], hash.keys
+  end
+end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -65,6 +65,30 @@ class RequestTest < Minitest::Test
     assert_equal 'bar', Marshal.load(dumped)['foo']
   end
 
+  it 'symbolizes wrapped params for keyword-argument splatting' do
+    request = Sinatra::Request.new(
+      'REQUEST_METHOD' => 'PUT',
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+      'rack.input' => StringIO.new('name=ada&lang=ruby')
+    )
+    params = Sinatra::IndifferentHash[request.params]
+    greet = ->(name:, lang:) { "#{name}/#{lang}" }
+    assert_equal 'ada/ruby', greet.call(**params.symbolize_keys)
+  end
+
+  it 'overrides ActiveSupport Hash#symbolize_keys for IndifferentHash instances' do
+    # test_helper preloads active_support/core_ext/hash/keys, which defines
+    # Hash#symbolize_keys. Our override must win by method resolution order and
+    # yield real symbols; AS's version routes through the overridden
+    # #transform_keys, which would re-stringify the keys.
+    assert Hash.method_defined?(:symbolize_keys), 'expected ActiveSupport to be loaded'
+
+    result = Sinatra::IndifferentHash[a: 1].symbolize_keys
+    assert_equal [Symbol], result.keys.map(&:class)
+    assert_instance_of Hash, result
+    refute_kind_of Sinatra::IndifferentHash, result
+  end
+
   it "exposes the preferred type's parameters" do
     request = Sinatra::Request.new(
       'HTTP_ACCEPT' => 'image/jpeg; compress=0.25'


### PR DESCRIPTION
## What

Adds `Sinatra::IndifferentHash#symbolize_keys`, the supported bridge for splatting params into keyword arguments:

```ruby
def some_method(name:, lang:); end
some_method(**params.symbolize_keys)
```

## Why

`IndifferentHash` stores symbol keys as strings (`convert_key`), so splatting it into keyword arguments does not bind:

```ruby
def greet(a:, b:); end
greet(**Sinatra::IndifferentHash[a: 1, b: 2])
# => ArgumentError: missing keywords: :a, :b   (keyword args bind by symbol; stored keys are strings)
```

There was no supported way to do this, and the obvious workaround is a silent trap:

```ruby
Sinatra::IndifferentHash[a: 1].transform_keys(&:to_sym).keys
# => ["a"]   <-- still strings!
```

`#transform_keys` is overridden to re-apply `convert_key`, so it turns the symbols straight back into strings.

> Note on #1592's original report: the `TypeError: hash key "a" is not a Symbol` it shows is Ruby <= 2.6 behaviour. On every Ruby Sinatra currently supports (floor `>= 2.7.8`), the live failure is the `ArgumentError` above (or, when splatting into a `**rest` collector, silently String-typed keys). The root cause is the same: stored keys are strings.

## Design

- New `#symbolize_keys` returns a **plain `Hash`** with symbol keys. It does **not** route through `#transform_keys` (that would re-stringify); it iterates and builds a plain Hash directly.
- **Internal string storage is untouched** (`convert_key` unchanged), so this is purely additive and backward compatible.
- **Encoding-guarded.** Param names are attacker-controlled and `#to_sym` raises `EncodingError` on invalid-encoding strings, so a `symbolizable?` predicate (`String && valid_encoding?`) leaves malformed keys, and non-string keys (Integers, existing Symbols), as-is rather than turning a request into a 500.
- The result is a plain Hash and is **no longer indifferent** (`s["a"]` returns nil) - documented on both the method and the class header. It is shallow: nested values were already wrapped as `IndifferentHash` by `convert_value`, so they stay indifferent.

This mirrors `ActiveSupport::HashWithIndifferentAccess`, which solves the same problem the same way (`**hash.symbolize_keys`, returning a plain Hash) and likewise never symbolizes its storage. Where ActiveSupport is loaded, this override wins for `IndifferentHash` instances by method resolution order, and is safer (encoding-guarded).

## Backward compatibility

Non-breaking, additive (one public method + one private predicate). `keys`, `to_h`, `**`, JSON, iteration, and every existing method are byte-for-byte unchanged. The only compatibility surface is the method name, which intentionally matches the ActiveSupport core-ext name.

## The honest scope question

This adds the **supported bridge**, not literal native-`**` transparency. `m(**params)` cannot yield symbol keys while keys are stored as strings, and flipping storage to symbols would invert the documented "keys come back as strings" guarantee and break consumers reading `params.keys` as strings - a major-version change, not something for a 4.x minor.

So: do you consider `**params.symbolize_keys` an acceptable resolution to #1592 (as Rails does for the identical case), or would you rather keep #1592 open as a tracker for native splat in a future major? I deliberately did not auto-close it.

## Tests

- `test/indifferent_hash_test.rb` (standalone, no ActiveSupport): symbol-key result, real-Symbol key classes (canary against a `#transform_keys` refactor), splatting into named kwargs and a `**` collector, invalid-encoding key left as String (no raise), binary key, non-string key pass-through, indifference-lost, nested-stays-indifferent, no mutation.
- `test/request_test.rb` (ActiveSupport loaded): real request params splat into kwargs, and the override wins over ActiveSupport's `Hash#symbolize_keys`.

Verified green on Ruby 3.4 and Ruby 2.7 (the gemspec floor); request tests pass with ActiveSupport loaded.
