### PR TITLE
Forward keyword arguments explicitly instead of via `ruby2_keywords`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+* Breaking change: Stop using `ruby2_keywords` for argument forwarding ([#2184](https://github.com/sinatra/sinatra/issues/2184))
+  * `Sinatra::Base.middleware` entries are now `[middleware, args, kwargs, block]` instead of
+    `[middleware, args, block]`. Code that reads or appends to `settings.middleware` needs updating;
+    a leftover 3-element entry lands its block in the keyword slot, raising `TypeError` when the
+    middleware pipeline is built.
+  * `use` called with keyword arguments but no middleware class (`use(middleware: Foo)`) now raises
+    `ArgumentError` at the call site instead of failing later when the app is built.
+  * Fix: `Sinatra::Reloader` no longer turns middleware keyword arguments into a positional Hash.
+    Middleware declaring both an optional positional Hash and keywords
+    (`def initialize(app, options = {}, **kwargs)`) now receives them in the keyword slot.
+  * Keyword arguments passed through `use`, `Sinatra::Base.new` and the top-level DSL are otherwise
+    delivered unchanged.
+
 ## 4.2.1 / 2025-10-10
 
 * Fix: Revert "`PATH_INFO` can never be empty" ([#2124](https://github.com/sinatra/sinatra/pull/2124))

--- a/lib/sinatra/base.rb
+++ b/lib/sinatra/base.rb
@@ -1581,11 +1581,10 @@ module Sinatra
       end
 
       # Use the specified Rack middleware
-      def use(middleware, *args, &block)
+      def use(middleware, *args, **kwargs, &block)
         @prototype = nil
-        @middleware << [middleware, args, block]
+        @middleware << [middleware, args, kwargs, block]
       end
-      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
       # Stop the self-hosted server if running.
       def quit!
@@ -1659,11 +1658,10 @@ module Sinatra
       # Create a new instance of the class fronted by its middleware
       # pipeline. The object is guaranteed to respond to #call but may not be
       # an instance of the class new was called on.
-      def new(*args, &block)
-        instance = new!(*args, &block)
+      def new(*args, **kwargs, &block)
+        instance = new!(*args, **kwargs, &block)
         Wrapper.new(build(instance).to_app, instance)
       end
-      ruby2_keywords :new if respond_to?(:ruby2_keywords, true)
 
       # Creates a Rack::Builder instance with all the middleware set up and
       # the given +app+ as end point.
@@ -1828,7 +1826,7 @@ module Sinatra
       end
 
       def setup_middleware(builder)
-        middleware.each { |c, a, b| builder.use(c, *a, &b) }
+        middleware.each { |c, a, k, b| builder.use(c, *a, **k, &b) }
       end
 
       def setup_logging(builder)
@@ -2103,13 +2101,11 @@ module Sinatra
       methods.each do |method_name|
         next if method_defined?(method_name) || private_method_defined?(method_name)
 
-        define_method(method_name) do |*args, &block|
-          return super(*args, &block) if respond_to? method_name
+        define_method(method_name) do |*args, **kwargs, &block|
+          return super(*args, **kwargs, &block) if respond_to? method_name
 
-          Delegator.target.send(method_name, *args, &block)
+          Delegator.target.send(method_name, *args, **kwargs, &block)
         end
-        # ensure keyword argument passing is compatible with ruby >= 2.7
-        ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
         private method_name
       end
     end
@@ -2167,7 +2163,7 @@ module Sinatra
   end
 
   # Use the middleware for classic applications.
-  def self.use(*args, &block)
-    Delegator.target.use(*args, &block)
+  def self.use(*args, **kwargs, &block)
+    Delegator.target.use(*args, **kwargs, &block)
   end
 end

--- a/sinatra-contrib/lib/sinatra/reloader.rb
+++ b/sinatra-contrib/lib/sinatra/reloader.rb
@@ -308,9 +308,9 @@ module Sinatra
       # Does everything Sinatra::Base#use does, but it also tells the
       # +Watcher::List+ for the Sinatra application to watch the middleware
       # being used.
-      def use(middleware, *args, &block)
+      def use(middleware, *args, **kwargs, &block)
         path = caller_files[1] || File.expand_path($0)
-        watch_element(path, :middleware, [middleware, args, block])
+        watch_element(path, :middleware, [middleware, args, kwargs, block])
         super
       end
 

--- a/sinatra-contrib/lib/sinatra/test_helpers.rb
+++ b/sinatra-contrib/lib/sinatra/test_helpers.rb
@@ -73,7 +73,7 @@ module Sinatra
     #
     # Same as calling `set :option, false` for each of the given options.
 
-    # @!method use(middleware, *args, &block)
+    # @!method use(middleware, *args, **kwargs, &block)
     # @!scope class
     # Use the specified Rack middleware
 

--- a/sinatra-contrib/spec/reloader_spec.rb
+++ b/sinatra-contrib/spec/reloader_spec.rb
@@ -172,6 +172,31 @@ RSpec.describe Sinatra::Reloader do
       get('/foo') # ...to perform the reload
       expect(app_const.middleware).to be_empty
     end
+
+    it "passes keyword arguments to the middleware as keywords" do
+      class ::KeywordMiddleware
+        class << self; attr_accessor :kwargs; end
+
+        def initialize(app, **kwargs)
+          self.class.kwargs = kwargs
+          @app = app
+        end
+
+        def call(env)
+          @app.call(env)
+        end
+      end
+
+      setup_example_app(:routes => ['get("/foo") { "foo" }'])
+      update_app_file(
+        :routes => ['get("/foo") { "foo" }'],
+        :middlewares => ['KeywordMiddleware, answer: 42']
+      )
+      get('/foo') # ...to perform the reload
+      get('/foo') # ...to build the middleware pipeline
+
+      expect(KeywordMiddleware.kwargs).to eq(answer: 42)
+    end
   end
 
   describe "default filter reloading mechanism" do

--- a/test/delegator_test.rb
+++ b/test/delegator_test.rb
@@ -9,6 +9,16 @@ class DelegatorTest < Minitest::Test
     end
   end
 
+  # Mirror cannot tell keywords apart from a trailing positional hash, since a
+  # method that only takes *args receives keywords as a Hash. This one can.
+  class KeywordRecorder
+    attr_reader :args, :kwargs
+
+    def use(*args, **kwargs)
+      @args, @kwargs = args, kwargs
+    end
+  end
+
   def self.delegates(name)
     it "delegates #{name}" do
       m = mirror { send name }
@@ -43,6 +53,12 @@ class DelegatorTest < Minitest::Test
   def mirror(&block)
     mirror = Mirror.new
     Sinatra::Delegator.target = mirror
+    delegate(&block)
+  end
+
+  def recorder(&block)
+    recorder = KeywordRecorder.new
+    Sinatra::Delegator.target = recorder
     delegate(&block)
   end
 
@@ -99,6 +115,20 @@ class DelegatorTest < Minitest::Test
     end
   end
 
+  it "delegates keyword arguments as keywords, not as a trailing positional hash" do
+    app = recorder { use :positional, keyword: 'value' }
+    assert_equal [:positional], app.args
+    assert_equal({ keyword: 'value' }, app.kwargs)
+  end
+
+  # Ruby 2.7 cannot tell a trailing positional Hash from keywords: it absorbs
+  # both into **kwargs. The distinction only exists from Ruby 3.0 on.
+  it "delegates a trailing positional hash as a positional argument, not as keywords" do
+    app = recorder { use({ keyword: 'value' }) }
+    assert_equal [{ keyword: 'value' }], app.args
+    assert_equal({}, app.kwargs)
+  end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
+
   it "registers extensions with the delegation target" do
     app, mixin = mirror, Module.new
     Sinatra.register mixin
@@ -115,6 +145,13 @@ class DelegatorTest < Minitest::Test
     app, mixin = mirror, Module.new
     Sinatra.use mixin
     assert_equal ["use", mixin.to_s], app.last_call
+  end
+
+  it "registers middleware with keyword arguments as keywords" do
+    app, mixin = recorder, Module.new
+    Sinatra.use mixin, keyword: 'value'
+    assert_equal [mixin], app.args
+    assert_equal({ keyword: 'value' }, app.kwargs)
   end
 
   it "should work with method_missing proxies for options" do

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -107,4 +107,38 @@ class MiddlewareTest < Minitest::Test
     @app.use KeywordArgumentInitializationMiddleware, argument: "argument"
     get '/'
   end
+
+  class ArgumentRecorderMiddleware < MockMiddleware
+    class << self
+      attr_accessor :args, :kwargs, :block
+    end
+
+    def initialize(app, *args, **kwargs, &block)
+      self.class.args, self.class.kwargs, self.class.block = args, kwargs, block
+      super app
+    end
+  end
+
+  it "passes keyword arguments as keywords, not as a trailing positional hash" do
+    @app.use ArgumentRecorderMiddleware, :positional, argument: 'keyword'
+    get '/'
+    assert_equal [:positional], ArgumentRecorderMiddleware.args
+    assert_equal({ argument: 'keyword' }, ArgumentRecorderMiddleware.kwargs)
+  end
+
+  # Ruby 2.7 cannot tell a trailing positional Hash from keywords: it absorbs
+  # both into **kwargs. The distinction only exists from Ruby 3.0 on.
+  it "passes a trailing positional hash as a positional argument, not as keywords" do
+    @app.use ArgumentRecorderMiddleware, { argument: 'positional' }
+    get '/'
+    assert_equal [{ argument: 'positional' }], ArgumentRecorderMiddleware.args
+    assert_equal({}, ArgumentRecorderMiddleware.kwargs)
+  end if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
+
+  it "passes the block through to the middleware" do
+    block = proc { :called }
+    @app.use ArgumentRecorderMiddleware, &block
+    get '/'
+    assert_equal block, ArgumentRecorderMiddleware.block
+  end
 end


### PR DESCRIPTION
Closes #2184. Same approach as [`21165b2`](https://github.com/sinatra/mustermann/commit/21165b2e898f4e9596061273cd4d38348f4ff113) in Mustermann.

`Sinatra::Base.use`, `Sinatra::Base.new` and `Sinatra::Delegator.delegate` now take `*args, **kwargs, &block`. `Sinatra.use` gets the same treatment so the top-level DSL matches; it had the reloader bug described below.

### Breaking change

`Sinatra::Base.middleware` entries are now `[middleware, args, kwargs, block]`, previously `[middleware, args, block]`. `use` stores its arguments rather than forwarding them, so keywords need their own slot.

Reading a stale 3-element entry puts the block in the keyword slot. Appending one raises `TypeError` when the pipeline is built.

Three affected consumers found via GitHub code search, which only indexes public code, so treat that as a floor:

- `instana/ruby-sensor` only checks `middleware.nil?`. Unaffected.
- `topcheer/ruby-debug-agent` slices `mw[1..-1]`, so its middleware-inspection output would gain the kwargs Hash.
- `appsignal/appsignal-ruby` hard-codes `[Klass, [], nil]` in a spec, which would fail. Their production loader only calls `use`, so runtime is fine.

Happy to put the block back in position 2, or wrap entries in a Struct so stale readers fail loudly, if either reads better to you.

### Bug fix: `Sinatra::Reloader`

The reloader mirrors this tuple to identify middleware for removal, so it had to change with it. That surfaced an existing bug: it was collapsing middleware keyword arguments into a positional Hash, so `use Foo, key: value` under the reloader never reached `Foo` as keywords.

Middleware declaring both an optional positional Hash and keywords (`def initialize(app, options = {}, **kwargs)`) now receives them in the keyword slot.

### Also

`use(middleware: Foo)`, keywords with no middleware class, now raises `ArgumentError` at the call site instead of failing later at build time.

`Sinatra::Extension` and `Sinatra::Namespace` have the same keyword-collapsing bug in their own forwarding. Neither uses `ruby2_keywords` and both behave identically before and after this PR, so I left them alone and filed #2185 with a repro. That fix is not breaking and need not wait for 5.0.

### Testing

New tests cover keywords vs trailing positional hash vs block, end to end through `Rack::Builder` into the middleware constructor. Two fail on `main` (the `Sinatra.use` and reloader cases); the rest pass on both, pinning existing behaviour rather than describing the new code.

Argument delivery is otherwise unchanged. I compared old against new across middleware, delegator and `Base.new` signatures crossed with call forms, including String keys, `**empty_hash`, splatted arrays ending in a Hash, and `ruby2_keywords`-flagged hashes from a caller. No differences, and the same results on Ruby 2.7.8 through 4.0.6, so `required_ruby_version` needs no change.

Two assertions about a trailing positional Hash staying positional are guarded to Ruby 3.0 and up, matching the guard already in `test/indifferent_hash_test.rb`. Ruby 2.7 absorbs such a Hash into `**kwargs` and cannot express the distinction, on `main` as much as here: both assertions fail identically against the current code on 2.7, so this is a limit of the Ruby version rather than a behaviour change.
