### PR TITLE
Update mustermann-4.0: merge main + content-type fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,33 +90,30 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
-        bundler:
-          - default
         rubyopt:
           - "--enable-frozen-string-literal --debug-frozen-string-literal"
         include:
-          # Avoid Bundler 4 for now: https://github.com/sinatra/sinatra/issues/2135
-          - { ruby: "4.0", bundler: 2.7.2, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: "4.0", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Rack
-          - { ruby: 3.4, bundler: default, rack: "~>3.0.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
-          - { ruby: 3.4, bundler: default, rack: "~>3.1.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
-          - { ruby: 3.4, bundler: default, rack: head, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: "~>3.0.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: "~>3.1.0", puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: head, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Rack::Session
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: head, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: stable, rack_session: head, zeitwerk: stable }
           # Puma
-          - { ruby: 3.4, bundler: default, rack: stable, puma: head, tilt: stable, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: head, tilt: stable, rack_session: stable, zeitwerk: stable }
           # Tilt
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: stable }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: stable }
           # Test Zeitwerk < 2.7.0 separately
-          - { ruby: 3.4, bundler: default, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: '<2.7.0' }
+          - { ruby: 3.4, rack: stable, puma: stable, tilt: head, rack_session: stable, zeitwerk: '<2.7.0' }
           # JRuby, tests are notable flaky
-          - { ruby: jruby,            bundler: default, rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby,            rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # Never fail our build due to problems with head rubies
-          - { ruby: ruby-head,        bundler: 2.7.2,   rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
-          - { ruby: jruby-head,       bundler: default, rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
-          - { ruby: truffleruby-head, bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: ruby-head,        rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: jruby-head,       rubyopt: "", rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: truffleruby-head, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
           # truffleruby 24.1 fails, see https://github.com/oracle/truffleruby/issues/3788
-          - { ruby: truffleruby,      bundler: default, rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
+          - { ruby: truffleruby,      rack: stable, puma: stable, tilt: stable, rack_session: stable, zeitwerk: stable, allow-failure: true }
 
     env:
       rack: ${{ matrix.rack }}
@@ -146,20 +143,10 @@ jobs:
       id: setup-ruby
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: ${{ matrix.bundler }}
         bundler-cache: true
         # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490 (3.0)
         # and https://github.com/sinatra/sinatra/issues/2051 (3.1)
         rubygems: ${{ matrix.ruby == '3.0' && 'latest' || matrix.ruby == '3.1' && 'latest' || 'default' }}
-
-    # workaround for https://github.com/ruby/setup-ruby/issues/845
-    - name: Ensure Gemfile.lock is created with Bundler 2 for Ruby 4
-      if: matrix.ruby == '4.0' || matrix.ruby == 'ruby-head'
-      run: |
-        rm Gemfile.lock
-        bundle install
-      env:
-        BUNDLER_VERSION: ${{ matrix.bundler }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         rack:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"
@@ -84,10 +80,6 @@ jobs:
         zeitwerk:
           - stable
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
         rubyopt:
@@ -144,9 +136,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        # Update rubygems due to https://github.com/rubygems/rubygems/pull/6490 (3.0)
-        # and https://github.com/sinatra/sinatra/issues/2051 (3.1)
-        rubygems: ${{ matrix.ruby == '3.0' && 'latest' || matrix.ruby == '3.1' && 'latest' || 'default' }}
 
     - name: Run sinatra tests
       continue-on-error: ${{ matrix.allow-failure || false }}

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1070,7 +1070,7 @@ module Sinatra
       end
 
       routes&.each do |match_or_signature|
-        response.delete_header('content-type') unless @pinned_response
+        reset_content_type!
 
         if match_or_signature.is_a?(Mustermann::Match)
           match = match_or_signature
@@ -1094,13 +1094,22 @@ module Sinatra
       end
 
       # Set-based routing only iterates matching routes, so the per-iteration
-      # reset above is skipped after a route that set a content-type then passed.
-      # Clear it so the pass block starts clean, as the legacy all-routes scan did.
+      # reset above is skipped after a matching route set a content-type then
+      # passed. Reset it here too so the pass block starts clean, uniformly for
+      # every verb. (main's all-routes scan cleared this only incidentally for
+      # GET, via the built-in /__sinatra__ image route, and leaked it otherwise.)
       if pass_block
-        response.delete_header('content-type') unless @pinned_response
+        reset_content_type!
         route_eval(&pass_block)
       end
       route_missing
+    end
+
+    # Reset the content-type a passed/previous route may have set, so the next
+    # handler -- route block or pass block -- starts from its baseline: nothing,
+    # or the value a before-filter pinned via @pinned_response.
+    def reset_content_type!
+      response.delete_header('content-type') unless @pinned_response
     end
 
     # Run a route block and throw :halt with the result.

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1093,7 +1093,13 @@ module Sinatra
         return route!(base.superclass, pass_block)
       end
 
-      route_eval(&pass_block) if pass_block
+      # Set-based routing only iterates matching routes, so the per-iteration
+      # reset above is skipped after a route that set a content-type then passed.
+      # Clear it so the pass block starts clean, as the legacy all-routes scan did.
+      if pass_block
+        response.delete_header('content-type') unless @pinned_response
+        route_eval(&pass_block)
+      end
       route_missing
     end
 

--- a/test/integration_start_test.rb
+++ b/test/integration_start_test.rb
@@ -21,7 +21,9 @@ class IntegrationStartTest < Minitest::Test
     gem_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb")
     lock_file = File.join(__dir__, "integration", "gemfile_without_rackup.rb.lock")
     command = command_for(app_file)
-    env = { "BUNDLE_GEMFILE" => gem_file }
+    # BUNDLE_LOCKFILE is exported by Bundler 4; without clearing it the child would
+    # write the alternate gemfile's lock to the parent project's Gemfile.lock path
+    env = { "BUNDLE_GEMFILE" => gem_file, "BUNDLE_LOCKFILE" => nil }
 
     with_process(command: command, env: env) do |process, read_io|
       assert wait_for_output(read_io, /Sinatra could not start, the required gems weren't found/)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -936,7 +936,24 @@ class RoutingTest < Minitest::Test
     assert_equal 'from pass block', body
     # The content-type set by the passed route must not survive into the pass
     # block: set-based routing iterates only matching routes, so route! must
-    # clear it before the fallthrough just as the legacy all-routes scan did.
+    # clear it before the fallthrough.
+    assert_equal 'text/html;charset=utf-8', response.headers['content-type']
+  end
+
+  it "does not leak a passed route's content-type into the pass block for non-GET verbs" do
+    mock_app {
+      post('/a') do
+        content_type :json
+        pass { 'from pass block' }
+      end
+    }
+
+    post '/a'
+    assert_equal 200, status
+    assert_equal 'from pass block', body
+    # Non-GET verbs are the case main got wrong: it cleared a single-match GET
+    # only incidentally (via its built-in image route) and leaked every other
+    # verb. The shared-fallthrough reset covers them all.
     assert_equal 'text/html;charset=utf-8', response.headers['content-type']
   end
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -922,6 +922,24 @@ class RoutingTest < Minitest::Test
     assert "this", body
   end
 
+  it "does not leak a passed route's content-type into the pass block" do
+    mock_app {
+      get('/a') do
+        content_type :json
+        pass { 'from pass block' }
+      end
+      get('/b') { 'b' } # later, non-matching route for the same verb
+    }
+
+    get '/a'
+    assert_equal 200, status
+    assert_equal 'from pass block', body
+    # The content-type set by the passed route must not survive into the pass
+    # block: set-based routing iterates only matching routes, so route! must
+    # clear it before the fallthrough just as the legacy all-routes scan did.
+    assert_equal 'text/html;charset=utf-8', response.headers['content-type']
+  end
+
   it "passes when matching condition returns false" do
     mock_app {
       condition { params[:foo] == 'bar' }


### PR DESCRIPTION
@rkh following up on your "happy to review an updated PR" in #2163.

I merged current main (4.2.1) into your branch and kept your commits as they are (no rebase). On top of that:

- **Merge main.** The only conflict was `test.yml`. Your branch and main went different ways on the Ruby 4.0 / Bundler 4 stuff (you pin Bundler 2.7.2 via the matrix, main drops the pin per dentarg's fix), so I took main's Bundler handling and dropped the EOL Ruby versions (2.7-3.2), since this branch requires Ruby 3.3+.
- **Fixed a content-type leak in the pass-block fallthrough.** When a route sets a content type and then bails with `pass { ... }`, the pass block should fall back to the default `text/html`, not inherit the abandoned route's type. `set.match_all` only yields matching routes, so the per-iteration `delete_header('content-type')` never runs before the trailing pass block, and `content_type :json; pass { ... }` leaked `application/json`. The fix extracts a `reset_content_type!` helper (still guarded by `@pinned_response`) and calls it before the fallthrough too, so it clears uniformly for every verb, plus regression tests for GET and non-GET.

  One nuance worth flagging: this is a hair more than restoring main. For GET, main already clears (text/html). For non-GET verbs main *also* leaks today — its single-match reset only happens incidentally for GET, via the built-in `/__sinatra__` image route being iterated — so this additionally makes POST/PUT/etc. consistent. I think uniform-clear is right; happy to scope to GET-only if you'd rather match main exactly. Whether `pass` should roll back *all* response state (headers + status), not just content-type, is a separate contract question I opened as #2177.

Perf still holds, which is the whole point of this branch. Quick benchmark, 100 routes, this branch vs main:

| request | main | this branch |
| --- | --- | --- |
| last route | 10.5k req/s | 26.8k req/s (2.6x) |
| dynamic route | 10.9k req/s | 24.7k req/s (2.3x) |
| first route | 26.9k req/s | 27.0k req/s |

Set lookup is position independent, so route order stops mattering. On main the last route is about 2.6x slower than the first because it scans linearly.

Tested green on Ruby 4.0.5 with mustermann 4.0.0 (full `rake test`, reloader spec). I also ran my production Falcon/Rack 3 app's full CI suite against this exact branch tip: 351 examples, 0 failures.

---

**Note:** bumping to mustermann 4.0 raises the minimum Ruby to 3.3, which is a breaking change, so this likely belongs in a **5.0** major rather than a 4.x line. Flagging for release sequencing; happy to defer to the maintainers on the versioning call.
