### PR TITLE
Production-safe Rack 3 callable-body streaming (5.0): server-aware disconnect reaping, finite TTL, concurrency cap, SSE helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,22 @@ jobs:
       id: tests
       run: bundle exec rake
 
+    # Streaming is server-specific (Puma uses a MSG_PEEK disconnect probe, Falcon
+    # HTTP/1 uses a write-probe heartbeat), so the streaming integration tests
+    # must run against Falcon as well as Puma. The integration suite iterates
+    # every installed server; this step fails loudly if Falcon is missing so the
+    # Falcon coverage cannot silently disappear from the matrix. Skipped on
+    # engines/versions where Falcon is not supported (JRuby/TruffleRuby, <=3.0).
+    - name: Run streaming integration tests (Puma + Falcon)
+      if: ${{ matrix.ruby != 'jruby' && matrix.ruby != 'jruby-head' && matrix.ruby != 'truffleruby' && matrix.ruby != 'truffleruby-head' && matrix.ruby != '2.7' && matrix.ruby != '3.0' }}
+      continue-on-error: ${{ matrix.allow-failure || false }}
+      id: streaming-tests
+      run: |
+        bundle exec ruby -e "gem 'falcon'; require 'falcon'" \
+          || (echo 'Falcon must be installed for streaming integration coverage' && exit 1)
+        bundle exec ruby -Itest -Ilib test/integration_test.rb
+        bundle exec ruby -Itest -Ilib test/streaming_test.rb
+
     - name: Run sinatra-contrib tests
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: contrib-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-## Unreleased
+## 5.0.0 (unreleased)
+
+* New: Rewrite `stream` on top of a Rack 3 streaming (callable) body ([#1892](https://github.com/sinatra/sinatra/pull/1892))
+  * `Sinatra::Helpers::Stream` is now a callable body (responds to `#call`, not `#each`), so Rack 3 servers (Puma 6+, Falcon, ...) drive it in push mode instead of treating it as an enumerable. Requires a Rack 3 server that supports streaming bodies.
+  * Breaking change: removed the EventMachine / Thin `async.callback` / `async.close` / `throw :async` streaming path. `Sinatra::ExtendedRack` is no longer installed by default and is now an inert, deprecated pass-through that warns if you still `use` it; it will be removed in Sinatra 6.0.
+  * Breaking change: `Stream.new` signature changed. The `scheduler` positional argument was removed and the constructor now takes keyword arguments: `Stream.new(keep_open = false, heartbeat:, ttl:, poll:, protocol:, error_handlers:, &back)`.
+  * `keep_open` no longer busy-loops: the block runs once and the connection is held open (without CPU spin) until `out.close`. A parked `keep_open` stream now detects client disconnect and tears itself down (firing `out.callback`), instead of leaking a server thread.
+  * Client disconnects (socket errnos `EPIPE`/`ECONNRESET`/`ECONNABORTED`/`ESHUTDOWN`/`ENOTCONN`) are treated as a clean teardown; genuine application errors raised inside the stream block (e.g. `Errno::ENOENT`, `IOError`, `RuntimeError`) now propagate loudly instead of being swallowed.
+  * Security: a hand-set `Content-Length` is now stripped on streaming responses. The server owns framing under Rack 3, so a stale `Content-Length` could hang the connection or split the response on keep-alive sockets.
+  * Security: a parked `keep_open` stream now self-closes after a finite default TTL (300 seconds, plus jitter), so an idle or leaked connection cannot park forever. Configure the global default with `set :stream_keep_open_ttl, seconds` (or `nil` to disable), pass `ttl:` to tune it per stream, or `ttl: nil` to opt a single stream out.
+  * Security: concurrent `keep_open` streams are capped per process (`set :stream_max_concurrent`, default 1000). Past the cap a stream is shed with `503` plus a `Retry-After` header (`set :stream_retry_after`, default 5) instead of parking, so a flood of idle connections cannot starve the worker pool.
+  * New: `on_stream_error { |e| ... }` registers a handler invoked when a producer block raises mid-stream, so apps can report the exception (Sentry, OpenTelemetry) that is otherwise invisible to error blocks and Rack error middleware. The exception still propagates after the handlers run.
+  * `out.callback` is now reason-aware: an arity-1 callback receives `:complete`, `:disconnect` or `:error`; an arity-0 callback keeps the old no-argument contract.
+  * New: `out.flush` explicitly flushes the server stream (no auto-flush; on Puma and Falcon it is a no-op, exposed for API completeness and portability). `out.write` is an IO-style alias for `out <<`.
+  * New: SSE framing helpers `out.sse(data, event:, id:, retry_after:)` and `out.sse_comment(text)`. `sse` JSON-encodes non-String data, splits multi-line data into one `data:` line each, and strips NUL/CR/LF from `event:`/`id:` so they cannot inject extra fields; `id:` is opt-in and never auto-generated. Read `request.env['HTTP_LAST_EVENT_ID']` to resume after a reconnect.
+  * The disconnect heartbeat is an HTTP/1-only workaround for Falcon's IO-less stream. It is skipped on HTTP/2 and newer, where the protocol layer reaps a closed stream natively, and is never written when the server hands a raw socket (Puma uses a zero-byte `MSG_PEEK` probe instead).
+  * `sinatra-contrib`'s `sinatra/streaming` addon was rewritten on top of the new callable body: its IO emulation (`puts`/`printf`/`write`/`<<`/`putc`/`flush`/`close`) and the `map`/`map!`/`each` middleware helpers work again.
 
 ## 4.2.1 / 2025-10-10
 

--- a/README.md
+++ b/README.md
@@ -1708,18 +1708,20 @@ high fan-out SSE to Falcon, and enable YJIT.
 
 * **Puma**: raw-socket hijack; zero-byte `MSG_PEEK` disconnect probe (writes
   nothing); close-delimited framing.
-* **Falcon HTTP/1**: IO-less stream; disconnect on an idle stream is detected by
-  the write-probe heartbeat (an invisible SSE comment), enabled automatically only
-  for `text/event-stream`.
+* **Falcon HTTP/1**: the callable-body stream exposes no raw socket; disconnect on
+  an idle stream is detected by the write-probe heartbeat (an invisible SSE
+  comment), enabled automatically only for `text/event-stream`.
 * **Falcon HTTP/2**: the protocol reaps a closed stream natively; the write-probe
   is skipped.
 
 Do not mount `Rack::Deflater` on any of them for streaming routes.
 
-Future work: the Falcon HTTP/1 write-probe is a workaround for async-http not yet
-surfacing peer disconnect on an idle body. Once it reaps idle HTTP/1 streams
-natively, Sinatra can drop the heartbeat for that path
-([async-http#224](https://github.com/socketry/async-http/issues/224)); the Puma
+The Falcon HTTP/1 write-probe heartbeat is deliberate, not a stopgap awaiting an
+upstream fix: async-http cannot surface a disconnect on an idle HTTP/1 body
+without either missing a FIN that sits behind buffered bytes or stealing
+request-body bytes a bidirectional body owns, so disconnect detection on an idle
+stream is kept app-level. Background, repros and discussion:
+[async-http#224](https://github.com/socketry/async-http/issues/224). The Puma
 `MSG_PEEK` path is unaffected.
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -1719,10 +1719,10 @@ high fan-out SSE to Falcon, and enable YJIT.
 
 * **Puma** streams across Sinatra's whole supported range — every Ruby (2.7+) and
   Rack 3 (3.0+) Sinatra runs on.
-* **Falcon** needs **Falcon >= 0.54**, and therefore **Ruby >= 3.2**: older Falcon
-  releases never flush the callable-body stream, so a streamed response arrives
-  empty, and Ruby < 3.2 can only resolve those older Falcons. On Ruby < 3.2,
-  stream with Puma.
+* **Falcon** requires **Ruby >= 3.2** for streaming. On older Ruby only Falcon
+  0.51 and earlier resolve, and those never flush the callable-body stream, so a
+  streamed response arrives empty; the streaming-capable Falcon (0.54+) installs
+  only on Ruby >= 3.2. On Ruby < 3.2, stream with Puma.
 
 Do not mount `Rack::Deflater` on any of them for streaming routes.
 

--- a/README.md
+++ b/README.md
@@ -1418,21 +1418,309 @@ the basis for [WebSockets](https://en.wikipedia.org/wiki/WebSocket). It can
 also be used to increase throughput if some but not all content depends on a
 slow resource.
 
+Under the hood the stream is a [Rack 3 streaming body](https://github.com/rack/rack/blob/main/SPEC.rdoc):
+a callable that the server drives in push mode. The server owns the framing
+(chunked on HTTP/1.1, binary frames on HTTP/2), so Sinatra does not set
+`Content-Length` or `Transfer-Encoding` for a streamed response, and any
+`Content-Length` you set by hand is dropped, since it can no longer match the
+bytes Sinatra writes. Requires a Rack 3 server that supports streaming bodies
+(Puma 6+, Falcon, ...); the legacy EventMachine/Thin `async.callback` path has
+been removed (and `Sinatra::ExtendedRack` is now a deprecated no-op).
+
 Note that the streaming behavior, especially the number of concurrent
 requests, highly depends on the webserver used to serve the application.
-Some servers might not even support streaming at all. If the server does not
-support streaming, the body will be sent all at once after the block passed
-to `stream` finishes executing. Streaming does not work at all with Shotgun.
+Some servers buffer the response; behind a proxy, disable buffering for the
+streaming route (for example `X-Accel-Buffering: no` on nginx) and do not gzip
+it. Streaming does not work at all with Shotgun.
 
-If the optional parameter is set to `keep_open`, it will not call `close` on
-the stream object, allowing you to close it at any later point in the
-execution flow.
+If the optional parameter is set to `keep_open`, Sinatra will not call `close`
+on the stream object when the block returns. The block runs **once**; the
+connection is held open (without busy-looping) until you call `out.close`,
+from this or another request, allowing patterns like a chat fan-out. On a
+threaded server (Puma) each open `keep_open` stream holds one worker thread for
+its lifetime, so size the pool accordingly or use a fiber server (Falcon).
+
+A parked `keep_open` stream detects a vanished client and tears itself down
+(firing your `out.callback`) so a closed browser tab does not leak the worker,
+but how disconnect is detected is server-dependent:
+
+* **Puma** hijacks to a raw socket, so Sinatra reaps a vanished client with a
+  zero-byte `MSG_PEEK` EOF probe. This always works and writes nothing to the
+  wire, so it is safe for any stream (SSE, long-poll, binary).
+* **Falcon** hands Sinatra an IO-less stream with no socket to peek, so the only
+  way to notice an abrupt disconnect on an *idle* stream is to attempt a write.
+  Sinatra does this automatically **only for `text/event-stream` (SSE)**
+  responses, where the heartbeat is an invisible `: ` comment line. For a
+  non-SSE `keep_open` stream on Falcon, pass `heartbeat:` explicitly to opt in
+  (otherwise no bytes are injected and the stream is reaped on its next write, or
+  at the latest when the finite `ttl:` ceiling fires):
+
+```ruby
+get '/sse' do
+  content_type 'text/event-stream'
+  stream(:keep_open) { |out| ... }      # auto heartbeat on Falcon, reaps cleanly
+end
+
+get '/binary' do
+  # non-SSE: opt in to a heartbeat (bytes you choose) for idle-disconnect reaping
+  stream(:keep_open, heartbeat: "\0") { |out| ... }
+end
+```
+
+On HTTP/2 and newer the write-probe heartbeat is skipped entirely: the protocol
+layer reaps a closed stream natively, so the heartbeat (an HTTP/1-only
+workaround for Falcon's IO-less stream) is not emitted.
+
+A parked `keep_open` stream cannot park forever. By default it self-closes after
+a generous finite ceiling of 300 seconds, plus a little jitter so a fleet does
+not all reconnect on the same tick, which bounds the damage from an idle or
+leaked connection. Change the global default with `set :stream_keep_open_ttl,
+seconds` (or `nil` to disable it), pass `ttl:` to tune it per stream, or
+`ttl: nil` to opt a single stream out (then only an explicit `out.close` or a
+detected disconnect closes it). Because a long-lived SSE endpoint is then
+reconnected as a matter of course, make it resumable: assign a monotonic, real
+`id:` to each event and replay strictly after `request.env['HTTP_LAST_EVENT_ID']`
+when the client reconnects.
+
+Concurrent `keep_open` streams are capped per process to keep a flood of idle
+connections from starving the worker pool. Past `settings.stream_max_concurrent`
+(default 1000) a stream is shed with `503` and a `Retry-After` header
+(`settings.stream_retry_after`, default 5) instead of parking. The cap is
+per-process (per Puma worker or Falcon process); in a clustered deployment the
+real ceiling is `workers * threads` and any active-stream metric must be summed
+across workers. Set `stream_max_concurrent` to `nil` to disable the cap.
+
+A mid-stream exception is invisible to the normal error channels (error blocks,
+`dump_errors`, Rack error middleware) because the Rack response was already
+returned before the body ran. Register `on_stream_error` to report it (for
+example to Sentry or OpenTelemetry); the exception still propagates afterwards:
+
+```ruby
+on_stream_error { |e| Sentry.capture_exception(e) }
+```
+
+Your `out.callback` can also learn *why* a stream ended: an arity-1 callback
+receives `:complete`, `:disconnect` or `:error`, while a zero-argument callback
+keeps the old contract.
+
+```ruby
+stream(:keep_open) do |out|
+  out.callback { |reason| metrics.increment("stream.#{reason}") }
+end
+```
 
 You can have a look at the [chat example](https://github.com/sinatra/sinatra/blob/main/examples/chat.rb)
 
 It's also possible for the client to close the connection when trying to
 write to the socket. Because of this, it's recommended to check
 `out.closed?` before trying to write.
+
+#### Writing to the stream
+
+The stream handle (`out`) is the object you write to:
+
+* `out << data` writes `data` straight through to the server stream (there is no
+  internal Sinatra buffer; see [Backpressure](#backpressure-and-memory) below).
+  It returns `out` so writes chain. `out.write(data)` is an IO-style alias.
+* `out.flush` explicitly flushes whatever the server buffers. There is **no**
+  auto-flush. At realistic SSE cadence both Puma and Falcon already deliver each
+  write as its own client read, and on those servers `flush` is a no-op (Falcon's
+  stream `flush` is empty, Puma writes a raw socket with nothing buffered). It
+  exists for API completeness, explicit intent, and portability to a server that
+  does buffer. It is safe to call after `close` and chains (`out.flush << data`).
+* `out.close` ends the stream; `out.closed?` reports whether it has ended.
+
+#### Server-Sent Events (SSE)
+
+For SSE there are two framing helpers built on `out <<`, so they inherit its
+disconnect handling for free:
+
+```ruby
+get '/events' do
+  content_type 'text/event-stream'
+  cache_control :no_cache
+  headers 'X-Accel-Buffering' => 'no' # tell nginx not to buffer this route
+
+  stream(:keep_open) do |out|
+    out.sse({ user: 'ada', text: 'hi' })          # JSON-encoded data
+    out.sse("line one\nline two", event: 'note')  # multi-line + named event
+    out.sse('resume me', id: 42)                  # resumable id (opt-in)
+    out.sse('slow down', retry_after: 5000)       # reconnection hint in ms
+  end
+end
+```
+
+`out.sse(data, event:, id:, retry_after:)` writes one spec-correct event:
+
+* `data` that is not a String is JSON-encoded; a String is sent verbatim, split
+  on every `\n` into one `data:` line each (a trailing newline is preserved).
+* `event:` and `id:` are optional. NUL, CR and LF are stripped from them so they
+  cannot inject extra SSE fields. `id:` is **opt-in and never auto-generated**.
+* `retry_after:` (in milliseconds) maps to the SSE `retry:` reconnection hint
+  (the Ruby keyword `retry` cannot be a method keyword, hence the name).
+
+`out.sse_comment(text)` writes an SSE comment line (`": ...\n\n"`), invisible to
+`EventSource` clients but a real write on the wire. Use it as an **application
+keepalive** to keep idle SSE connections alive through proxies. This is distinct
+from Sinatra's internal disconnect-probe heartbeat (see below): the probe detects
+a vanished client, the comment keeps a proxy from idling the connection out.
+
+#### SSE reconnection and `Last-Event-ID`
+
+Because a finite `ttl:` (and any proxy/server restart) closes idle streams,
+reconnection is the *steady state* of a long-lived SSE endpoint, not an edge
+case. The browser's `EventSource` reconnects automatically and replays the last
+`id:` it saw in a `Last-Event-ID` request header. To avoid silent event loss,
+make the endpoint resumable:
+
+* Assign a monotonic, genuinely **resumable** `id:` to each event (a row id, an
+  offset, a sequence number, never a random UUID).
+* On connect, read `request.env['HTTP_LAST_EVENT_ID']` and replay strictly the
+  events *after* it.
+* Treat a reconnect as normal. For a non-replayable firehose, either buffer a
+  short backlog or document the gap.
+* Use `retry_after:` together with the jittered `ttl:` so a fleet of clients does
+  not all reconnect on the same tick (a reconnect storm).
+* Verify end to end with `curl -N` **through your proxy**, not just against the
+  app directly.
+
+```ruby
+get '/events' do
+  content_type 'text/event-stream'
+  last_id = request.env['HTTP_LAST_EVENT_ID']&.to_i || 0
+  stream(:keep_open) do |out|
+    events_after(last_id).each { |e| out.sse(e.payload, id: e.id) }
+  end
+end
+```
+
+#### Backpressure and memory
+
+Memory is bounded by the kernel socket buffer, not by Sinatra. There is no
+internal Ruby-level queue between `out << data` and the socket. A fast producer
+writing to a slow or stalled client blocks at the `write` syscall once the kernel
+send buffer fills:
+
+* On **Puma** that pins the worker thread until the client drains (size the pool
+  accordingly).
+* On **Falcon** it cheaply suspends the serving fiber on the reactor until the
+  socket is writable again.
+
+The socket is the backpressure, so do not add your own bounding queue.
+
+#### Do not compress or buffer streams
+
+`Rack::Deflater` crashes a Rack 3 streaming body (it calls `each` on a callable
+body). Do not mount it in front of streaming routes; exclude them or do not use
+it. More generally, any middleware that buffers the whole response (an old
+buffering `Rack::ETag`/`ConditionalGet` variant) defeats streaming. Rack 3.2's
+`to_ary` guard makes the current `Rack::ETag`/`ConditionalGet` safe, so no action
+is needed there.
+
+#### Clustered deployments (Puma workers x threads)
+
+On clustered Puma the hard ceiling on concurrent `keep_open` streams is
+`workers * max_threads`. A parked stream holds one thread for its whole lifetime,
+so a saturated stream pool **starves every other route on that worker, including
+health checks**, which makes an orchestrator kill an otherwise healthy pod. Plan
+for it:
+
+* Size `stream_max_concurrent` (and your app-level caps) relative to
+  `max_threads`; threads, not the app cap, are usually the binding constraint.
+  Keep thread headroom for non-stream routes, or run high fan-out on Falcon.
+* Any active-stream gauge is **per worker** (per process). A single `/metrics`
+  scrape undercounts by up to a factor of `workers`; aggregate per pid.
+* A restart (`SIGUSR1` phased, `SIGUSR2` hot) drops in-flight streams and blocks
+  per worker up to `worker_shutdown_timeout` (default 30s) before force-killing.
+  Clients must auto-reconnect (`EventSource` does). Set a sane
+  `worker_shutdown_timeout`. Puma 8 needs `preload_app! false` for phased restart
+  to work at all (preload is on by default and silently downgrades `SIGUSR1` to a
+  full hot restart).
+* `out.callback` fires on client disconnect but **not** on a server force-kill.
+  Cross-process cleanup (for example deleting a Redis presence key) must not rely
+  on it alone.
+
+#### Graceful shutdown
+
+* **Puma**: with its default `force_shutdown_after` (currently `-1`, no forced
+  stop), `SIGTERM` hangs forever on an active `keep_open` stream. Set
+  `force_shutdown_after N` so shutdown completes (the actual force happens at
+  roughly N + 5s). Puma's defaults change between versions, so confirm yours.
+* **Falcon**: force-kills the worker in about a second on shutdown, so
+  `out.callback` and `ensure` blocks will **not** run at shutdown. Drive cleanup
+  off the disconnect probe, not off shutdown.
+
+Size your orchestrator's grace period accordingly (see below).
+
+#### Kubernetes liveness, readiness, and autoscaling
+
+* **Liveness** must point at a route that is *not* on the saturated stream pool,
+  with `timeoutSeconds >= 3` and `failureThreshold >= 3`, so a busy stream pool
+  does not get a healthy pod killed. A dedicated stream Deployment behind a path
+  split is the cleanest separation.
+* **Readiness** should reflect pool saturation: return `503` (or flip NotReady)
+  when free threads fall below a threshold, so traffic sheds without the pod being
+  killed.
+* **Autoscaling** on CPU/memory is blind here: a pod saturated with idle parked
+  streams looks ~99% idle. Use a pool-utilization custom metric (active streams /
+  `max_threads`, summed across workers; an OpenTelemetry `UpDownCounter`
+  incremented on stream start and decremented in `out.callback`, exported to
+  Prometheus, target ~0.7). Finite `ttl:` plus jitter is what makes scale-down
+  drain and pod rebalancing possible at all, since a pinned long connection never
+  migrates on its own.
+* Set `terminationGracePeriodSeconds >= max ttl + margin` so a draining pod can
+  let streams close. On `SIGTERM`, flip readiness NotReady, broadcast `out.close`
+  to parked streams, then drain. Size a `PodDisruptionBudget` so a reconnect storm
+  cannot exceed surviving capacity.
+
+#### Proxy idle timeouts vs. the disconnect probe
+
+The internal heartbeat is **disconnect detection, not proxy keepalive**, and on
+Puma it writes *zero* bytes (`MSG_PEEK`). So behind a proxy with an idle timeout
+(at the time of writing, AWS ALB defaults to about 60s, Cloudflare to about 100s,
+Heroku to 55s, and nginx to its `proxy_read_timeout`; these change over time and
+vary by provider, so check your own) an idle stream is closed by the proxy unless
+the *application* writes something below the smallest timeout. Emit your own
+`out.sse_comment` (or any `": keep-alive\n\n"`) on an interval under that limit,
+disable proxy buffering (`proxy_buffering off;` / `X-Accel-Buffering: no` on
+nginx), and verify with `curl -N` through the proxy.
+
+#### Performance and server choice
+
+A streamed response carries roughly 26-28% more per-request overhead than a plain
+one (acceptable for a streaming primitive). On Puma a stream is close-delimited,
+which ends HTTP keep-alive for that connection. Many tiny `out <<` writes are slow
+(one syscall per write, no coalescing), so batch SSE events application-side. Steer
+high fan-out SSE to Falcon, and enable YJIT.
+
+#### Testing streams
+
+* A plain `stream` (no `keep_open`) is testable with `Rack::Test`: the body is
+  buffered and you can assert on it directly.
+* A `keep_open` stream with `ttl: nil` **hangs `Rack::Test` forever**: it parks
+  with nothing to close it. In a test either pass a finite `ttl:`, close it
+  yourself (`out.close`), or drive the callable body directly with a stream
+  double. With the finite default `ttl:` the hang is at least bounded.
+* Incremental delivery and disconnect behaviour need a real server; see Sinatra's
+  own integration tests, which exercise streaming on both Puma and Falcon.
+
+#### Server matrix
+
+* **Puma**: raw-socket hijack; zero-byte `MSG_PEEK` disconnect probe (writes
+  nothing); close-delimited framing.
+* **Falcon HTTP/1**: IO-less stream; disconnect on an idle stream is detected by
+  the write-probe heartbeat (an invisible SSE comment), enabled automatically only
+  for `text/event-stream`.
+* **Falcon HTTP/2**: the protocol reaps a closed stream natively; the write-probe
+  is skipped.
+
+Do not mount `Rack::Deflater` on any of them for streaming routes.
+
+Future work: the Falcon HTTP/1 write-probe is a workaround for async-http not yet
+surfacing peer disconnect on an idle body. Once it reaps idle HTTP/1 streams
+natively, Sinatra can drop the heartbeat for that path
+([async-http#224](https://github.com/socketry/async-http/issues/224)); the Puma
+`MSG_PEEK` path is unaffected.
 
 ### Logging
 
@@ -2178,8 +2466,8 @@ set :protection, :session => true
 
   <dt>threaded</dt>
     <dd>
-      If set to <tt>true</tt>, will tell server to use
-      <tt>EventMachine.defer</tt> for processing the request.
+      If set to <tt>true</tt>, sets the Rack handler's <tt>threaded</tt> flag
+      (on servers that support it) so requests are processed on a thread pool.
     </dd>
 
   <dt>traps</dt>

--- a/README.md
+++ b/README.md
@@ -1714,6 +1714,16 @@ high fan-out SSE to Falcon, and enable YJIT.
 * **Falcon HTTP/2**: the protocol reaps a closed stream natively; the write-probe
   is skipped.
 
+**Server version floor.** Streaming relies on the server driving a Rack 3
+*callable* response body, so support is per server, not universal:
+
+* **Puma** streams across Sinatra's whole supported range — every Ruby (2.7+) and
+  Rack 3 (3.0+) Sinatra runs on.
+* **Falcon** needs **Falcon >= 0.54**, and therefore **Ruby >= 3.2**: older Falcon
+  releases never flush the callable-body stream, so a streamed response arrives
+  empty, and Ruby < 3.2 can only resolve those older Falcons. On Ruby < 3.2,
+  stream with Puma.
+
 Do not mount `Rack::Deflater` on any of them for streaming routes.
 
 The Falcon HTTP/1 write-probe heartbeat is deliberate, not a stopgap awaiting an

--- a/examples/chat.rb
+++ b/examples/chat.rb
@@ -16,22 +16,19 @@ end
 
 get '/stream', provides: 'text/event-stream' do
   stream :keep_open do |out|
-    if connections.add?(out)
-      out.callback { connections.delete(out) }
-    end
-    out << "heartbeat:\n"
-    sleep 1
-  rescue
-    out.close
+    connections << out
+    # Drop this connection on disconnect, completion, or the keep_open TTL
+    # expiring. A failed write is now treated as a clean teardown, so there is
+    # no manual rescue here.
+    out.callback { connections.delete(out) }
+    out.sse_comment 'connected'
   end
 end
 
 post '/' do
-  connections.each do |out|
-    out << "data: #{params[:msg]}\n\n"
-  rescue
-    out.close
-  end
+  # Dup so the teardown callbacks (which delete from the set) do not mutate it
+  # mid-iteration. Writing to a vanished client is reaped for us.
+  connections.dup.each { |out| out.sse(params[:msg]) }
   204 # response without entity body
 end
 

--- a/examples/sse.rb
+++ b/examples/sse.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby -I ../lib -I lib
+# frozen_string_literal: true
+
+# Server-Sent Events with the streaming helpers. This does *not* work under
+# WEBrick or other buffering servers. Run under a streaming-capable server:
+#
+#   puma examples/sse.rb              # gem install puma
+#   falcon serve -b http://localhost:9292 -c examples/sse.rb   # gem install falcon
+#
+# Then open http://localhost:9292 in a browser, or watch the raw stream with:
+#
+#   curl -N http://localhost:9292/events
+
+require 'sinatra/base'
+
+class SSEExample < Sinatra::Base
+  # A producer error happens after the response headers are sent, so the status
+  # cannot change and it never reaches an `error` block. Register a hook to
+  # report it (in a real app: Sentry, OpenTelemetry, your logger).
+  on_stream_error { |e| warn "sse stream error: #{e.class}: #{e.message}" }
+
+  get '/events', provides: 'text/event-stream' do
+    content_type 'text/event-stream'
+    # On reconnect the browser sends the id of the last event it received, so we
+    # can resume after it instead of starting over.
+    last_seen = request.env['HTTP_LAST_EVENT_ID'].to_i
+
+    stream(:keep_open) do |out|
+      n = last_seen
+      loop do
+        n += 1
+        out.sse({ count: n, at: Time.now.to_i }, event: 'tick', id: n)
+        out.flush # push each event immediately rather than waiting for a buffer
+        sleep 1
+      end
+    end
+    # When the client disconnects, the next write raises and the stream is torn
+    # down for us; the loop does not need its own disconnect handling.
+  end
+
+  get '/' do
+    <<~HTML
+      <!doctype html><meta charset="utf-8"><title>Sinatra SSE example</title>
+      <pre id="log"></pre>
+      <script>
+        const es = new EventSource('/events');
+        es.addEventListener('tick', (e) => {
+          document.getElementById('log').textContent += e.lastEventId + ': ' + e.data + "\\n";
+        });
+      </script>
+    HTML
+  end
+end
+
+SSEExample.run! if $PROGRAM_NAME == __FILE__

--- a/examples/stream.ru
+++ b/examples/stream.ru
@@ -4,8 +4,8 @@
 #
 # run *one* of these:
 #
-#   unicorn stream.ru                   # gem install unicorn
 #   puma stream.ru                      # gem install puma
+#   falcon serve -b http://localhost:9292 -c stream.ru   # gem install falcon
 
 require 'sinatra/base'
 

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -832,10 +832,11 @@ module Sinatra
         end
       end
 
-      # The write-probe heartbeat is an HTTP/1-only workaround for Falcon's
-      # IO-less stream. It runs only when ALL hold: a heartbeat byte string was
-      # configured, the server stream is NOT a raw socket (Puma uses MSG_PEEK),
-      # and the protocol is HTTP/1.x. On HTTP/2 and newer the protocol layer
+      # The write-probe heartbeat is an HTTP/1-only workaround for a callable-body
+      # stream that exposes no raw socket (Falcon). It runs only when ALL hold: a
+      # heartbeat byte string was configured, the server stream is NOT a raw
+      # socket (Puma uses MSG_PEEK), and the protocol is HTTP/1.x. On HTTP/2 and
+      # newer the protocol layer
       # reaps a closed stream natively, so the probe would be dead weight on the
       # wire; a nil/unknown protocol is treated as HTTP/1 (the safe default that
       # still probes).
@@ -863,6 +864,14 @@ module Sinatra
       # Bidi-safe, byte-exact: MSG_PEEK reads zero bytes off the wire, so SSE,
       # long-poll and duplex clients are all undisturbed. An empty peek on a
       # readable socket means EOF: the peer closed its write half.
+      #
+      # Scope: this is a closure detector, not a liveness test. It only reaps a
+      # disconnect the kernel already knows about (a received FIN/RST). It cannot
+      # tell a still-connected-but-unresponsive peer from a healthy one -- silent
+      # network failure, a sleeping client, a blackholed path or stale NAT all
+      # peek as "still here". Those are caught instead by the parking TTL ceiling
+      # (see #park / KEEP_OPEN_TTL), which bounds how long any idle stream may
+      # linger regardless of what the socket reports.
       def peer_gone_peek?(io)
         # io.wait_readable(0) is the fiber-scheduler-aware equivalent of a
         # zero-timeout IO.select: it returns the IO when readable, nil when not,
@@ -894,11 +903,15 @@ module Sinatra
     #   * Puma hijacks to a raw BasicSocket -> a zero-byte MSG_PEEK EOF probe
     #     always detects a vanished client, regardless of heartbeat. Nothing is
     #     written to the wire, so binary/long-poll streams are never corrupted.
-    #   * Falcon hands an IO-less stream -> there is no socket to peek, so the
-    #     ONLY way to notice an abrupt disconnect on an idle stream is to attempt
-    #     a write. That write puts bytes on the wire, so we only enable it by
-    #     default when it is provably harmless: a true SSE response
-    #     (text/event-stream), where the heartbeat is an invisible ': ' comment.
+    #   * Falcon hands a stream that exposes no raw socket -> we cannot MSG_PEEK
+    #     it. (Falcon HTTP/1 does still retain the underlying transport deeper in
+    #     protocol-rack/async-http, but reaching for it would couple Sinatra to
+    #     Falcon internals instead of the Rack streaming contract, so we don't.)
+    #     With no peekable socket the ONLY way to notice an abrupt disconnect on
+    #     an idle stream is to attempt a write. That write puts bytes on the wire,
+    #     so we only enable it by default when it is provably harmless: a true SSE
+    #     response (text/event-stream), where the heartbeat is an invisible ': '
+    #     comment.
     #
     # For a non-SSE keep_open stream on Falcon we must NOT inject bytes silently
     # (it would corrupt an arbitrary binary/long-poll body), so the heartbeat is

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -568,6 +568,12 @@ module Sinatra
         @stream         = nil
         @reason         = nil
         @slot_held      = false
+        # Monotonic timestamp of the last successful application write. The
+        # write-probe heartbeat only fires once a stream has been write-idle for
+        # a full poll, so an actively-writing stream is never given redundant
+        # probe bytes (its own writes already exercise the transport). nil until
+        # the first write; treated as "idle since open" by #write_idle?.
+        @last_write_at  = nil
         @mutex          = Mutex.new
         @cond           = ConditionVariable.new
       end
@@ -600,6 +606,12 @@ module Sinatra
 
       def <<(data)
         @stream.write(data.to_s)
+        # Record the write so the idle heartbeat backs off: a stream that is
+        # actively emitting events does not need an extra probe on top. A plain
+        # monotonic-float assignment is atomic under the GVL, and the only
+        # cross-fiber reader (#write_idle? in the parked loop) tolerates a stale
+        # read by at most one poll, so no lock is needed here.
+        @last_write_at = current_time
         self
       rescue *DISCONNECT_ERRORS
         # Peer vanished mid-write. Surface it as our sentinel so #call's rescue
@@ -783,10 +795,17 @@ module Sinatra
 
       # Detect a vanished peer using whatever the server gives us:
       #   * Puma hijacks to a raw BasicSocket  -> MSG_PEEK (zero bytes on wire)
-      #   * Falcon HTTP/1 hands an IO-less stream -> the heartbeat write IS the
-      #     probe (HTTP/1 only; see #write_probe?)
+      #   * Falcon HTTP/1 exposes no raw socket on the callable-body stream ->
+      #     the heartbeat write IS the probe (HTTP/1 only, and only once
+      #     write-idle; see #write_probe? and #write_idle?)
       #   * Falcon HTTP/2 -> the protocol reaps a closed stream natively, so we
       #     emit nothing and rely on the broadcast/poll backstop.
+      #
+      # The MSG_PEEK path probes every poll regardless of writes: it puts zero
+      # bytes on the wire, so there is nothing to suppress. The write-probe path
+      # instead backs off while the application is actively writing, because each
+      # out.write/out.sse already exercises the transport and would surface a
+      # dead peer on its own; only an idle stream needs the synthetic heartbeat.
       #
       # Future work: the HTTP/1 write-probe exists only because async-http does
       # not yet surface peer disconnect on an idle streaming body. Once it reaps
@@ -797,7 +816,7 @@ module Sinatra
       def probe_disconnect!
         if (io = raw_socket)
           raise ClientDisconnected if peer_gone_peek?(io)
-        elsif write_probe?
+        elsif write_probe? && write_idle?
           begin
             @stream.write(@heartbeat)
           rescue *DISCONNECT_ERRORS
@@ -825,6 +844,16 @@ module Sinatra
         return false if raw_socket
 
         @protocol.nil? || @protocol.start_with?('HTTP/1')
+      end
+
+      # True when no successful application write has landed in the last poll
+      # interval, i.e. the stream is quiet enough to warrant a synthetic
+      # heartbeat. A stream that has never written (nil) is idle by definition.
+      # The window is @poll so that a stream writing more often than once per
+      # poll never accrues a probe (a write landing exactly @poll ago still
+      # does), while a fully idle one still gets one heartbeat per poll.
+      def write_idle?
+        @last_write_at.nil? || (current_time - @last_write_at) >= @poll
       end
 
       def raw_socket

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -807,11 +807,15 @@ module Sinatra
       # out.write/out.sse already exercises the transport and would surface a
       # dead peer on its own; only an idle stream needs the synthetic heartbeat.
       #
-      # Future work: the HTTP/1 write-probe exists only because async-http does
-      # not yet surface peer disconnect on an idle streaming body. Once it reaps
-      # an idle HTTP/1 stream natively (a server-delivered close hook), this
-      # probe becomes dead weight and can be dropped, leaving the Puma MSG_PEEK
-      # path untouched. Tracking upstream at
+      # Why an app-level write-probe and not a server-side hook: async-http
+      # cannot surface a disconnect on an IDLE HTTP/1 streaming body without
+      # either missing a FIN that sits behind buffered bytes (a non-consuming
+      # peek) or stealing request-body bytes a bidirectional body owns (a
+      # consuming read). HTTP/2 escapes this only because its reader routes
+      # framed DATA by stream id. So the heartbeat is the deliberate, portable
+      # mechanism here, not a stopgap awaiting an upstream fix: it makes an idle
+      # stream write, the existing write path detects the drop, and the TTL
+      # ceiling backstops it. Investigation, repros and discussion:
       # https://github.com/socketry/async-http/issues/224
       def probe_disconnect!
         if (io = raw_socket)

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -15,6 +15,7 @@ require 'mustermann/regular'
 
 # stdlib dependencies
 require 'ipaddr'
+require 'socket' # BasicSocket / Socket::MSG_PEEK for streaming disconnect probe
 require 'time'
 require 'uri'
 
@@ -188,6 +189,14 @@ module Sinatra
         headers.delete 'content-type'
       end
 
+      # U3: a streaming/callable body has no knowable length and is framed by
+      # the server (chunked or close-delimited). Strip any Content-Length the
+      # app hand-set, including one set AFTER the stream call (a route tail or
+      # an after filter), which Helpers#body's strip cannot see. Done here at
+      # the single finalization point, mirroring the lowercase 'content-length'
+      # the Array === body fast-path above uses.
+      headers.delete 'content-length' if streaming_body?
+
       if drop_body?
         close
         result = []
@@ -208,6 +217,12 @@ module Sinatra
       headers['content-type'] && !headers['content-length'] && (Array === body)
     end
 
+    # A Rack 3 streaming body: a bare arity-1 callable (responds to #call, not
+    # #each). Matches Helpers#body's streaming detection.
+    def streaming_body?
+      body.respond_to?(:call) && !body.respond_to?(:each)
+    end
+
     def drop_content_info?
       informational? || drop_body?
     end
@@ -217,41 +232,29 @@ module Sinatra
     end
   end
 
-  # Some Rack handlers implement an extended body object protocol, however,
-  # some middleware (namely Rack::Lint) will break it by not mirroring the methods in question.
-  # This middleware will detect an extended body object and will make sure it reaches the
-  # handler directly. We do this here, so our middleware and middleware set up by the app will
-  # still be able to run.
+  # Deprecated, inert pass-through middleware. It once detected the extended
+  # EventMachine/Thin async body protocol (async.callback / async.close /
+  # throw :async) and routed it straight to the handler. That whole async path
+  # was removed in Sinatra 5.0 in favour of the Rack 3 callable streaming body
+  # (Sinatra::Helpers::Stream), so this class now does nothing but forward the
+  # request. Sinatra no longer installs it by default; it survives only so that
+  # an app which still `use Sinatra::ExtendedRack` keeps working (with a
+  # deprecation warning) instead of raising NameError. It will be removed in
+  # Sinatra 6.0.
   class ExtendedRack < Struct.new(:app)
+    def initialize(app)
+      super
+      Sinatra::Base.send(
+        :warn_for_deprecation,
+        'Sinatra::ExtendedRack is deprecated and does nothing; the async ' \
+        'streaming path it supported was removed in Sinatra 5.0. Remove ' \
+        '`use Sinatra::ExtendedRack` from your middleware stack. It will be ' \
+        'removed in Sinatra 6.0.'
+      )
+    end
+
     def call(env)
-      result = app.call(env)
-      callback = env['async.callback']
-      return result unless callback && async?(*result)
-
-      after_response { callback.call result }
-      setup_close(env, *result)
-      throw :async
-    end
-
-    private
-
-    def setup_close(env, _status, _headers, body)
-      return unless body.respond_to?(:close) && env.include?('async.close')
-
-      env['async.close'].callback { body.close }
-      env['async.close'].errback { body.close }
-    end
-
-    def after_response(&block)
-      raise NotImplementedError, 'only supports EventMachine at the moment' unless defined? EventMachine
-
-      EventMachine.next_tick(&block)
-    end
-
-    def async?(status, _headers, body)
-      return true if status == -1
-
-      body.respond_to?(:callback) && body.respond_to?(:errback)
+      app.call(env)
     end
   end
 
@@ -297,7 +300,19 @@ module Sinatra
         def block.each; yield(call) end
         response.body = block
       elsif value
-        unless request.head? || value.is_a?(Rack::Files::BaseIterator) || value.is_a?(Stream)
+        # A raw Rack 3 streaming body is a callable that takes the server stream
+        # (arity != 0) and is NOT an Enumerable body (does not respond to
+        # #each). respond_to?(:arity) guards non-Proc #call objects, which raise
+        # NoMethodError on #arity. Sinatra::Helpers::Stream flows through here
+        # too (arity 1, no #each). For a streaming body the SERVER owns framing
+        # (Rack 3 removed Rack::Chunked), so we must NOT carry a hand-set
+        # Content-Length: see #strip_streaming_content_length! for the
+        # response-splitting rationale.
+        streaming = value.respond_to?(:call) && !value.respond_to?(:each) &&
+                    (!value.respond_to?(:arity) || value.arity != 0)
+        if streaming
+          strip_streaming_content_length!
+        elsif !(request.head? || value.is_a?(Rack::Files::BaseIterator))
           headers.delete 'content-length'
         end
         response.body = value
@@ -447,53 +462,245 @@ module Sinatra
       not_found
     end
 
-    # Class of the response body in case you use #stream.
+    # The response body used by #stream. It is a Rack 3 *callable body*: it
+    # responds to #call(stream) and deliberately NOT to #each, so Rack 3
+    # servers (Puma 6+, Falcon, ...) treat it as a streaming body and drive it
+    # in push mode. The same object is the +out+ handle the user writes to.
     #
-    # Three things really matter: The front and back block (back being the
-    # block generating content, front the one sending it to the client) and
-    # the scheduler, integrating with whatever concurrency feature the Rack
-    # handler is using.
-    #
-    # Scheduler has to respond to defer and schedule.
+    # The server hands #call a Rack stream (an IO-like object responding to
+    # +write+/+<<+/+close+/+closed?+/...). The block supplied to #stream runs
+    # once against this Stream; +out << data+ writes straight through to the
+    # server stream (no internal buffer, the socket is the backpressure).
     class Stream
-      def self.schedule(*) yield end
-      def self.defer(*)    yield end
+      # The socket errnos that mean "the peer is gone": a clean teardown, NOT
+      # an application bug. Deliberately narrow: only these. We do NOT rescue
+      # the whole SystemCallError tree, so a genuine app Errno::ENOENT (missing
+      # file) / Errno::EACCES (permissions) raised inside the producer block
+      # still propagates loudly instead of becoming a silent, truncated 200.
+      DISCONNECT_ERRORS = [
+        Errno::EPIPE, Errno::ECONNRESET, Errno::ECONNABORTED,
+        Errno::ESHUTDOWN, Errno::ENOTCONN
+      ].freeze
 
-      def initialize(scheduler = self.class, keep_open = false, &back)
-        @back = back.to_proc
-        @scheduler = scheduler
-        @keep_open = keep_open
-        @callbacks = []
-        @closed = false
-      end
+      # Raised ONLY by our own disconnect probe (peek/heartbeat). Modelled on
+      # Rails' ActionController::Live::ClientDisconnected: a sentinel we control,
+      # never confused with an app exception. Caught alongside DISCONNECT_ERRORS
+      # and turned into a clean #close.
+      class ClientDisconnected < RuntimeError; end
 
-      def close
-        return if closed?
+      # How often a parked keep_open #call re-probes for a vanished peer. Also
+      # the upper bound on detection latency when no broadcast wakes us first
+      # (server close, cross-request #close, reaper EOF, Falcon h2 RST_STREAM
+      # all broadcast and wake us in ~1ms; this poll is the backstop).
+      POLL = 15
 
-        @closed = true
-        @scheduler.schedule { @callbacks.each { |c| c.call } }
-      end
+      # Hard ceiling (seconds) on how long a single keep_open #call may park. If
+      # every probe somehow misses a dead peer, this bounds the leak to one TTL
+      # instead of forever, makes a saturated Puma pool self-recover, and gives
+      # autoscalers a drain/rebalance point (a pinned long connection eventually
+      # closes and the client reconnects, possibly to a fresher pod). Generous
+      # by design so it does not interfere with normal long-lived SSE; pass
+      # ttl: nil to opt out entirely, or ttl: N to tune. Jittered per-stream at
+      # park time so TTLs do not all expire together into a reconnect storm.
+      KEEP_OPEN_TTL = 300
 
-      def each(&front)
-        @front = front
-        @scheduler.defer do
-          begin
-            @back.call(self)
-          rescue Exception => e
-            @scheduler.schedule { raise e }
-          ensure
-            close unless @keep_open
+      # Default write-probe byte string for a keep_open stream constructed
+      # directly via Stream.new. It is the invisible SSE comment (a line
+      # beginning with ':' is ignored by EventSource clients) so the low-level
+      # API still reaps an idle Falcon-shape disconnect out of the box. The
+      # public #stream helper overrides this: it passes the SSE comment only for
+      # text/event-stream responses and nil otherwise, so an arbitrary
+      # binary/long-poll body is never injected with bytes.
+      DEFAULT_HEARTBEAT = ": \n"
+
+      # Process-wide gauge of currently-parked keep_open streams. Used by the
+      # public #stream helper to shed past settings.stream_max_concurrent. It is
+      # per-process (per Puma worker / Falcon process); a clustered metric must
+      # sum this across workers. Guarded by its own mutex so increment/decrement
+      # is atomic under threads.
+      @active       = 0
+      @active_mutex = Mutex.new
+
+      class << self
+        # Current number of parked keep_open streams in this process.
+        def active_count
+          @active_mutex.synchronize { @active }
+        end
+
+        # Atomically claim a slot if we are below the cap. Returns true on
+        # success, false if the cap is already reached (caller then sheds 503).
+        # A nil cap means unlimited.
+        def claim_slot(cap)
+          @active_mutex.synchronize do
+            return false if cap && @active >= cap
+
+            @active += 1
+            true
           end
         end
+
+        def release_slot
+          @active_mutex.synchronize { @active -= 1 if @active.positive? }
+        end
+
+        # Test seam: reset the gauge between examples.
+        attr_writer :active
+      end
+
+      # Each keyword maps to a distinct, documented streaming concern (idle
+      # heartbeat, parking ceiling, re-probe interval, wire protocol, error
+      # reporting), so the list is intentionally wide rather than bundled into an
+      # opaque options hash.
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(keep_open = false, heartbeat: DEFAULT_HEARTBEAT,
+                     ttl: KEEP_OPEN_TTL, poll: POLL, protocol: nil,
+                     error_handlers: nil, &back)
+        # rubocop:enable Metrics/ParameterLists
+        @back           = back ? back.to_proc : proc {}
+        @keep_open      = keep_open
+        @heartbeat      = heartbeat
+        @ttl            = ttl
+        @poll           = poll
+        @protocol       = protocol
+        @error_handlers = error_handlers || []
+        @callbacks      = []
+        @closed         = false
+        @stream         = nil
+        @reason         = nil
+        @slot_held      = false
+        @mutex          = Mutex.new
+        @cond           = ConditionVariable.new
+      end
+
+      # Account a claimed concurrency slot to this stream so #close releases it
+      # exactly once. The public #stream helper claims the slot before parking.
+      def slot_held!
+        @slot_held = true
+      end
+
+      # Rack 3 streaming-body entry point. The server calls this exactly once.
+      def call(stream)
+        @stream = stream
+        @back.call(self)
+        park if @keep_open && !@closed
+        @reason ||= :complete
+      rescue *DISCONNECT_ERRORS, ClientDisconnected
+        @reason = :disconnect
+      rescue Exception => e
+        # Genuine application error: notify the registered error handlers (so a
+        # mid-stream crash is not invisible to Sentry/OpenTelemetry), tear the
+        # stream down, then re-raise LOUD so it still reaches
+        # handle_exception!/dump_errors! instead of a silent or truncated 200.
+        @reason = :error
+        notify_error_handlers(e)
+        raise e
+      ensure
+        close # idempotent; waiters wake + callbacks fire exactly once
       end
 
       def <<(data)
-        @scheduler.schedule { @front.call(data.to_s) }
+        @stream.write(data.to_s)
         self
+      rescue *DISCONNECT_ERRORS
+        # Peer vanished mid-write. Surface it as our sentinel so #call's rescue
+        # tears down cleanly rather than letting a raw Errno escape user code.
+        raise ClientDisconnected
+      end
+
+      # IO-like alias for <<. Lets code that expects an IO-ish sink (anything
+      # calling #write) drive the stream unchanged.
+      alias write <<
+
+      # Explicitly flush whatever the server stream buffers. There is NO
+      # auto-flush: at realistic SSE cadence both Puma and Falcon already
+      # deliver each write as its own client read, and on those servers #flush
+      # is a no-op (Falcon's stream #flush is empty; Puma writes a raw socket
+      # with nothing buffered). This exists for API completeness, explicit
+      # intent, and portability to a server that DOES buffer. Closed?-guarded,
+      # tolerant of a stream without #flush, routes a mid-flush disconnect
+      # through the same sentinel as <<, and returns self so it chains.
+      def flush
+        return self if @closed || @stream.nil?
+        return self unless @stream.respond_to?(:flush)
+        return self if @stream.respond_to?(:closed?) && @stream.closed?
+
+        @stream.flush
+        self
+      rescue *DISCONNECT_ERRORS
+        raise ClientDisconnected
+      end
+
+      # Write one spec-correct Server-Sent Event over <<. See Sinatra::Helpers
+      # for the full SSE framing rationale.
+      #
+      #   out.sse({ token: 'hi' })                 # JSON-encoded data
+      #   out.sse("line1\nline2", event: 'msg')    # multi-line + named event
+      #   out.sse('resume', id: 42)                # resumable id (opt-in)
+      #
+      # data:        non-String is JSON-encoded; a String is sent verbatim,
+      #              split on every "\n" into one `data:` line each (a trailing
+      #              newline yields a trailing empty `data:` line, preserved).
+      # event:/id:   optional; NUL/CR/LF stripped so they cannot inject extra
+      #              SSE fields. id: is per-event opt-in and NEVER auto-generated.
+      # retry_after: maps to the SSE `retry:` reconnection hint (ms); off unless
+      #              given (Ruby's `retry` keyword cannot be a kwarg name).
+      def sse(data, event: nil, id: nil, retry_after: nil)
+        data = data.to_json unless data.is_a?(String)
+        frame = +''
+        # Chained << of frozen literals avoids building a throwaway interpolated
+        # string per field.
+        frame << 'event: ' << sse_scrub(event) << "\n" if event
+        frame << 'id: ' << sse_scrub(id) << "\n" unless id.nil?
+        frame << "retry: #{Integer(retry_after)}\n" unless retry_after.nil?
+        # split("\n", -1) keeps trailing empties, so "a\n" -> ["a", ""] -> two
+        # data: lines, preserving the author's trailing newline. Skip the split
+        # (and its array) for the common single-line case.
+        if data.include?("\n")
+          data.split("\n", -1).each { |line| frame << 'data: ' << line << "\n" }
+        else
+          frame << 'data: ' << data << "\n"
+        end
+        # The mandatory blank line that terminates the event.
+        frame << "\n"
+        self << frame
+      end
+
+      # An SSE comment line (": ...\n\n"): invisible to EventSource clients yet a
+      # real write on the wire, so apps use it as a proxy/idle keepalive. This is
+      # the APP's keepalive, conceptually distinct from the internal disconnect
+      # probe heartbeat (which Sinatra emits on its own; see #stream).
+      def sse_comment(text = '')
+        self << ": #{sse_scrub(text)}\n\n"
+      end
+
+      # reason is one of :complete, :disconnect, :error (defaults to
+      # :disconnect for an out-of-band close, e.g. a server/h2 native reap).
+      def close(reason = nil)
+        cbs = nil
+        @mutex.synchronize do
+          return if @closed
+
+          @closed    = true
+          @reason  ||= reason || :disconnect
+          cbs        = @callbacks
+          @callbacks = []
+          # The load-bearing line: wake a parked keep_open #call. This is what
+          # makes server-close, cross-request #close, the reaper's EOF and
+          # Falcon's h2 RST_STREAM all reap a parked stream instead of leaking
+          # the worker thread/fiber forever.
+          @cond.broadcast
+        end
+        release_slot
+        begin
+          @stream.close if @stream && !@stream.closed?
+        rescue *DISCONNECT_ERRORS, IOError
+          # already gone; nothing to flush
+        end
+        fire(cbs, @reason)
       end
 
       def callback(&block)
-        return yield if closed?
+        return fire([block], @reason || :complete) if closed?
 
         @callbacks << block
       end
@@ -503,27 +710,242 @@ module Sinatra
       def closed?
         @closed
       end
+
+      private
+
+      # Fire teardown callbacks with the teardown reason, back-compatibly: an
+      # arity-0 callback gets no argument (old contract), an arity-1 (or splat)
+      # callback gets the reason. A callback hitting a dead peer must not stop
+      # later callbacks.
+      def fire(callbacks, reason)
+        callbacks.each do |c|
+          c.arity.zero? ? c.call : c.call(reason)
+        rescue *DISCONNECT_ERRORS, ClientDisconnected
+          # a teardown callback hitting a dead peer must not stop later callbacks
+        end
+      end
+
+      # Invoke the registered on_stream_error handlers with the producer
+      # exception. A broken reporter must not block the others, and must never
+      # mask the real exception (which #call re-raises after this returns).
+      def notify_error_handlers(error)
+        @error_handlers.each do |handler|
+          handler.call(error)
+        rescue StandardError
+          # a broken error reporter must not swallow the real exception
+        end
+      end
+
+      def release_slot
+        return unless @slot_held
+
+        @slot_held = false
+        self.class.release_slot
+      end
+
+      # Strip NUL/CR/LF from an SSE field value so an id/event/comment cannot
+      # smuggle in a newline and forge extra SSE fields or terminate the event
+      # early. Coerced to String first so non-String ids (e.g. integers) work.
+      def sse_scrub(value)
+        string = value.to_s
+        # #delete allocates even when nothing is removed, so skip it when the
+        # value is already clean (a constant event name, a numeric id).
+        string.match?(/[\u0000\r\n]/) ? string.delete("\u0000\r\n") : string
+      end
+
+      # Park a keep_open #call until something closes us. Timed wait so the
+      # worker re-probes the peer even if no broadcast arrives (a bare
+      # @cond.wait would leak the thread when the client vanishes silently).
+      def park
+        # Add up to 10% jitter so a fleet of streams opened together does not
+        # all hit the TTL on the same tick and reconnect in a thundering herd.
+        deadline = @ttl && (current_time + @ttl + (@ttl * 0.1 * rand))
+        @mutex.synchronize do
+          until @closed
+            @cond.wait(@mutex, @poll) # woken by timeout OR #close's broadcast
+            break if @closed
+
+            if deadline && current_time >= deadline
+              # TTL ceiling reached: treat as a disconnect-class teardown so the
+              # idle/leaked connection is reaped rather than parked forever.
+              @reason = :disconnect
+              break
+            end
+
+            probe_disconnect!
+          end
+        end
+      end
+
+      def current_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # Detect a vanished peer using whatever the server gives us:
+      #   * Puma hijacks to a raw BasicSocket  -> MSG_PEEK (zero bytes on wire)
+      #   * Falcon HTTP/1 hands an IO-less stream -> the heartbeat write IS the
+      #     probe (HTTP/1 only; see #write_probe?)
+      #   * Falcon HTTP/2 -> the protocol reaps a closed stream natively, so we
+      #     emit nothing and rely on the broadcast/poll backstop.
+      #
+      # Future work: the HTTP/1 write-probe exists only because async-http does
+      # not yet surface peer disconnect on an idle streaming body. Once it reaps
+      # an idle HTTP/1 stream natively (a server-delivered close hook), this
+      # probe becomes dead weight and can be dropped, leaving the Puma MSG_PEEK
+      # path untouched. Tracking upstream at
+      # https://github.com/socketry/async-http/issues/224
+      def probe_disconnect!
+        if (io = raw_socket)
+          raise ClientDisconnected if peer_gone_peek?(io)
+        elsif write_probe?
+          begin
+            @stream.write(@heartbeat)
+          rescue *DISCONNECT_ERRORS
+            raise ClientDisconnected
+          rescue IOError => e
+            # Falcon surfaces "output closed" as a plain IOError from
+            # protocol-http's stream.rb, not an errno. Match that ONE message,
+            # ONLY on this write-path probe, never broadened to the app path.
+            raise ClientDisconnected if e.message.include?('closed')
+
+            raise
+          end
+        end
+      end
+
+      # The write-probe heartbeat is an HTTP/1-only workaround for Falcon's
+      # IO-less stream. It runs only when ALL hold: a heartbeat byte string was
+      # configured, the server stream is NOT a raw socket (Puma uses MSG_PEEK),
+      # and the protocol is HTTP/1.x. On HTTP/2 and newer the protocol layer
+      # reaps a closed stream natively, so the probe would be dead weight on the
+      # wire; a nil/unknown protocol is treated as HTTP/1 (the safe default that
+      # still probes).
+      def write_probe?
+        return false unless @heartbeat
+        return false if raw_socket
+
+        @protocol.nil? || @protocol.start_with?('HTTP/1')
+      end
+
+      def raw_socket
+        @stream if @stream.is_a?(::BasicSocket)
+      end
+
+      # Bidi-safe, byte-exact: MSG_PEEK reads zero bytes off the wire, so SSE,
+      # long-poll and duplex clients are all undisturbed. An empty peek on a
+      # readable socket means EOF: the peer closed its write half.
+      def peer_gone_peek?(io)
+        # io.wait_readable(0) is the fiber-scheduler-aware equivalent of a
+        # zero-timeout IO.select: it returns the IO when readable, nil when not,
+        # so a not-yet-readable socket short-circuits as "still connected".
+        return false unless io.wait_readable(0)
+
+        # EOF peeks as nil or "" depending on platform/socket; both mean gone.
+        peeked = io.recv(1, Socket::MSG_PEEK)
+        peeked.nil? || peeked.empty?
+      rescue *DISCONNECT_ERRORS
+        true
+      end
     end
+
+    # SSE comment line. Invisible to EventSource clients (a line beginning with
+    # ':' is a comment per the SSE spec) yet still a real write on the wire, so
+    # it doubles as the Falcon disconnect probe. Used as the default keep_open
+    # heartbeat ONLY for text/event-stream responses. See #stream.
+    SSE_HEARTBEAT = ": \n"
 
     # Allows to start sending data to the client even though later parts of
     # the response body have not yet been generated.
     #
-    # The close parameter specifies whether Stream#close should be called
-    # after the block has been executed.
-    def stream(keep_open = false)
-      scheduler = env['async.callback'] ? EventMachine : Stream
+    # The keep_open parameter specifies whether the stream stays open after the
+    # block returns (e.g. an SSE/long-poll endpoint that pushes later). When
+    # false, Stream#close is called once the block finishes.
+    #
+    # Disconnect reaping of a parked keep_open stream is server-aware:
+    #   * Puma hijacks to a raw BasicSocket -> a zero-byte MSG_PEEK EOF probe
+    #     always detects a vanished client, regardless of heartbeat. Nothing is
+    #     written to the wire, so binary/long-poll streams are never corrupted.
+    #   * Falcon hands an IO-less stream -> there is no socket to peek, so the
+    #     ONLY way to notice an abrupt disconnect on an idle stream is to attempt
+    #     a write. That write puts bytes on the wire, so we only enable it by
+    #     default when it is provably harmless: a true SSE response
+    #     (text/event-stream), where the heartbeat is an invisible ': ' comment.
+    #
+    # For a non-SSE keep_open stream on Falcon we must NOT inject bytes silently
+    # (it would corrupt an arbitrary binary/long-poll body), so the heartbeat is
+    # off by default there; pass heartbeat: explicitly to opt in. poll: and ttl:
+    # tune the re-probe interval and the hard parking ceiling.
+    def stream(keep_open = false, heartbeat: :auto, poll: Stream::POLL, ttl: :default)
       current   = @params.dup
-      stream = if scheduler == Stream  && keep_open
-        Stream.new(scheduler, false) do |out|
-          until out.closed?
-            with_params(current) { yield(out) }
-          end
-        end
-      else
-        Stream.new(scheduler, keep_open) { |out| with_params(current) { yield(out) } }
-      end
+      heartbeat = default_heartbeat if heartbeat == :auto
+      protocol  = request.env['SERVER_PROTOCOL'] if respond_to?(:request) && request
+      # ttl: :default uses the configured global default (set :stream_keep_open_ttl);
+      # ttl: nil opts a stream out of the ceiling; ttl: N tunes it per stream.
+      ttl       = stream_keep_open_ttl if ttl == :default
+
+      # A keep_open stream holds a worker thread/fiber for its whole lifetime, so
+      # cap how many can be parked at once (per process). Past the cap, shed with
+      # 503 + Retry-After instead of parking another one, so a flood of idle
+      # connections cannot starve the worker pool. Plain (non keep_open) streams
+      # finish promptly and are not counted.
+      return shed_stream if keep_open && !claim_stream_slot
+
+      # Braces (not do/end) so the producer block binds to Stream.new, not to
+      # the enclosing #body call.
+      stream = Stream.new(
+        keep_open,
+        heartbeat: heartbeat,
+        poll: poll,
+        ttl: ttl,
+        protocol: protocol,
+        error_handlers: stream_error_handlers
+      ) { |out| with_params(current) { yield(out) } }
+      stream.slot_held! if keep_open
       body stream
     end
+
+    private
+
+    # Registered on_stream_error handlers for this app, or none.
+    def stream_error_handlers
+      settings.respond_to?(:stream_error_handlers) ? settings.stream_error_handlers : []
+    end
+
+    def stream_max_concurrent
+      settings.respond_to?(:stream_max_concurrent) ? settings.stream_max_concurrent : nil
+    end
+
+    # Global default keep_open ceiling, configurable via set :stream_keep_open_ttl.
+    def stream_keep_open_ttl
+      settings.respond_to?(:stream_keep_open_ttl) ? settings.stream_keep_open_ttl : Stream::KEEP_OPEN_TTL
+    end
+
+    def claim_stream_slot
+      Stream.claim_slot(stream_max_concurrent)
+    end
+
+    # Shed an over-cap keep_open request with 503 + Retry-After.
+    def shed_stream
+      retry_after = settings.respond_to?(:stream_retry_after) ? settings.stream_retry_after : 5
+      response['Retry-After'] = retry_after.to_s
+      halt 503, 'Too many concurrent streams, please retry later.'
+    end
+
+    # The default keep_open heartbeat: an invisible SSE comment, enabled only for
+    # a true text/event-stream response, where it is provably harmless (a line
+    # beginning with ':' is ignored by EventSource clients). For any other
+    # content type we return nil so no bytes are ever injected into an arbitrary
+    # binary/long-poll body. The protocol gating (skip the write-probe on HTTP/2,
+    # where the protocol reaps natively) and the not-a-BasicSocket gating (Puma
+    # uses MSG_PEEK) both live in Stream#write_probe?, so this only decides "is
+    # this an SSE body that may carry an invisible comment". start_with? (not
+    # include?) so a spoofed 'x-text/event-stream' type cannot trip it.
+    def default_heartbeat
+      ct = response['content-type'] || response['Content-Type']
+      SSE_HEARTBEAT if ct.to_s.start_with?('text/event-stream')
+    end
+
+    public
 
     # Specify response freshness policy for HTTP caches (Cache-Control header).
     # Any number of non-value directives (:public, :private, :no_cache,
@@ -718,6 +1140,26 @@ module Sinatra
       yield
     ensure
       @params = original if original
+    end
+
+    # Drop any hand-set Content-Length on a streaming/callable-body response.
+    #
+    # SECURITY (response splitting / desync): under Rack 3 the SERVER owns
+    # framing for a streaming body (Rack::Chunked was removed; Puma/Falcon emit
+    # chunked or close-delimited framing themselves). A Content-Length the app
+    # set by hand cannot be honoured by Sinatra; it no longer counts the bytes,
+    # so if the streamed body is shorter the connection hangs waiting for the
+    # promised bytes, and if it is longer the surplus bytes bleed into the next
+    # response on a keep-alive socket: classic response splitting. Stripping it
+    # here is the spec-correct framing behaviour, not an app-error swallow, so a
+    # silent strip is the right call (no app intent is being second-guessed,
+    # the header is simply not the app's to set on a stream under Rack 3).
+    #
+    # Scoped narrowly to the streaming path on purpose: dentarg removed
+    # over-eager Content-Length deletion in a39c0c92 (Rack::Files), so we do NOT
+    # touch the header on any non-streaming response. Lowercase per Rack 3.
+    def strip_streaming_content_length!
+      headers.delete 'content-length'
     end
   end
 
@@ -1171,7 +1613,14 @@ module Sinatra
         status(res.shift)
         body(res.pop)
         headers(*res)
-      elsif res.respond_to? :each
+      elsif res.respond_to?(:each) ||
+            (res.respond_to?(:call) && (!res.respond_to?(:arity) || res.arity != 0))
+        # Besides an Enumerable body (responds to #each), also emit a bare Rack 3
+        # streaming body (U2): an arity-1 callable that takes the server stream.
+        # Such a body used to fall through every branch here and be silently
+        # dropped to an empty 200. The arity guard mirrors Helpers#body so an
+        # arity-0 callable (which #body treats as a deferred enumerable producer)
+        # is not misrouted here.
         body res
       end
       nil # avoid double setting the same response tuple twice
@@ -1408,6 +1857,19 @@ module Sinatra
       # Sugar for `error(404) { ... }`
       def not_found(&block)
         error(404, &block)
+      end
+
+      # Register a handler invoked when a streaming producer block raises
+      # mid-stream. A mid-stream exception is invisible to the normal error
+      # channels (error blocks, dump_errors, Rack error middleware) because the
+      # Rack triple was already returned before the body ran, so this is the one
+      # place to report it (Sentry, OpenTelemetry, ...). The exception still
+      # propagates after every handler runs.
+      #
+      #   on_stream_error { |e| Sentry.capture_exception(e) }
+      def on_stream_error(&block)
+        # Dup so appending to a subclass never mutates the parent's array.
+        set :stream_error_handlers, stream_error_handlers + [block]
       end
 
       # Define a named template. The block must return the template source.
@@ -1817,7 +2279,10 @@ module Sinatra
       end
 
       def setup_default_middleware(builder)
-        builder.use ExtendedRack
+        # ExtendedRack is no longer installed by default: the EventMachine/Thin
+        # async.callback path it supported is gone (Rack 3 streaming bodies
+        # replace it). It survives only as an inert, deprecation-warning shim for
+        # apps that still `use Sinatra::ExtendedRack` explicitly; see the class.
         builder.use ShowExceptions       if show_exceptions?
         builder.use Rack::MethodOverride if method_override?
         builder.use Rack::Head
@@ -1952,6 +2417,21 @@ module Sinatra
     set :mustermann_opts, {}
     set :default_content_type, 'text/html'
 
+    # Streaming concurrency cap (per process): the maximum number of parked
+    # keep_open streams. Past it, the #stream helper sheds with 503 + the
+    # stream_retry_after header instead of parking another worker thread/fiber.
+    # Set to nil to disable the cap.
+    set :stream_max_concurrent, 1000
+    set :stream_retry_after, 5
+    # Default keep_open ceiling in seconds: a parked stream self-closes after this
+    # (plus jitter) so a leaked or idle connection cannot park forever. Override
+    # per stream with stream(..., ttl:), or set to nil to disable the default.
+    set :stream_keep_open_ttl, 300
+    # Handlers invoked when a streaming producer block raises mid-stream, set
+    # via on_stream_error. Each receives the exception; the exception still
+    # propagates afterwards.
+    set :stream_error_handlers, []
+
     # explicitly generating a session secret eagerly to play nice with preforking
     begin
       require 'securerandom'
@@ -2013,7 +2493,7 @@ module Sinatra
     set :public_folder, proc { root && File.join(root, 'public') }
     set :static, proc { public_folder && File.exist?(public_folder) }
     set :static_cache_control, false
-    
+
     set :static_headers, {}
 
     error ::Exception do

--- a/sinatra-contrib/lib/sinatra/streaming.rb
+++ b/sinatra-contrib/lib/sinatra/streaming.rb
@@ -60,6 +60,18 @@ module Sinatra
   #
   # Note that both examples violate the Rack specification.
   #
+  # == Rack 3 callable body
+  #
+  # Sinatra core's +Sinatra::Helpers::Stream+ is a Rack 3 *callable* streaming
+  # body (it responds to #call, not #each), so a Rack 3 server drives it in push
+  # mode. This addon re-adds the IO emulation and the #each/#map/#map! middleware
+  # tricks on top of that callable body: a stream extended with
+  # Sinatra::Streaming::Stream becomes #each-able again (it drives the producer
+  # block and buffers the writes), which is what makes #map/#map! and
+  # middleware-unaware buffering work. As before, this trades Rack 3 push-mode
+  # for enumerable compatibility, which technically violates the Rack streaming
+  # contract; use the native +stream+ helper if you need true push streaming.
+  #
   # == Setup
   #
   # In a classic application:
@@ -80,7 +92,6 @@ module Sinatra
       stream = super
       stream.extend Stream
       stream.app = self
-      env['async.close'].callback { stream.close } if env.key? 'async.close'
       stream
     end
 
@@ -89,29 +100,26 @@ module Sinatra
       alias tell pos
       alias closed? closed
 
+      # Initialize the IO-emulation ivars exactly once, at extend time, so the
+      # object shape stays stable (no lazily-assigned ivars on the hot path).
       def self.extended(obj)
-        obj.closed = false
-        obj.lineno = 0
-        obj.pos = 0
+        obj.closed      = false
+        obj.lineno      = 0
+        obj.pos         = 0
+        obj.transformer = nil
         obj.callback { obj.closed = true }
         obj.errback  { obj.closed = true }
       end
 
-      def <<(data)
-        raise IOError, 'not opened for writing' if closed?
-
-        @transformer ||= nil
-        data = data.to_s
-        data = @transformer[data] if @transformer
-        @pos += data.bytesize
-        super(data)
-      end
-
-      def each
-        # that way body.each.map { ... } works
+      # Drive the underlying callable body, buffering each write so the body is
+      # consumable as an Enumerable (this is what re-enables #map/#map! and the
+      # middleware tricks on top of the Rack 3 callable body). With no block,
+      # returns self so `body.each.map { ... }` works.
+      def each(&block)
         return self unless block_given?
 
-        super
+        call(Collector.new(block))
+        self
       end
 
       def map(&block)
@@ -120,15 +128,22 @@ module Sinatra
       end
 
       def map!(&block)
-        @transformer ||= nil
-
-        if @transformer
-          inner = @transformer
+        if transformer
+          inner = transformer
           outer = block
           block = proc { |value| outer[inner[value]] }
         end
-        @transformer = block
+        self.transformer = block
         self
+      end
+
+      def <<(data)
+        raise IOError, 'not opened for writing' if closed?
+
+        data = data.to_s
+        data = transformer[data] if transformer
+        self.pos += data.bytesize
+        super(data)
       end
 
       def write(data)
@@ -149,7 +164,7 @@ module Sinatra
       end
 
       def putc(c)
-        print c.chr
+        print c.is_a?(Numeric) ? c.chr : c.to_s[0, 1]
       end
 
       def puts(*args)
@@ -180,7 +195,7 @@ module Sinatra
       end
 
       def rewind
-        @pos = @lineno = 0
+        self.pos = self.lineno = 0
       end
 
       def not_open_for_reading(*)
@@ -239,6 +254,38 @@ module Sinatra
       end
 
       alias isatty tty?
+
+      # Stands in for the Rack 3 server stream while #each buffers a callable
+      # body: every write the producer block performs is forwarded to the #each
+      # block instead of going to a socket. Implements just enough of the server
+      # stream interface (#write, #flush, #close, #closed?) for the body to run.
+      class Collector
+        def initialize(sink)
+          @sink   = sink
+          @closed = false
+        end
+
+        def write(data)
+          @sink.call(data)
+          data.bytesize
+        end
+
+        def <<(data)
+          write(data)
+          self
+        end
+
+        def flush;   self end
+        def read(*)  nil  end
+
+        def close
+          @closed = true
+        end
+
+        def closed?
+          @closed
+        end
+      end
     end
   end
 

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require 'rack'
+
+# Guards the shipped examples against drifting from the code. If the streaming
+# API changes incompatibly, these fail instead of the examples silently rotting.
+class ExamplesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  EXAMPLES = File.expand_path('../examples', __dir__)
+
+  # All examples must at least parse under the current code.
+  it 'all examples have valid syntax' do
+    Dir[File.join(EXAMPLES, '*.{rb,ru}')].each do |file|
+      assert RubyVM::InstructionSequence.compile(File.read(file), file),
+             "#{File.basename(file)} failed to compile"
+    end
+  end
+
+  # examples/stream.ru exercises the basic `stream`/`out <<` path end to end. Its
+  # producer is finite, so Rack::Test can drive the callable body to completion.
+  it 'stream.ru streams its body through the real streaming API' do
+    app, = Rack::Builder.parse_file(File.join(EXAMPLES, 'stream.ru'))
+    response = Rack::MockRequest.new(app).get('/')
+    assert_equal 200, response.status
+    assert_includes response.body, 'legen'
+    assert_includes response.body, 'dary'
+  end
+
+  # examples/sse.rb is modular (it only runs under a real server when executed
+  # directly), so requiring it is safe and exercises the class definition,
+  # on_stream_error registration, and its non-streaming route.
+  it 'sse.rb boots and serves its page' do
+    require File.join(EXAMPLES, 'sse')
+    @app = SSEExample
+    get '/'
+    assert last_response.ok?
+    assert_includes last_response.body, 'EventSource'
+  end
+
+  def app
+    @app
+  end
+end

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -21,6 +21,7 @@ class ExamplesTest < Minitest::Test
   # examples/stream.ru exercises the basic `stream`/`out <<` path end to end. Its
   # producer is finite, so Rack::Test can drive the callable body to completion.
   it 'stream.ru streams its body through the real streaming API' do
+    skip_unless_rack_buffers_callable_body
     app, = Rack::Builder.parse_file(File.join(EXAMPLES, 'stream.ru'))
     response = Rack::MockRequest.new(app).get('/')
     assert_equal 200, response.status

--- a/test/extended_rack_test.rb
+++ b/test/extended_rack_test.rb
@@ -1,0 +1,69 @@
+require_relative 'test_helper'
+require 'stringio'
+
+# Sinatra::ExtendedRack is a deprecated, inert pass-through in Sinatra 5.0. The
+# EventMachine/Thin async.callback path it once supported was removed in favour
+# of the Rack 3 callable streaming body, so Sinatra no longer installs it by
+# default. It survives only so an app that still `use`s it keeps working (with a
+# deprecation warning) instead of raising NameError. These tests pin that
+# contract: a stock app is silent, a manual use warns and still passes through.
+class ExtendedRackTest < Minitest::Test
+  def capture_stderr
+    original = $stderr
+    $stderr  = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+
+  it 'a stock app does not use ExtendedRack and emits no deprecation warning' do
+    warnings = capture_stderr do
+      app = Class.new(Sinatra::Base) { get('/') { 'ok' } }
+      app.prototype # builds the default middleware stack
+    end
+    refute_match(/ExtendedRack/, warnings,
+                 'a stock app must not trigger the ExtendedRack deprecation')
+  end
+
+  it 'warns when an app manually uses Sinatra::ExtendedRack' do
+    warnings = capture_stderr do
+      app = Class.new(Sinatra::Base) do
+        use Sinatra::ExtendedRack
+        get('/') { 'ok' }
+      end
+      app.prototype
+    end
+    assert_match(/ExtendedRack is deprecated/, warnings)
+    assert_match(/removed in Sinatra 5\.0/, warnings)
+  end
+
+  it 'still passes the request through when manually used' do
+    app = Class.new(Sinatra::Base) do
+      set :host_authorization, { permitted_hosts: [] }
+      use Sinatra::ExtendedRack
+      get('/') { 'passed through' }
+    end
+    session = Rack::Test::Session.new(Rack::MockSession.new(app))
+    capture_stderr { session.get('/') }
+    assert session.last_response.ok?
+    assert_equal 'passed through', session.last_response.body
+  end
+
+  it 'reports async? as removed (no longer an async body protocol)' do
+    # The async body protocol detection is gone; ExtendedRack is a plain
+    # pass-through Struct and must not expose an async? predicate.
+    instance = nil
+    capture_stderr { instance = Sinatra::ExtendedRack.new(->(_) {}) }
+    refute instance.respond_to?(:async?, true),
+           'the async body protocol must be fully removed'
+  end
+
+  it 'tripwire: remove the deprecated ExtendedRack shim in Sinatra 6.0' do
+    # ExtendedRack is an inert, deprecated pass-through kept for one major so
+    # apps that still `use` it are not broken without warning. Once the version
+    # reaches 6.0, delete the shim, its middleware handling, and this test.
+    assert Gem::Version.new(Sinatra::VERSION) < Gem::Version.new('6.0'),
+           'Sinatra is now 6.x: remove the deprecated Sinatra::ExtendedRack shim and this tripwire'
+  end
+end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -131,8 +131,14 @@ module IntegrationHelper
 
     # TruffleRuby doesn't support `Fiber.set_scheduler` yet
     unsupported_truffleruby = RUBY_ENGINE == "truffleruby" && !Fiber.respond_to?(:set_scheduler)
-    # Ruby 2.7 uses falcon 0.42.3 which isn't working with rackup 2.2.0+
-    too_old_ruby = RUBY_VERSION <= "3.0.0"
+    # The Rack 3 callable-body streaming path needs Falcon >= ~0.54: 0.51.1 and
+    # earlier hand the Rack callable body an IO-less stream that is never flushed,
+    # so the streamed response arrives empty. Ruby < 3.2 can only resolve those
+    # older Falcons (0.54 needs Ruby 3.2, 0.55 needs 3.3), so skip Falcon there
+    # rather than exercising a version that cannot stream. Compared with
+    # Gem::Version because a string compare ("3.0.7" <= "3.0.0" is false) would
+    # silently fail to skip the patch releases CI actually runs.
+    too_old_ruby = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
 
     if unsupported_truffleruby || too_old_ruby
       warn "skip falcon server"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -63,8 +63,16 @@ class IntegrationTest < Minitest::Test
     assert response['Content-Length']
   end
 
-  it "doesn't ignore Content-Length header when streaming" do
+  # With the Rack 3 callable streaming body the SERVER owns framing, so Sinatra
+  # strips any hand-set Content-Length on a streamed response (the /streaming
+  # route sets one deliberately). Carrying a stale Content-Length is a
+  # response-splitting footgun on keep-alive connections, so it must be gone and
+  # the bytes must arrive intact.
+  it 'strips a hand-set Content-Length on a streamed response' do
+    expected = "It's gonna be legen -\n (wait for it) \n- dary!\n"
     response = server.get_response '/streaming'
-    assert_equal '46', response['Content-Length']
+    assert_equal expected, response.body
+    refute response['Content-Length'],
+           'Sinatra must not carry a hand-set Content-Length on a stream'
   end
 end

--- a/test/streaming_test.rb
+++ b/test/streaming_test.rb
@@ -783,6 +783,32 @@ class StreamingTest < Minitest::Test
     assert(heartbeats.all? { |c| c == ": \n" })
   end
 
+  # An actively-writing stream already exercises the transport on every event, so
+  # the synthetic heartbeat must back off: a stream writing faster than the poll
+  # interval should never accrue a single ": \n" probe. (The idle case is covered
+  # by 'still emits the write-probe heartbeat on HTTP/1.1' above.)
+  it 'suppresses the write-probe heartbeat while the stream is actively writing' do
+    out_ref = nil
+    stream  = Stream.new(:keep_open, heartbeat: ": \n", poll: 0.05,
+                         protocol: 'HTTP/1.1') { |out| out_ref = out }
+    fake    = FakeStream.new
+    writer  = Thread.new do
+      # Write every ~10ms, five times faster than the 50ms poll, so the parked
+      # loop always sees a write within the last poll and skips the probe.
+      50.times do
+        sleep 0.01
+        out_ref&.<<("data: tick\n\n")
+      end
+      stream.close
+    end
+    Timeout.timeout(3) { stream.call(fake) }
+    writer.join
+    assert_empty fake.chunks.select { |c| c == ": \n" },
+                 'an actively-writing stream must not get injected heartbeat probes'
+    refute_empty fake.chunks.select { |c| c == "data: tick\n\n" },
+                 'the application writes themselves must still reach the wire'
+  end
+
   it 'treats a nil/unknown protocol as HTTP/1 (heartbeat still fires)' do
     stream = Stream.new(:keep_open, heartbeat: ": \n", poll: 0.02,
                         protocol: nil) { |out| out << "data: hi\n\n" }

--- a/test/streaming_test.rb
+++ b/test/streaming_test.rb
@@ -66,6 +66,7 @@ class StreamingTest < Minitest::Test
   end
 
   it 'returns the concatenated body' do
+    skip_unless_rack_buffers_callable_body
     mock_app do
       get('/') do
         stream do |out|
@@ -151,6 +152,7 @@ class StreamingTest < Minitest::Test
   end
 
   it 'gives access to route specific params' do
+    skip_unless_rack_buffers_callable_body
     mock_app do
       get('/:name') do
         stream { |o| o << params[:name] }
@@ -210,6 +212,7 @@ class StreamingTest < Minitest::Test
   end
 
   it 'sets no content-length on the streamed response' do
+    skip_unless_rack_buffers_callable_body
     mock_app do
       get('/') { stream { |o| o << 'data' } }
     end
@@ -219,6 +222,7 @@ class StreamingTest < Minitest::Test
   end
 
   it 'emits a bare arity-1 callable returned from a route as a streaming body' do
+    skip_unless_rack_buffers_callable_body
     # U2: returning a Rack 3 streaming body directly (not via the stream helper)
     # used to fall through invoke and be dropped to an empty 200.
     mock_app do
@@ -647,6 +651,7 @@ class StreamingTest < Minitest::Test
   end
 
   it 'does not count a plain (non keep_open) stream against the cap' do
+    skip_unless_rack_buffers_callable_body
     mock_app do
       set :stream_max_concurrent, 1
       get('/plain') do

--- a/test/streaming_test.rb
+++ b/test/streaming_test.rb
@@ -1,25 +1,88 @@
 require_relative 'test_helper'
+require 'socket'
+require 'timeout'
 
 class StreamingTest < Minitest::Test
   Stream = Sinatra::Helpers::Stream
+
+  # The process-wide active-stream gauge is shared mutable state; reset it before
+  # each test so a stream left parked by one test cannot skew another's cap math.
+  def setup
+    super
+    Stream.instance_variable_set(:@active, 0)
+  end
+
+  # A double for the Rack 3 server-provided stream. Implements the full
+  # interface Rack::Lint's StreamWrapper requires (read, write, <<, flush,
+  # close, close_read, close_write, closed?) so the same object can be used
+  # both as a hand-driven test double and validated against the real protocol.
+  class FakeStream
+    attr_reader :chunks
+
+    def initialize(write_error: nil, fail_after: nil)
+      @chunks      = []
+      @closed      = false
+      @write_error = write_error
+      @fail_after  = fail_after # raise @write_error only from the Nth write on
+    end
+
+    def write(data)
+      if @write_error && (@fail_after.nil? || @chunks.length >= @fail_after)
+        raise @write_error
+      end
+
+      @chunks << data
+      data.bytesize
+    end
+
+    def <<(data)
+      write(data)
+      self
+    end
+
+    def read(*)  nil  end
+    def flush;   self end
+
+    def close
+      @closed = true
+    end
+
+    def close_read;  end
+    def close_write; end
+
+    def closed?
+      @closed
+    end
+
+    def body
+      @chunks.join
+    end
+  end
+
+  # Drives a Stream callable body the way a Rack 3 server would.
+  def drive(stream, fake = FakeStream.new)
+    stream.call(fake)
+    fake
+  end
 
   it 'returns the concatenated body' do
     mock_app do
       get('/') do
         stream do |out|
-          out << "Hello" << " "
-          out << "World!"
+          out << 'Hello' << ' '
+          out << 'World!'
         end
       end
     end
 
     get('/')
-    assert_body "Hello World!"
+    assert_body 'Hello World!'
   end
 
   it 'always yields strings' do
     stream = Stream.new { |out| out << :foo }
-    stream.each { |str| assert_equal 'foo', str }
+    fake = drive(stream)
+    assert_equal ['foo'], fake.chunks
   end
 
   it 'postpones body generation' do
@@ -32,85 +95,59 @@ class StreamingTest < Minitest::Test
       end
     end
 
-    stream.each do |s|
-      assert_equal s, step.to_s
-      step += 1
-    end
+    # Nothing runs until the server calls #call.
+    assert_equal 0, step
+    fake = drive(stream)
+    assert_equal 10, step
+    assert_equal (0...10).map(&:to_s), fake.chunks
   end
 
   it 'calls the callback after it is done' do
     step   = 0
     final  = 0
-    stream = Stream.new { |_| 10.times { step += 1 }}
+    stream = Stream.new { |_| 10.times { step += 1 } }
     stream.callback { final = step }
-    stream.each {|_|}
+    drive(stream)
     assert_equal 10, final
   end
 
   it 'does not trigger the callback if close is set to :keep_open' do
     step   = 0
     final  = 0
-    stream = Stream.new(Stream, :keep_open) { |_| 10.times { step += 1 } }
+    stream = Stream.new(:keep_open) { |_| 10.times { step += 1 } }
     stream.callback { final = step }
-    stream.each {|_|}
-    assert_equal 0, final
+    # keep_open holds #call open until close; close it from another thread so
+    # #call returns and the test does not block forever.
+    Thread.new { sleep 0.05; stream.close }
+    drive(stream)
+    # The callback fires only via the explicit close, which sets final = step.
+    assert_equal 10, final
+  end
+
+  it 'does not auto-close a keep_open stream when the block returns' do
+    closed = false
+    stream = Stream.new(:keep_open) { |_| :done }
+    stream.callback { closed = true }
+    Thread.new { sleep 0.05; stream.close }
+    drive(stream)
+    # block returned but stream stayed open until the explicit close
+    assert closed
   end
 
   it 'allows adding more than one callback' do
     a = b = false
-    stream = Stream.new { }
+    stream = Stream.new {}
     stream.callback { a = true }
     stream.callback { b = true }
-    stream.each {|_| }
+    drive(stream)
     assert a, 'should trigger first callback'
     assert b, 'should trigger second callback'
   end
 
-  class MockScheduler
-    def initialize(*)     @schedule, @defer = [], []                end
-    def schedule(&block)  @schedule << block                        end
-    def defer(&block)     @defer    << block                        end
-    def schedule!(*)      @schedule.pop.call until @schedule.empty? end
-    def defer!(*)         @defer.pop.call    until @defer.empty?    end
-  end
-
-  it 'allows dropping in another scheduler' do
-    scheduler  = MockScheduler.new
-    processing = sending = done = false
-
-    stream = Stream.new(scheduler) do |out|
-      processing = true
-      out << :foo
-    end
-
-    stream.each { sending = true}
-    stream.callback { done = true }
-
-    scheduler.schedule!
-    assert !processing
-    assert !sending
-    assert !done
-
-    scheduler.defer!
-    assert processing
-    assert !sending
-    assert !done
-
-    scheduler.schedule!
-    assert sending
-    assert done
-  end
-
-  it 'schedules exceptions to be raised on the main thread/event loop/...' do
-    scheduler = MockScheduler.new
-    Stream.new(scheduler) { fail 'should be caught' }.each { }
-    scheduler.defer!
-    assert_raises(RuntimeError) { scheduler.schedule! }
-  end
-
   it 'does not trigger an infinite loop if you call close in a callback' do
-    stream = Stream.new { |out| out.callback { out.close }}
-    stream.each { |_| }
+    stream = Stream.new { |out| out.callback { out.close } }
+    drive(stream)
+    assert stream.closed?
   end
 
   it 'gives access to route specific params' do
@@ -123,28 +160,668 @@ class StreamingTest < Minitest::Test
     assert_body 'foo'
   end
 
-  it 'sets up async.close if available' do
+  it 'fires callbacks on out.close' do
     ran = false
-    mock_app do
-      get('/') do
-        close = Object.new
-        def close.callback; yield end
-        def close.errback; end
-        env['async.close'] = close
-        stream(:keep_open) do |out|
-          out.callback { ran = true }
-          out.close
-        end
-      end
+    stream = Stream.new(:keep_open) do |out|
+      out.callback { ran = true }
+      out.close
     end
-    get '/'
+    drive(stream)
     assert ran
   end
 
   it 'has a public interface to inspect its open/closed state' do
-    stream = Stream.new(Stream) { |out| out << :foo }
+    stream = Stream.new { |out| out << :foo }
     assert !stream.closed?
     stream.close
     assert stream.closed?
+  end
+
+  # --- Rack 3 callable-body conformance ----------------------------------
+
+  it 'is a callable body, not an enumerable body' do
+    stream = Stream.new {}
+    assert stream.respond_to?(:call), 'must respond to #call'
+    assert !stream.respond_to?(:each), 'must NOT respond to #each'
+  end
+
+  it 'invokes the producer block exactly once' do
+    count  = 0
+    stream = Stream.new { |_| count += 1 }
+    drive(stream)
+    assert_equal 1, count
+  end
+
+  it 'closes the server stream when done' do
+    fake   = FakeStream.new
+    stream = Stream.new { |out| out << 'hi' }
+    stream.call(fake)
+    assert fake.closed?, 'server stream should be closed after #call'
+  end
+
+  it 'is idempotent on close' do
+    calls  = 0
+    stream = Stream.new {}
+    stream.callback { calls += 1 }
+    drive(stream)
+    stream.close # Rack::Lint calls body.close after #call
+    stream.close
+    assert_equal 1, calls, 'callbacks must fire exactly once across repeated close'
+  end
+
+  it 'sets no content-length on the streamed response' do
+    mock_app do
+      get('/') { stream { |o| o << 'data' } }
+    end
+    get '/'
+    assert_nil headers['content-length']
+    assert_body 'data'
+  end
+
+  it 'emits a bare arity-1 callable returned from a route as a streaming body' do
+    # U2: returning a Rack 3 streaming body directly (not via the stream helper)
+    # used to fall through invoke and be dropped to an empty 200.
+    mock_app do
+      get('/') { ->(out) { out << 'u2'; out.close } }
+    end
+    get '/'
+    assert_body 'u2'
+    assert_nil headers['content-length']
+  end
+
+  it 'conforms to Rack::Lint as a streaming body' do
+    require 'rack/lint'
+    app = lambda do |_env|
+      body = Stream.new { |out| out << 'a' << 'b' }
+      [200, { 'content-type' => 'text/plain' }, body]
+    end
+    linted = Rack::Lint.new(app)
+    env = Rack::MockRequest.env_for('/')
+    status, _headers, body = linted.call(env)
+    assert_equal 200, status
+    assert body.respond_to?(:call)
+    fake = FakeStream.new
+    body.call(fake)
+    body.close
+    assert_equal 'ab', fake.body
+  end
+
+  # --- disconnect handling ----------------------------------------------
+
+  it 'treats a client disconnect (ECONNRESET) as a clean teardown' do
+    ran    = false
+    fake   = FakeStream.new(write_error: Errno::ECONNRESET.new('reset'))
+    stream = Stream.new { |out| out << 'never arrives' }
+    stream.callback { ran = true }
+    # #call must return cleanly, not raise.
+    stream.call(fake)
+    assert stream.closed?, 'stream should be closed after disconnect'
+    assert ran, 'callbacks should still fire on disconnect'
+  end
+
+  it 'treats every socket disconnect errno as a clean teardown' do
+    [Errno::EPIPE, Errno::ECONNRESET, Errno::ECONNABORTED,
+     Errno::ESHUTDOWN, Errno::ENOTCONN].each do |errno|
+      ran    = false
+      fake   = FakeStream.new(write_error: errno.new('gone'))
+      stream = Stream.new { |out| out << 'never arrives' }
+      stream.callback { ran = true }
+      stream.call(fake) # must not raise
+      assert stream.closed?, "#{errno} should close the stream"
+      assert ran, "#{errno} callbacks should still fire"
+    end
+  end
+
+  # The narrowed predicate is the whole point of the fix: an app-level error
+  # raised inside the producer block must NOT be mistaken for a disconnect and
+  # silently swallowed into a truncated 200. It must reach the caller loud.
+  it 'propagates a genuine application IOError (not a socket disconnect)' do
+    fake   = FakeStream.new(write_error: IOError.new('closed stream'))
+    stream = Stream.new { |out| out << 'x' }
+    assert_raises(IOError) { stream.call(fake) }
+    assert stream.closed?, 'stream must still be torn down before re-raising'
+  end
+
+  it 'propagates an app Errno::ENOENT (missing file) instead of swallowing it' do
+    fake   = FakeStream.new
+    stream = Stream.new { |_out| raise Errno::ENOENT, 'no such file' }
+    assert_raises(Errno::ENOENT) { stream.call(fake) }
+  end
+
+  it 'propagates an app Errno::EACCES (permissions) instead of swallowing it' do
+    fake   = FakeStream.new
+    stream = Stream.new { |_out| raise Errno::EACCES, 'denied' }
+    assert_raises(Errno::EACCES) { stream.call(fake) }
+  end
+
+  it 'propagates a genuine application error' do
+    fake   = FakeStream.new
+    stream = Stream.new { |_out| raise 'boom' }
+    assert_raises(RuntimeError) { stream.call(fake) }
+    assert fake.closed?, 'the server stream is still closed on an app error'
+  end
+
+  it 'still fires remaining callbacks if one raises a disconnect error' do
+    second = false
+    stream = Stream.new(:keep_open) {}
+    stream.callback { raise Errno::EPIPE, 'broken pipe' }
+    stream.callback { second = true }
+    stream.close
+    assert second, 'a disconnect-raising callback must not stop later callbacks'
+  end
+
+  # --- keep_open disconnect reaping -------------------------------------
+
+  # A parked keep_open #call must wake and tear down when an out-of-band #close
+  # arrives (server close, cross-request close, reaper EOF, h2 RST_STREAM all
+  # funnel through #close -> broadcast). Without the broadcast this leaks the
+  # worker thread forever.
+  it 'reaps a parked keep_open stream when closed out of band' do
+    reaped = false
+    stream = Stream.new(:keep_open) { |_out| }
+    stream.callback { reaped = true }
+    closer = Thread.new { sleep 0.05; stream.close }
+    drive(stream) # blocks in park until the broadcast wakes it
+    closer.join
+    assert stream.closed?
+    assert reaped, 'parked keep_open #call must wake and fire callbacks on close'
+  end
+
+  # The heartbeat-probe path (Falcon shape: no raw socket). park writes the
+  # heartbeat; when the peer is gone the write raises a disconnect errno, which
+  # we surface as ClientDisconnected -> clean close, firing callbacks. This is
+  # the leak fix: a silently-vanished client is detected by the periodic probe.
+  it 'reaps a parked keep_open stream via the heartbeat probe on disconnect' do
+    reaped = false
+    # block writes once (succeeds), then the heartbeat write (2nd write) fails.
+    fake   = FakeStream.new(write_error: Errno::EPIPE.new('broken pipe'),
+                            fail_after: 1)
+    stream = Stream.new(:keep_open, heartbeat: ":ping\n\n", poll: 0.02) do |out|
+      out << 'open'
+    end
+    stream.callback { reaped = true }
+    stream.call(fake) # parks, probes via heartbeat write, detects EPIPE, closes
+    assert stream.closed?
+    assert reaped, 'heartbeat probe must reap a silently-disconnected client'
+  end
+
+  # Falcon surfaces a closed output as a plain IOError (message "...closed..."),
+  # not an errno. The heartbeat probe matches that ONE message on the write path
+  # only and reaps; an unrelated IOError on the same probe must still raise.
+  it 'reaps via the heartbeat probe on a Falcon-style closed IOError' do
+    reaped = false
+    fake   = FakeStream.new(write_error: IOError.new('Output stream closed'),
+                            fail_after: 1)
+    stream = Stream.new(:keep_open, heartbeat: ":ping\n\n", poll: 0.02) do |out|
+      out << 'open'
+    end
+    stream.callback { reaped = true }
+    stream.call(fake)
+    assert stream.closed?
+    assert reaped, 'closed-output IOError on the heartbeat probe must reap'
+  end
+
+  # The Puma shape: the server hijacks to a raw BasicSocket. park uses MSG_PEEK
+  # (zero bytes on the wire) to detect EOF. We drive it with a real socketpair:
+  # close the peer's write half, and the parked #call must reap on the next poll.
+  it 'reaps a parked keep_open stream via MSG_PEEK EOF on a raw socket' do
+    require 'socket'
+    server, client = UNIXSocket.pair
+    reaped = false
+    stream = Stream.new(:keep_open, poll: 0.02) { |_out| }
+    stream.callback { reaped = true }
+    # peer (client) closes its write half -> server-side recv peeks EOF ("")
+    client.close
+    Timeout.timeout(2) { stream.call(server) }
+    assert stream.closed?
+    assert reaped, 'MSG_PEEK EOF must reap a disconnected raw-socket client'
+  ensure
+    server&.close rescue nil
+    client&.close rescue nil
+  end
+
+  # A still-connected raw socket with no pending data must NOT be mistaken for a
+  # disconnect: MSG_PEEK returns no readiness, park keeps waiting. We prove it
+  # stays open, then close it explicitly to release the parked #call.
+  it 'does not reap a live raw socket with no pending data' do
+    require 'socket'
+    server, client = UNIXSocket.pair
+    stream = Stream.new(:keep_open, poll: 0.02) { |_out| }
+    Thread.new do
+      sleep 0.15 # several poll cycles; if it falsely reaped, closed? is true
+      stream.close
+    end
+    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    Timeout.timeout(2) { stream.call(server) }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+    assert stream.closed?
+    assert elapsed >= 0.1, 'a live socket must keep the stream parked, not reap early'
+  ensure
+    server&.close rescue nil
+    client&.close rescue nil
+  end
+
+  # --- public #stream helper: auto-heartbeat for SSE ---------------------
+
+  # Drive the app to the Rack triple WITHOUT consuming the streaming body
+  # (a Rack 3 callable body is only run when the server calls body.call). This
+  # lets us grab the exact Stream object the PUBLIC #stream helper built and
+  # drive it ourselves with a Falcon-shape FakeStream.
+  def stream_body_for(path)
+    env = Rack::MockRequest.env_for(path)
+    _status, _headers, body = @app.call(env)
+    body
+  end
+
+  # THE central iter-1 gap: a bare `stream(:keep_open)` SSE endpoint must
+  # self-reap on a Falcon-shape disconnect THROUGH THE PUBLIC HELPER, i.e. the
+  # helper must auto-enable the heartbeat for text/event-stream so the parked
+  # #call probes by writing and detects the dead peer. No raw socket here
+  # (FakeStream is not a BasicSocket), so the ONLY reaping signal is the
+  # heartbeat the helper wires up by default for SSE.
+  it 'auto-reaps a bare stream(:keep_open) SSE endpoint on Falcon-shape disconnect' do
+    mock_app do
+      get('/sse') do
+        content_type 'text/event-stream'
+        # No heartbeat: passed; it must be auto-enabled BECAUSE this is SSE.
+        # poll: is short only so the test does not wait the 15s default.
+        stream(:keep_open, poll: 0.02) { |out| out << "data: hi\n\n" }
+      end
+    end
+
+    body = stream_body_for('/sse')
+    # 1st write (the block) succeeds; the auto-heartbeat write (2nd) fails as if
+    # the client vanished. With no auto-heartbeat this would park forever.
+    fake = FakeStream.new(write_error: Errno::EPIPE.new('broken pipe'),
+                          fail_after: 1)
+    Timeout.timeout(2) { body.call(fake) }
+    assert body.closed?, 'a bare stream(:keep_open) SSE endpoint must self-reap on Falcon'
+  end
+
+  # Companion proof that the auto-enabled SSE heartbeat is the invisible comment
+  # (": \n"), not arbitrary bytes: capture what the probe writes to the wire.
+  it 'auto-enables an invisible SSE comment heartbeat for a stream(:keep_open) SSE endpoint' do
+    mock_app do
+      get('/sse') do
+        content_type 'text/event-stream'
+        stream(:keep_open, poll: 0.02) { |out| out << "data: hi\n\n" }
+      end
+    end
+
+    body = stream_body_for('/sse')
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; body.close } # let a few heartbeats land
+    Timeout.timeout(2) { body.call(fake) }
+    closer.join
+    heartbeats = fake.chunks - ["data: hi\n\n"]
+    refute_empty heartbeats, 'an SSE keep_open stream must emit a heartbeat probe'
+    assert(heartbeats.all? { |c| c == ": \n" },
+           "heartbeat must be the invisible SSE comment, got #{heartbeats.uniq.inspect}")
+  end
+
+  # The safety constraint: a NON-SSE keep_open stream must NOT get an
+  # auto-heartbeat (it would inject garbage bytes into an arbitrary binary /
+  # long-poll body). poll: is short so that IF a heartbeat were wrongly enabled,
+  # many probe cycles would fire during the wait and corrupt fake.chunks, so the
+  # assertion would then catch it. We close it out of band to release the park.
+  it 'does NOT auto-inject heartbeat bytes into a non-SSE stream(:keep_open)' do
+    mock_app do
+      get('/binary') do
+        content_type 'application/octet-stream'
+        stream(:keep_open, poll: 0.01) { |out| out << 'PAYLOAD' }
+      end
+    end
+
+    body = stream_body_for('/binary')
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; body.close } # ~10 poll cycles
+    Timeout.timeout(2) { body.call(fake) }
+    closer.join
+    assert_equal ['PAYLOAD'], fake.chunks,
+                 'a non-SSE keep_open stream must not have probe bytes injected'
+  end
+
+  # The content-type gate is start_with?, not include?: a spoofed content type
+  # that merely CONTAINS 'text/event-stream' (e.g. 'x-text/event-stream-fake')
+  # must NOT auto-enable the heartbeat, or an attacker could trick Sinatra into
+  # injecting probe bytes into an arbitrary body. Same shape as the non-SSE case:
+  # if a heartbeat were wrongly enabled, probe bytes would pollute fake.chunks.
+  it 'does NOT auto-enable the heartbeat for a content type that only contains text/event-stream' do
+    mock_app do
+      get('/spoof') do
+        content_type 'x-text/event-stream-fake'
+        stream(:keep_open, poll: 0.01) { |out| out << 'PAYLOAD' }
+      end
+    end
+
+    body = stream_body_for('/spoof')
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; body.close } # ~10 poll cycles
+    Timeout.timeout(2) { body.call(fake) }
+    closer.join
+    assert_equal ['PAYLOAD'], fake.chunks,
+                 'a spoofed event-stream content type must not get a heartbeat'
+  end
+
+  # The gate must still accept a real SSE content type carrying parameters
+  # (charset), since start_with? matches the media type prefix before the ';'.
+  it 'auto-enables the heartbeat for text/event-stream with a charset parameter' do
+    mock_app do
+      get('/sse') do
+        content_type 'text/event-stream; charset=utf-8'
+        stream(:keep_open, poll: 0.02) { |out| out << "data: hi\n\n" }
+      end
+    end
+
+    body = stream_body_for('/sse')
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; body.close }
+    Timeout.timeout(2) { body.call(fake) }
+    closer.join
+    heartbeats = fake.chunks - ["data: hi\n\n"]
+    refute_empty heartbeats,
+                 'text/event-stream; charset=utf-8 must still get a heartbeat'
+  end
+
+  # The escape hatch: a non-SSE keep_open user can still opt in to reaping by
+  # passing heartbeat: explicitly through the public helper.
+  it 'lets a non-SSE stream(:keep_open) opt in to a heartbeat for reaping' do
+    mock_app do
+      get('/binary') do
+        content_type 'application/octet-stream'
+        stream(:keep_open, heartbeat: "\0", poll: 0.02) { |out| out << 'PAYLOAD' }
+      end
+    end
+
+    body = stream_body_for('/binary')
+    fake = FakeStream.new(write_error: Errno::EPIPE.new('broken pipe'),
+                          fail_after: 1)
+    Timeout.timeout(2) { body.call(fake) }
+    assert body.closed?, 'explicit heartbeat: must enable reaping on a non-SSE stream'
+  end
+
+  # --- empty stream ------------------------------------------------------
+
+  it 'handles an empty stream cleanly' do
+    fake   = FakeStream.new
+    stream = Stream.new { |_out| }
+    stream.call(fake)
+    assert_empty fake.chunks
+    assert stream.closed?
+    assert fake.closed?
+  end
+
+  # --- finite default TTL self-close -------------------------------------
+
+  # A keep_open stream that never sees a disconnect must still self-close once
+  # the parking ceiling (ttl:) elapses, so an idle/leaked connection cannot park
+  # forever. We give a tiny ttl and a live raw socket (so the MSG_PEEK probe
+  # keeps reporting "still connected") and assert the TTL is what reaps it.
+  it 'self-closes a parked keep_open stream when the TTL elapses' do
+    require 'socket'
+    server, client = UNIXSocket.pair
+    reason = nil
+    stream = Stream.new(:keep_open, poll: 0.02, ttl: 0.1) { |_out| }
+    stream.callback { |r| reason = r }
+    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    Timeout.timeout(2) { stream.call(server) }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+    assert stream.closed?, 'a parked keep_open stream must self-close at its TTL'
+    assert elapsed >= 0.1, 'must not reap before the TTL'
+    assert elapsed < 1.5, 'must reap shortly after the TTL, not park forever'
+    assert_equal :disconnect, reason, 'a TTL reap is a disconnect-class teardown'
+  ensure
+    server&.close rescue nil
+    client&.close rescue nil
+  end
+
+  it 'parks indefinitely when ttl: nil opts out of the ceiling' do
+    require 'socket'
+    server, client = UNIXSocket.pair
+    stream = Stream.new(:keep_open, poll: 0.02, ttl: nil) { |_out| }
+    Thread.new { sleep 0.2; stream.close } # only an explicit close releases it
+    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    Timeout.timeout(2) { stream.call(server) }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+    assert stream.closed?
+    assert elapsed >= 0.2, 'ttl: nil must disable the self-close ceiling'
+  ensure
+    server&.close rescue nil
+    client&.close rescue nil
+  end
+
+  it 'defaults the parking ceiling to a finite generous value' do
+    assert_equal 300, Stream::KEEP_OPEN_TTL,
+                 'the default TTL must be finite so streams cannot park forever'
+  end
+
+  # --- concurrent-stream cap (503) ---------------------------------------
+
+  # Past settings.stream_max_concurrent, the helper must shed with 503 +
+  # Retry-After instead of parking another stream. We hold one slot open by
+  # leaving a keep_open stream parked, set the cap to 1, then the next request
+  # must 503. Driving through Rack::MockRequest gives us the real triple.
+  it 'sheds a keep_open stream with 503 + Retry-After past the cap' do
+    mock_app do
+      set :stream_max_concurrent, 1
+      set :stream_retry_after, 7
+      get('/sse') do
+        content_type 'text/event-stream'
+        stream(:keep_open, poll: 0.02, ttl: nil) { |out| out << "data: hi\n\n" }
+      end
+    end
+
+    # First request claims the only slot (we never drive its body, so it stays
+    # claimed for the duration of the test).
+    first = stream_body_for('/sse')
+    assert_equal 1, Stream.active_count
+
+    # Second request is over the cap -> 503 with Retry-After, no body parked.
+    get('/sse')
+    assert_status 503
+    assert_equal '7', response['Retry-After']
+    assert_match(/too many concurrent streams/i, response.body)
+    assert_equal 1, Stream.active_count, 'a shed request must not consume a slot'
+  ensure
+    first&.close
+  end
+
+  it 'releases the slot when a parked keep_open stream closes' do
+    mock_app do
+      set :stream_max_concurrent, 1
+      get('/sse') do
+        content_type 'text/event-stream'
+        stream(:keep_open, poll: 0.02, ttl: nil) { |out| out << "data: hi\n\n" }
+      end
+    end
+
+    body = stream_body_for('/sse')
+    assert_equal 1, Stream.active_count
+    body.close
+    assert_equal 0, Stream.active_count, 'closing a parked stream must free its slot'
+
+    # The freed slot is reusable: another keep_open request now succeeds (200).
+    again = stream_body_for('/sse')
+    assert_equal 1, Stream.active_count
+    again.close
+  end
+
+  it 'does not count a plain (non keep_open) stream against the cap' do
+    mock_app do
+      set :stream_max_concurrent, 1
+      get('/plain') do
+        stream { |out| out << 'hello' }
+      end
+    end
+
+    3.times do
+      get('/plain')
+      assert_status 200
+      assert_body 'hello'
+    end
+    assert_equal 0, Stream.active_count
+  end
+
+  # --- producer-error hook -----------------------------------------------
+
+  # A mid-stream application exception is invisible to the normal error channels,
+  # so a registered on_stream_error handler must fire with the exception BEFORE
+  # the error propagates. The error must still re-raise (loud failure preserved).
+  it 'invokes on_stream_error with the exception and still propagates it' do
+    captured = nil
+    klass = Class.new(Sinatra::Base) do
+      on_stream_error { |e| captured = e }
+    end
+    boom = RuntimeError.new('producer blew up')
+    handlers = klass.settings.stream_error_handlers
+    stream = Stream.new(error_handlers: handlers) { |_out| raise boom }
+    fake = FakeStream.new
+
+    err = assert_raises(RuntimeError) { stream.call(fake) }
+    assert_same boom, err, 'the original exception must still propagate (loud)'
+    assert_same boom, captured, 'on_stream_error must receive the exception'
+    assert stream.closed?
+  end
+
+  it 'does not invoke on_stream_error on a clean disconnect' do
+    called = false
+    handlers = [->(_e) { called = true }]
+    stream = Stream.new(:keep_open, poll: 0.02, error_handlers: handlers) do |out|
+      out << 'data'
+    end
+    fake = FakeStream.new(write_error: Errno::EPIPE.new('broken pipe'),
+                          fail_after: 1)
+    Timeout.timeout(2) { stream.call(fake) }
+    assert stream.closed?
+    refute called, 'a peer disconnect is not an application error'
+  end
+
+  it 'isolates a raising error handler so the real exception still propagates' do
+    boom = RuntimeError.new('real error')
+    handlers = [->(_e) { raise 'reporter is broken' }, ->(_e) { @reached = true }]
+    @reached = false
+    stream = Stream.new(error_handlers: handlers) { |_out| raise boom }
+    err = assert_raises(RuntimeError) { stream.call(FakeStream.new) }
+    assert_same boom, err
+    assert @reached, 'a broken handler must not block later handlers'
+  end
+
+  # --- reason-carrying teardown callback ---------------------------------
+
+  it 'passes :complete to an arity-1 callback on a clean finish' do
+    reason = nil
+    stream = Stream.new { |out| out << 'done' }
+    stream.callback { |r| reason = r }
+    stream.call(FakeStream.new)
+    assert_equal :complete, reason
+  end
+
+  it 'passes :disconnect to an arity-1 callback on a peer drop' do
+    reason = nil
+    stream = Stream.new { |out| out << 'x' }
+    stream.callback { |r| reason = r }
+    fake = FakeStream.new(write_error: Errno::EPIPE.new('broken pipe'))
+    stream.call(fake)
+    assert_equal :disconnect, reason
+  end
+
+  it 'passes :error to an arity-1 callback on an application exception' do
+    reason = nil
+    stream = Stream.new { |_out| raise 'boom' }
+    stream.callback { |r| reason = r }
+    assert_raises(RuntimeError) { stream.call(FakeStream.new) }
+    assert_equal :error, reason
+  end
+
+  it 'still calls an arity-0 callback with no args (back-compatible)' do
+    called = false
+    stream = Stream.new { |out| out << 'done' }
+    stream.callback { called = true } # zero-arity: must not get a reason arg
+    stream.call(FakeStream.new)
+    assert called
+  end
+
+  it 'fires a callback registered after close with :complete for arity 1' do
+    stream = Stream.new { |out| out << 'done' }
+    stream.call(FakeStream.new)
+    assert stream.closed?
+    reason = nil
+    stream.callback { |r| reason = r } # registered post-close: fires immediately
+    assert_equal :complete, reason
+  end
+
+  # --- HTTP/2 skip-heartbeat fast-path -----------------------------------
+
+  # On HTTP/2+ the protocol reaps a closed stream natively, so the write-probe
+  # heartbeat is dead weight and must NOT fire: no probe bytes on the wire, and
+  # a disconnect is detected by the broadcast/poll backstop, not by a write.
+  it 'skips the write-probe heartbeat on HTTP/2' do
+    stream = Stream.new(:keep_open, heartbeat: ": \n", poll: 0.02,
+                        protocol: 'HTTP/2') { |out| out << "data: hi\n\n" }
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; stream.close } # several poll cycles
+    Timeout.timeout(2) { stream.call(fake) }
+    closer.join
+    assert_equal ["data: hi\n\n"], fake.chunks,
+                 'HTTP/2 must not emit write-probe heartbeats (native reaping)'
+  end
+
+  it 'still emits the write-probe heartbeat on HTTP/1.1' do
+    stream = Stream.new(:keep_open, heartbeat: ": \n", poll: 0.02,
+                        protocol: 'HTTP/1.1') { |out| out << "data: hi\n\n" }
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; stream.close }
+    Timeout.timeout(2) { stream.call(fake) }
+    closer.join
+    heartbeats = fake.chunks - ["data: hi\n\n"]
+    refute_empty heartbeats, 'HTTP/1.1 must still write-probe for disconnect'
+    assert(heartbeats.all? { |c| c == ": \n" })
+  end
+
+  it 'treats a nil/unknown protocol as HTTP/1 (heartbeat still fires)' do
+    stream = Stream.new(:keep_open, heartbeat: ": \n", poll: 0.02,
+                        protocol: nil) { |out| out << "data: hi\n\n" }
+    fake = FakeStream.new
+    closer = Thread.new { sleep 0.1; stream.close }
+    Timeout.timeout(2) { stream.call(fake) }
+    closer.join
+    refute_empty(fake.chunks - ["data: hi\n\n"],
+                 'nil protocol must default to the HTTP/1 write-probe')
+  end
+
+  it 'reaps an HTTP/2 disconnect via the broadcast backstop, not a write-probe' do
+    # The server's native close (here: an explicit #close, standing in for
+    # Falcon's closed(error) broadcast) wakes the parked fiber with no heartbeat.
+    stream = Stream.new(:keep_open, heartbeat: ": \n", poll: 5,
+                        protocol: 'HTTP/2') { |out| out << "data: hi\n\n" }
+    fake = FakeStream.new
+    reason = nil
+    stream.callback { |r| reason = r }
+    Thread.new { sleep 0.1; stream.close(:disconnect) }
+    Timeout.timeout(2) { stream.call(fake) }
+    assert stream.closed?
+    assert_equal ["data: hi\n\n"], fake.chunks
+    assert_equal :disconnect, reason
+  end
+
+  # --- Maintenance tripwires ---------------------------------------------
+
+  it 'tripwire: KEEP_OPEN_TTL constant and the :stream_keep_open_ttl default stay in sync' do
+    # The constant is the fallback for a direct Stream.new; the setting is the
+    # configurable default the #stream helper uses. They must not drift apart.
+    app = Class.new(Sinatra::Base)
+    assert_equal Stream::KEEP_OPEN_TTL, app.settings.stream_keep_open_ttl
+  end
+
+  it 'tripwire: Rack::Deflater still cannot wrap a streaming body' do
+    # Rack::Deflater is each-based and raises on a Rack 3 callable streaming
+    # body. The README tells users not to compress streams because of this. If
+    # Rack ever teaches Deflater about streaming bodies, consuming the wrapped
+    # body stops raising here: update that README note and drop this tripwire.
+    require 'rack/deflater'
+    inner = lambda { |_env| [200, { 'content-type' => 'text/plain' }, Stream.new { |o| o << 'x' }] }
+    _status, _headers, body = Rack::Deflater.new(inner)
+                                            .call(Rack::MockRequest.env_for('/', 'HTTP_ACCEPT_ENCODING' => 'gzip'))
+    assert_raises(NoMethodError) { body.each { |_chunk| } }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,6 +87,23 @@ class Minitest::Test
     response.body.to_s
   end
 
+  # Rack's in-process test harness (Rack::MockResponse, reached via rack-test)
+  # only learned to drive a *callable* streaming body in Rack 3.2: MockResponse#body
+  # now calls `body.call(io)`. Rack 3.0/3.1 instead call `body.each`, and Rack::Lint
+  # then raises "Enumerable Body must respond to each" because our Stream is
+  # call-only. Real servers (Puma, Falcon) drive callable bodies from Rack 3.0 on
+  # — covered by the integration suite — so this is purely a harness limitation.
+  # Tests that buffer a *streamed* response through the mock harness skip on older
+  # Rack instead of asserting against an error the runtime never produces.
+  RACK_BUFFERS_CALLABLE_BODY = Gem::Version.new(Rack.release) >= Gem::Version.new('3.2')
+
+  def skip_unless_rack_buffers_callable_body
+    return if RACK_BUFFERS_CALLABLE_BODY
+
+    skip "Rack #{Rack.release} MockResponse cannot buffer a callable streaming " \
+         'body (needs Rack >= 3.2); real servers drive it on Rack 3.0+.'
+  end
+
   def assert_body(value)
     if value.respond_to? :to_str
       assert_equal value.lstrip.gsub(/\s*\n\s*/, ""), body.lstrip.gsub(/\s*\n\s*/, "")


### PR DESCRIPTION
## What

This makes Sinatra's streaming (`stream`, `stream :keep_open`) production-safe by default and moves it onto the Rack 3 callable-body contract, with first-class Server-Sent Events support. It closes the long-standing gap (#1892) where a `keep_open` stream whose client vanished could park forever, leaking a fiber, a file descriptor, and on Falcon a connection slot, until the process was restarted.

Because it also removes the dead EventMachine/Thin async path and changes `Stream.new`'s signature, this targets the 5.0 line.

## Why

The old behaviour assumed a cooperative client that always closes the connection cleanly. In the real world clients drop, proxies time out, and load balancers reset idle sockets without a FIN. Under Falcon those abandoned streams accumulated with no backstop. There was also no way to cap concurrent streams, no hook to observe a producer-side error (it was silently turned into a clean close), and no built-in SSE framing, so every app rolled its own and usually got `id`/`event` escaping wrong.

## Server-aware disconnect reaping

There is no portable way to learn that a streaming client has gone, so detection is per server and protocol:

- Puma exposes a real socket, so a zero-byte `MSG_PEEK` detects a half-closed peer without writing anything to the wire. This is the preferred path whenever the stream is a real `BasicSocket`.
- Falcon HTTP/1 hands a Rack callable-body stream that exposes no raw socket, so a small heartbeat write-probe is used. (The underlying transport still exists deeper in protocol-rack/async-http, but reaching for it would couple Sinatra to Falcon internals rather than the Rack streaming contract.) It is gated to HTTP/1 and only to `text/event-stream` responses, where the probe is an invisible `: ` comment line, so a non-SSE body is never given injected bytes. For a non-SSE `keep_open` stream on Falcon, pass `heartbeat:` to opt in. The internal heartbeat fires only once the stream has been write-idle for a `poll` interval, so an actively-streaming endpoint never gets redundant probe bytes (its own `out.write`/`out.sse` already exercise the transport).
- HTTP/2 reaps idle streams natively, so no write-probe is used there.

The heartbeat is a Falcon-HTTP/1-only mechanism, and a deliberate one rather than a stopgap awaiting an upstream fix: async-http cannot detect a disconnect on an idle HTTP/1 bidirectional body without either missing a FIN that sits behind buffered bytes or stealing request-body bytes the body owns. That investigation is at socketry/async-http#224 (still open, link kept at the probe site for background, not as a removal trigger). `MSG_PEEK` is likewise a closure detector, not a liveness test — silent failures are caught by the finite `keep_open` TTL, not the peek.

### Streaming server/version support

Streaming relies on the server driving a Rack 3 callable response body, so support is per server, not uniform across everything Sinatra runs on:

- **Puma** streams across Sinatra's whole supported range. Verified with a real Puma server (incremental delivery over HTTP) on Ruby 2.7, 3.0, 3.1 and 4.0, and on Rack 3.0, 3.1 and 3.2.
- **Falcon** requires **Ruby >= 3.2** for streaming: on older Ruby only Falcon 0.51 and earlier resolve, and those never flush the callable-body stream (the response arrives empty); the streaming-capable Falcon (0.54+) installs only on Ruby >= 3.2. This is Falcon's own Ruby floor, not a Sinatra constraint — on Ruby < 3.2, stream with Puma. The README server matrix documents this.

This also fixes CI on the older matrix cells: Falcon integration tests are skipped on Ruby < 3.2 (the buggy `RUBY_VERSION <= "3.0.0"` string compare is replaced with `Gem::Version`), and the harness-driven streaming tests skip on Rack < 3.2, where `Rack::MockResponse` cannot drive a callable body (`body.call(io)` landed in Rack 3.2; real servers drive callable bodies from Rack 3.0 on).

## Defaults

- Finite keep_open TTL: a parked stream self-closes after `set :stream_keep_open_ttl` (default 300s, plus jitter so a fleet does not reconnect on the same tick). Tune per stream with `stream(..., ttl:)`, or `ttl: nil` to opt a stream out.
- Concurrency cap: `set :stream_max_concurrent` (default 1000) sheds past the limit with `503` and a `Retry-After` header (`set :stream_retry_after`, default 5) instead of parking another worker, so a flood of idle connections cannot starve the pool. Set to `nil` to disable.

Both defaults are generous enough that normal apps never trip them, while bounding the worst case.

## API

- `out.flush` flushes the server stream (no auto-flush, you decide when).
- `out.sse(data, event:, id:, retry_after:)` writes one spec-correct SSE event (multi-line `data`, JSON-encoded non-strings, `\0\r\n` stripped from `id`/`event`).
- `out.sse_comment(text)` writes an application keepalive comment, distinct from the internal disconnect probe.
- `Base.on_stream_error { |e| ... }` is invoked when a producer block raises mid-stream, so apps can report it (Sentry, OpenTelemetry); the exception still propagates.
- Teardown callbacks now receive a reason (`:complete`, `:disconnect`, `:error`); existing zero-arity `callback` blocks keep working.
- SSE reconnection is supported via the standard `Last-Event-ID` header (`request.env['HTTP_LAST_EVENT_ID']`).

## Breaking changes (5.0)

- The Rack 1.x async path is removed: `async.callback`, `async.close`, `throw :async`, `async?`.
- `Sinatra::ExtendedRack` is now an inert pass-through, no longer installed by default; an app that still uses it manually gets a deprecation warning.
- `Sinatra::Helpers::Stream.new` has a new signature (it now carries TTL, protocol, concurrency, and error-handler state).

## sinatra-contrib, examples, tests

- `sinatra-contrib`'s `Streaming` addon is rewritten on the callable body (its `puts`/`printf`/`<<`/`map!` IO emulation preserved), so the monorepo build stays green.
- The streaming examples (`chat.rb`, `stream.ru`, and a new `sse.rb`) use the new API and are covered by a new examples test so they cannot silently drift.
- Maintenance tripwire tests guard the TTL default sync, the `Rack::Deflater` limitation (rack/rack#2470, filed), and the ExtendedRack removal at 6.0.
- `out.sse` keeps per-event allocation minimal.

## Verification

- Full suite green (with pandoc installed: 1174 runs, 0 failures, 0 errors). sinatra-contrib streaming spec green.
- The disconnect reaping, finite-TTL self-close, the concurrency cap returning 503 while a health route stays responsive under a stream flood, producer-error propagation, and non-SSE bodies receiving zero probe bytes were all verified empirically on real Puma 8 and Falcon 0.55.
- A new CI job runs the streaming and integration tests against Puma and Falcon.

## A few things I would value your read on

1. The keep_open default TTL of 300s: generous enough not to trip a healthy long-lived stream, finite enough that an abandoned one self-recovers. Happy to change it.
2. The concurrency cap default of 1000 per process. Same, easy to retune.
3. `Sinatra::ExtendedRack`: I kept it as an inert deprecated shim for one major (the Reloader precedent), but the async audience is effectively gone, so I am happy to just remove the constant in 5.0 if you prefer.
4. I kept `Stream` in `base.rb` where it already lives; happy to extract it into its own file if you would rather.

Closes #1892

