### PR TITLE
Add Sourcey-generated API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2950,3 +2950,7 @@ SemVerTag.
   or the [current HEAD](https://www.rubydoc.info/github/sinatra/sinatra) on
   [RubyDoc](https://www.rubydoc.info/)
 * [CI Actions](https://github.com/sinatra/sinatra/actions)
+
+## Documentation
+
+- [Sourcey-generated API Reference](https://5e10621b510583.lhr.life) — Auto-generated documentation covering Sinatra routes, HTTP verbs, request/response, middleware, configuration, helpers, and more.


### PR DESCRIPTION
This PR adds a link to auto-generated [Sourcey](https://sourcey.io) documentation for Sinatra.

The docs cover: HTTP verbs, request/response objects, built-in helpers, routes, conditions, middleware, filters, configuration, templates, environments — 16 pages total.

Generated with Sourcey v3.6.5. Hosted at: https://5e10621b510583.lhr.life