### PR TITLE
Fix typos in rack-protection comments

### DIFF
--- a/rack-protection/lib/rack/protection/content_security_policy.rb
+++ b/rack-protection/lib/rack/protection/content_security_policy.rb
@@ -47,7 +47,7 @@ module Rack
     # [Any Supported CSP Directive, underscorized] - All supported CSP directives can be configured individually. See DIRECTIVES 
     #                                                and NO_ARG_DIRECTIVES for a list of what is supported.
     #
-    #                                                Note that this list is not necessarly complete as the spec and
+    #                                                Note that this list is not necessarily complete as the spec and
     #                                                browser behavior is constantly evolving (for example,
     #                                                <tt>script-src-elem</tt> is not supported).
     #                                                

--- a/rack-protection/lib/rack/protection/http_origin.rb
+++ b/rack-protection/lib/rack/protection/http_origin.rb
@@ -25,7 +25,7 @@ module Rack
     #                               that you should include the scheme, and include the port *only* if it 
     #                               is not the default port for the scheme (80 for http and 443 for https).
     #
-    # [<tt>:allow_if</tt>] A Proc to be used for custom logic, superceding the values in <tt>:permitted_origins</tt>.
+    # [<tt>:allow_if</tt>] A Proc to be used for custom logic, superseding the values in <tt>:permitted_origins</tt>.
     #                      By default, this is <tt>nil</tt>, meaning that <tt>:permitted_origins</tt> control
     #                      the behavior. Note that if the request's origin is the same as the Origin header,
     #                      this Proc is not evaluated and the request is allowed.  Further note that if there is no


### PR DESCRIPTION
Fix two spelling mistakes in documentation comments within rack-protection:

- `necessarly` → `necessarily` in `content_security_policy.rb`
- `superceding` → `superseding` in `http_origin.rb`