### PR TITLE
Roll back all response state on `pass`, not just content-type (#2177)

### DIFF
--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1096,23 +1096,6 @@ module Sinatra
       route_missing
     end
 
-    # Snapshot the response state a route may mutate, so process_route can roll
-    # it back if the route passes. Array-valued headers (e.g. multiple
-    # set-cookie) are dup'd too: Rack appends to them in place, which would
-    # otherwise mutate the snapshot through the shared array reference.
-    def response_snapshot
-      headers = response.headers.transform_values { |v| v.is_a?(Array) ? v.dup : v }
-      [response.status, headers]
-    end
-
-    # Restore a snapshot captured by response_snapshot, undoing every status and
-    # header change a passed route made.
-    def restore_response(snapshot)
-      status, headers = snapshot
-      response.status = status
-      response.headers.replace(headers)
-    end
-
     # Run a route block and throw :halt with the result.
     def route_eval
       throw :halt, yield
@@ -1148,20 +1131,28 @@ module Sinatra
         values += params.values.flatten
       end
 
+      # Snapshot the response state a route may mutate so it can be rolled back
+      # if the route passes. Array-valued headers (e.g. multiple set-cookie) are
+      # dup'd: Rack appends to them in place, which would otherwise mutate the
+      # snapshot through the shared reference.
+      snapshot_status  = response.status
+      snapshot_headers = response.headers.transform_values { |v| v.is_a?(Array) ? v.dup : v }
+
       passed = true
-      snapshot = response_snapshot
       result = catch(:pass) do
         conditions.each { |c| throw :pass if c.bind(self).call == false }
         value = block ? block[self, values] : yield(self, values)
         passed = false
         value
       end
-      # Roll the response back to its pre-route baseline only when the route
-      # actually passed: a real :pass throw leaves `passed` true, while a
-      # before-filter returning normally through this method sets it false and
-      # keeps whatever content-type it set. A matching route throws :halt, which
-      # unwinds past here and keeps its response untouched.
-      restore_response(snapshot) if passed
+      # Roll back only when the route actually passed: a real :pass throw leaves
+      # `passed` true, while a before-filter returning normally through this
+      # method sets it false and keeps whatever content-type it set. A matching
+      # route throws :halt, which unwinds past here and keeps its response.
+      if passed
+        response.status = snapshot_status
+        response.headers.replace(snapshot_headers)
+      end
       result
     rescue StandardError
       @env['sinatra.error.params'] = @params

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -983,7 +983,6 @@ module Sinatra
       super()
       @app = app
       @template_cache = TemplateCache.new
-      @pinned_response = nil # whether a before! filter pinned the content-type
       yield self if block_given?
     end
 
@@ -997,7 +996,6 @@ module Sinatra
       @params   = IndifferentHash.new
       @request  = Request.new(env)
       @response = Response.new
-      @pinned_response = nil
       template_cache.clear if settings.reload_templates
 
       invoke { dispatch! }
@@ -1070,8 +1068,6 @@ module Sinatra
       end
 
       routes&.each do |match_or_signature|
-        reset_content_type!
-
         if match_or_signature.is_a?(Mustermann::Match)
           match = match_or_signature
           pattern, conditions, block = match_or_signature.value
@@ -1093,23 +1089,28 @@ module Sinatra
         return route!(base.superclass, pass_block)
       end
 
-      # Set-based routing only iterates matching routes, so the per-iteration
-      # reset above is skipped after a matching route set a content-type then
-      # passed. Reset it here too so the pass block starts clean, uniformly for
-      # every verb. (main's all-routes scan cleared this only incidentally for
-      # GET, via the built-in /__sinatra__ image route, and leaked it otherwise.)
-      if pass_block
-        reset_content_type!
-        route_eval(&pass_block)
-      end
+      # A passed route restores its own response state on the :pass throw (see
+      # process_route), so the pass block already starts from the pre-route
+      # baseline -- no reset needed here, for any verb or iteration position.
+      route_eval(&pass_block) if pass_block
       route_missing
     end
 
-    # Reset the content-type a passed/previous route may have set, so the next
-    # handler -- route block or pass block -- starts from its baseline: nothing,
-    # or the value a before-filter pinned via @pinned_response.
-    def reset_content_type!
-      response.delete_header('content-type') unless @pinned_response
+    # Snapshot the response state a route may mutate, so process_route can roll
+    # it back if the route passes. Array-valued headers (e.g. multiple
+    # set-cookie) are dup'd too: Rack appends to them in place, which would
+    # otherwise mutate the snapshot through the shared array reference.
+    def response_snapshot
+      headers = response.headers.transform_values { |v| v.is_a?(Array) ? v.dup : v }
+      [response.status, headers]
+    end
+
+    # Restore a snapshot captured by response_snapshot, undoing every status and
+    # header change a passed route made.
+    def restore_response(snapshot)
+      status, headers = snapshot
+      response.status = status
+      response.headers.replace(headers)
     end
 
     # Run a route block and throw :halt with the result.
@@ -1147,10 +1148,21 @@ module Sinatra
         values += params.values.flatten
       end
 
-      catch(:pass) do
+      passed = true
+      snapshot = response_snapshot
+      result = catch(:pass) do
         conditions.each { |c| throw :pass if c.bind(self).call == false }
-        block ? block[self, values] : yield(self, values)
+        value = block ? block[self, values] : yield(self, values)
+        passed = false
+        value
       end
+      # Roll the response back to its pre-route baseline only when the route
+      # actually passed: a real :pass throw leaves `passed` true, while a
+      # before-filter returning normally through this method sets it false and
+      # keeps whatever content-type it set. A matching route throws :halt, which
+      # unwinds past here and keeps its response untouched.
+      restore_response(snapshot) if passed
+      result
     rescue StandardError
       @env['sinatra.error.params'] = @params
       raise
@@ -1228,9 +1240,7 @@ module Sinatra
 
       invoke do
         static! if settings.static? && (request.get? || request.head?)
-        filter! :before do
-          @pinned_response = !response['content-type'].nil?
-        end
+        filter! :before
         route!
       end
     rescue ::Exception => e

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -957,6 +957,124 @@ class RoutingTest < Minitest::Test
     assert_equal 'text/html;charset=utf-8', response.headers['content-type']
   end
 
+  it "does not leak a passed route's status into the pass block" do
+    mock_app {
+      get('/a') do
+        status 201
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    # The abandoned route's status must not survive into the pass block.
+    assert_equal 200, status
+  end
+
+  it "does not leak a passed route's custom header into the pass block" do
+    mock_app {
+      get('/a') do
+        headers['X-Foo'] = 'bar'
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    assert_nil response.headers['X-Foo']
+  end
+
+  it "does not leak a passed route's cookie into the pass block" do
+    mock_app {
+      get('/a') do
+        response.set_cookie('foo', 'bar')
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    # Set-Cookie is just a response header, so the header rollback covers it.
+    assert_nil response.headers['set-cookie']
+  end
+
+  it "does not leak a passed route's cookie when a baseline cookie array already exists" do
+    # A before-filter leaves 'set-cookie' as an Array; the passing route appends
+    # to it. Rack mutates that array in place, so a shallow snapshot must dup the
+    # array or the appended cookie leaks past the rollback.
+    mock_app {
+      before do
+        response.set_cookie('a', '1')
+        response.set_cookie('b', '2')
+      end
+      get('/a') do
+        response.set_cookie('c', '3')
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    cookies = Array(response.headers['set-cookie'])
+    assert(cookies.any? { |c| c.start_with?('a=1') }, 'filter cookie a should survive')
+    assert(cookies.any? { |c| c.start_with?('b=2') }, 'filter cookie b should survive')
+    refute(cookies.any? { |c| c.start_with?('c=3') }, "passed route's cookie must not leak")
+  end
+
+  it "does not leak a passed route's status and headers into a later matching route" do
+    mock_app {
+      get('/a') do
+        status 201
+        headers['X-Foo'] = 'bar'
+        pass
+      end
+      get('/a') { 'second route' }
+    }
+
+    get '/a'
+    assert_equal 'second route', body
+    # The leak surfaces between routes, not just into the pass block.
+    assert_equal 200, status
+    assert_nil response.headers['X-Foo']
+  end
+
+  it "resets response state when the last defined route passes" do
+    # rkh's edge case (PR #2175 review): with no later route to iterate to,
+    # the previous positional reset never fired. Snapshot/restore-on-throw
+    # cleans up regardless of iteration position.
+    mock_app {
+      get('/a') do
+        status 201
+        headers['X-Foo'] = 'bar'
+        content_type :json
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    assert_equal 200, status
+    assert_nil response.headers['X-Foo']
+    assert_equal 'text/html;charset=utf-8', response.headers['content-type']
+  end
+
+  it "keeps a before-filter's content-type through a passing route" do
+    # Guard: rollback fires only on the :pass throw. A before-filter returns
+    # normally through the same process_route and must keep what it set.
+    mock_app {
+      before { content_type :json }
+      get('/a') do
+        content_type :xml
+        pass { 'from pass block' }
+      end
+    }
+
+    get '/a'
+    assert_equal 'from pass block', body
+    # Rolls back to the filter's pinned baseline, not the route's xml.
+    assert_equal 'application/json', response.headers['content-type']
+  end
+
   it "passes when matching condition returns false" do
     mock_app {
       condition { params[:foo] == 'bar' }


### PR DESCRIPTION
Implements the gated-rollback PoC offered in #2177. Draft: this is a **behaviour/contract change**, so it's parked here until maintainers confirm the direction (see the two questions in #2177). Stacked on `mustermann-4.0` because it reworks the `reset_content_type!` / `Mustermann::Set` code that only exists on that branch (from #2175); it should retarget `main` once #2163 lands.

### What changes

Today `pass` resets only the content-type between route attempts. A route that sets a status, an arbitrary header, or a cookie and then passes leaks that state into the next handler. The reset is also *positional* — it fires when iterating to the next route — so @rkh's review note on #2175 (the last matching route passing, with nothing after it) skipped it entirely.

This snapshots `status` + `headers` at the top of `process_route` and restores them **only on a real `:pass` throw**.

| Route sets before `pass` | Before (post-#2175) | After |
|---|---|---|
| `content_type :json` | reset ✅ | reset |
| `status 201` | leaks → next handler sees 201 | **reset** to baseline |
| `headers['X-Foo'] = 'bar'` | leaks | **reset** |
| `set_cookie(...)` (`Set-Cookie` header) | leaks | **reset** (covered by the header snapshot) |
| last defined route passes (rkh's case) | content-type reset via trailing special-case; status/headers leak | **all reset**, uniformly |

### Why it's safe

The restore is gated on the throw, not on iteration position:

- **A route calls `pass`** → `:pass` thrown → `passed` stays true → restore.
- **A before-filter returns normally** through the same `process_route` → `passed` set false → **kept** (this preserves `provides`/negotiation, superclass-filter and error-handler content types).
- **A matching route** throws `:halt`, which unwinds past the restore untouched.

Because each passed route now restores its own baseline, both positional `reset_content_type!` calls in `route!` **and** the `@pinned_response` pin that guarded them are removed — the snapshot baseline preserves a filter's content-type naturally.

One correctness subtlety caught in review: array-valued headers (multiple `Set-Cookie`) are dup'd in the snapshot, because Rack appends to them in place and a shallow dup would otherwise mutate the snapshot through the shared reference.

### Tests

Full matrix in `test/routing_test.rb`: status / header / cookie leak into the pass block, leak into a *later matching route* (not just the pass block), the last-route-pass edge case, a before-filter-keeps-its-content-type guard, and the multi-cookie in-place-append case. Full suite green (1129 runs, 0 failures) on Ruby 4.0 locally.

### Cost (measured)

benchmark-ips + memory_profiler on Ruby 4.0, this branch vs the `mustermann-4.0` content-type-only baseline, driving a plain matching route and both pass paths through `Rack::MockRequest`:

| Path | Baseline | This branch | Δ |
|---|---|---|---|
| plain matching route (no pass) | 128.1 obj / 11808 B | 129.1 obj / 11888 B | **+1 obj / +80 B** |
| pass → later matching route | 145.2 obj | 144.2 obj | **−1 obj** |
| pass → pass block | 142.1 obj | 140.1 obj | **−2 obj** |

The universal (no-pass) path costs one extra allocation — the `headers.transform_values` snapshot — per matched route. Both pass paths come out allocation-neutral or better, because removing the two `reset_content_type!` calls offsets the snapshot. **0 objects retained** on every path (no leak). Throughput is unchanged: across repeated samples the branch lands within the benchmark's own variance of baseline (faster in some runs, marginally slower in others), never a clear regression.

Related: #2175, #2163, #2177.
