### PR TITLE
Add support for the QUERY HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ end
 unlink '/' do
   .. separate something ..
 end
+
+query '/' do
+  .. find something ..
+end
 ```
 
 Routes are matched in the order they are defined. The first route that

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1540,6 +1540,8 @@ module Sinatra
 
       def post(path, opts = {}, &block)    route 'POST',    path, opts, &block end
 
+      def query(path, opts = {}, &block)   route 'QUERY',   path, opts, &block end
+
       def delete(path, opts = {}, &block)  route 'DELETE',  path, opts, &block end
 
       def head(path, opts = {}, &block)    route 'HEAD',    path, opts, &block end
@@ -2114,7 +2116,7 @@ module Sinatra
       end
     end
 
-    delegate :get, :patch, :put, :post, :delete, :head, :options, :link, :unlink,
+    delegate :get, :patch, :put, :post, :query, :delete, :head, :options, :link, :unlink,
              :template, :layout, :before, :after, :error, :not_found, :configure,
              :set, :mime_type, :enable, :disable, :use, :development?, :test?,
              :production?, :helpers, :settings, :register, :on_start, :on_stop

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -68,11 +68,15 @@ module Sinatra
     end
 
     def safe?
-      get? || head? || options? || trace?
+      get? || head? || options? || trace? || query?
     end
 
     def idempotent?
       safe? || put? || delete? || link? || unlink?
+    end
+
+    def query?
+      request_method == 'QUERY'
     end
 
     def link?

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -16,7 +16,7 @@ class PatternLookAlike
 end
 
 class RoutingTest < Minitest::Test
-  %w[get put post delete options patch link unlink].each do |verb|
+  %w[get put post query delete options patch link unlink].each do |verb|
     it "defines #{verb.upcase} request handlers with #{verb}" do
       mock_app {
         send verb, '/hello' do
@@ -1698,5 +1698,18 @@ class RoutingTest < Minitest::Test
 
     get '/foo/'
     assert_equal 'foo', body
+  end
+
+  it 'registers the route signature for QUERY' do
+    signature = list = nil
+
+    mock_app do
+      signature = query('/') { }
+      list = routes['QUERY']
+    end
+
+    assert_equal Array, signature.class
+    assert_equal 3, signature.length
+    assert list.include?(signature)
   end
 end


### PR DESCRIPTION
Adds a `query` method for defining routes, same as `get`/`post`/`put`/etc:

```ruby
query '/search' do
  # handle a QUERY request
end
```

QUERY is a newer HTTP method (see the [IETF draft](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-08.html)) meant for sending a query in the request body while keeping GET-like safe/idempotent semantics, instead of overloading POST for reads.

Changes:
- added `Base#query` in `base.rb`, right alongside the other verb methods
- added `:query` to `Delegator.delegate` so it also works with the classic top-level DSL
- updated the README's verb list
- added tests in `routing_test.rb`

One caveat: this only covers the Sinatra side. Routing itself is generic over `request.request_method`, so it dispatches fine once a QUERY request actually reaches Sinatra, I tested that locally via `Rack::MockRequest` and it works without issue. But whether a QUERY request gets that far at all depends on Rack and whatever server you're running (Puma, WEBrick, etc.) actually recognizing QUERY as a valid method.

Ran the full test suite locally and it's clean aside from some pre-existing RDoc-related failures unrelated to this change (version mismatch between `rdoc` and `tilt`'s RDoc adapter on my machine).